### PR TITLE
fix: make Docker pnpm prune non-interactive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN pnpm build
 RUN pnpm build:extension
 
 # Prune development dependencies to keep production image light
-RUN pnpm install --prod --ignore-scripts
+RUN CI=true pnpm install --prod --ignore-scripts
 
 # ── Production Runner Stage ────────────────────────────────────
 FROM node:24-alpine AS runner


### PR DESCRIPTION
## Summary

Fixes the Docker/GHCR release failure after 0.6.1 by running the production pnpm prune/install step with CI=true so pnpm does not abort in non-interactive Docker builds.

## Verification

- pnpm format:check
- pnpm typecheck
- pnpm lint
- git diff --check

Local Docker CLI is unavailable in this WSL environment; GitHub Actions Docker build is the authoritative verification.
