### PR TITLE
fix: add CLI shebang for Windows npx

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -100,6 +100,7 @@ jobs:
         if: ${{ env.RELEASE_RUN == 'true' }}
         run: |
           pnpm build
+          pnpm check:metadata
           pnpm build:extension
           pnpm verify:extension
 

--- a/scripts/check-metadata.mjs
+++ b/scripts/check-metadata.mjs
@@ -34,6 +34,10 @@ function warn(msg) {
 const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
 const serverJson = JSON.parse(fs.readFileSync(path.join(root, 'server.json'), 'utf8'));
 const versionTs = fs.readFileSync(path.join(root, 'src', 'config', 'version.ts'), 'utf8');
+const cliSourcePath = path.join(root, 'src', 'index.ts');
+const cliSource = fs.readFileSync(cliSourcePath, 'utf8');
+const cliDistPath = path.join(root, 'dist', 'index.js');
+const cliDist = fs.existsSync(cliDistPath) ? fs.readFileSync(cliDistPath, 'utf8') : null;
 const extJsonPath = path.join(root, 'easyeda-bridge-extension', 'extension.json');
 const extJson = fs.existsSync(extJsonPath)
   ? JSON.parse(fs.readFileSync(extJsonPath, 'utf8'))
@@ -88,13 +92,27 @@ if (mcpName && serverJson.name !== mcpName) {
 
 // ── 4. Binary / command consistency ─────────────────────────────────────────
 
-const binName = Object.keys(pkg.bin || {})[0] || '';
+const binEntries = Object.entries(pkg.bin || {});
+const binName = binEntries[0]?.[0] || '';
+const binTarget = binEntries[0]?.[1] || '';
 if (binName) {
   // Check README uses correct npx command
   const npxPattern = `npx ${binName}`;
   const readmeNpxCount = (readme.match(new RegExp(npxPattern, 'g')) || []).length;
   if (readmeNpxCount === 0) {
     warn(`README.md does not reference "npx ${binName}" — install command may be outdated`);
+  }
+
+  if (binTarget !== 'dist/index.js') {
+    error(`package.json bin target "${binTarget}" should be "dist/index.js"`);
+  }
+
+  if (!cliSource.startsWith('#!/usr/bin/env node')) {
+    error('src/index.ts must start with #!/usr/bin/env node so npx works on Windows');
+  }
+
+  if (cliDist !== null && !cliDist.startsWith('#!/usr/bin/env node')) {
+    error('dist/index.js must start with #!/usr/bin/env node before publishing');
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 import 'dotenv/config';
 import {
   createDoctorReport,

--- a/tests/unit/cli/bin.test.ts
+++ b/tests/unit/cli/bin.test.ts
@@ -1,0 +1,15 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('npm CLI binary metadata', () => {
+  it('declares a Node shebang for Windows npx execution', async () => {
+    const packageJson = JSON.parse(await readFile(join(process.cwd(), 'package.json'), 'utf8')) as {
+      bin?: Record<string, string>;
+    };
+    const source = await readFile(join(process.cwd(), 'src', 'index.ts'), 'utf8');
+
+    expect(packageJson.bin).toEqual({ 'easyeda-mcp-pro': 'dist/index.js' });
+    expect(source.startsWith('#!/usr/bin/env node')).toBe(true);
+  });
+});


### PR DESCRIPTION
Fixes Windows npx launching the JS file through the OS file association instead of Node. Adds a Node shebang to the CLI entry, metadata checks for source and built dist shebangs, and a regression test for npm bin metadata.