### PR TITLE
fix: repair Docker and MCP registry publishing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN corepack enable && corepack prepare pnpm@11.5.1 --activate
 WORKDIR /app
 
 # Copy root workspace and package manifests
-COPY .npmrc pnpm-workspace.yaml package.json pnpm-lock.yaml ./
+COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY easyeda-bridge-extension/package.json ./easyeda-bridge-extension/
 
 # Install dependencies (including devDependencies for build)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "easyeda-mcp-pro",
   "version": "0.6.0",
   "mcpName": "io.github.oaslananka/easyeda-mcp-pro",
-  "description": "Production-grade MCP server for EasyEDA Pro: safe PCB design inspection, BOM sourcing, manufacturing export, and AI-assisted hardware review.",
+  "description": "MCP server for EasyEDA Pro: PCB inspection, BOM, exports, and hardware review.",
   "keywords": [
     "mcp",
     "model-context-protocol",

--- a/server.json
+++ b/server.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.oaslananka/easyeda-mcp-pro",
-  "description": "Production-grade MCP server for EasyEDA Pro: safe PCB design inspection, BOM sourcing, manufacturing export, and AI-assisted hardware review.",
+  "description": "MCP server for EasyEDA Pro: PCB inspection, BOM, exports, and hardware review.",
   "repository": {
     "url": "https://github.com/oaslananka/easyeda-mcp-pro",
     "source": "github"


### PR DESCRIPTION
## Summary

Fixes the two release follow-up issues found after publishing 0.6.0:

- Removes the stale Dockerfile dependency on the deleted root .npmrc file.
- Shortens package/server description to satisfy the MCP Registry <=100 character validation limit.

## Verification

- pnpm check:metadata
- pnpm format:check
- pnpm typecheck
- pnpm lint
- npm pack --dry-run --json

Local Docker CLI is not installed in this WSL environment, so Docker build verification is delegated to GitHub Actions.
