### PR TITLE
fix: add wire probe and stabilize API call schema

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -57,6 +57,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_schematic_place_component`     | `core`  | `medium` | Place a library component/device on the active schematic sheet.                                                                                                                                                                                                                                               |
 | `easyeda_schematic_search_device`       | `core`  | `low`    | Search for schematic symbols/devices in the EasyEDA library by keywords.                                                                                                                                                                                                                                      |
 | `easyeda_schematic_validate_netlist`    | `core`  | `low`    | Validate the EasyEDA Pro schematic netlist for connectivity issues. Reports net names, connected component references and pins, floating pins, graphical wires without netlist connectivity, and mismatches between visual wires and actual SCH_Net/SCH_Netlist entries. This is a read-only diagnostic tool. |
+| `easyeda_wire_probe`                    | `dev`   | `low`    | Inspect live schematic wire objects, including line coordinates, net names, methods, and state getter values, to validate EasyEDA runtime mappings.                                                                                                                                                           |
 
 ---
 
@@ -1513,6 +1514,33 @@ Returns a JSON object matching the schema:
   wires_without_netlist: any;
   valid: any;
   warnings: any;
+  not_available: any;
+  error: any;
+}
+```
+
+---
+
+## `easyeda_wire_probe`
+
+**Profile:** `dev` | **Risk Level:** `low`
+
+> Inspect live schematic wire objects, including line coordinates, net names, methods, and state getter values, to validate EasyEDA runtime mappings.
+
+### Input Parameters
+
+| Parameter | Type  | Required | Description |
+| --------- | ----- | -------- | ----------- |
+| `limit`   | `any` | Yes      |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  total: any;
+  samples: any;
   not_available: any;
   error: any;
 }

--- a/easyeda-bridge-extension/src/index.ts
+++ b/easyeda-bridge-extension/src/index.ts
@@ -624,6 +624,26 @@ async function inspectComponentsApi(limit = 5): Promise<unknown> {
   };
 }
 
+async function inspectWiresApi(limit = 10): Promise<unknown> {
+  const schWireClass = readFirstPath<any>([
+    'SCH_PrimitiveWire',
+    'SCH_PrimitiveWire3',
+    'sch_PrimitiveWire',
+  ]);
+  if (!schWireClass || typeof schWireClass.getAll !== 'function') {
+    throw new Error('SCH_PrimitiveWire.getAll is not available in this EasyEDA runtime');
+  }
+
+  const wires = await schWireClass.getAll();
+  const items = Array.isArray(wires) ? wires : [];
+  return {
+    total: items.length,
+    samples: items
+      .slice(0, Math.max(1, Math.min(limit, 50)))
+      .map((item) => normalizeValue(item, 6)),
+  };
+}
+
 async function listLayersApi(): Promise<unknown> {
   const globalObj = getGlobal();
   const pcbLayerClass = readPath<any>(globalObj, 'pcb_Layer');
@@ -1240,6 +1260,8 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
       return inspectApiInventory(typeof params.filter === 'string' ? params.filter : undefined);
     case 'system.inspectComponents':
       return inspectComponentsApi(typeof params.limit === 'number' ? params.limit : 5);
+    case 'system.inspectWires':
+      return inspectWiresApi(typeof params.limit === 'number' ? params.limit : 10);
     case 'api.call':
       return callAllowedApi(
         typeof params.path === 'string' ? params.path : '',
@@ -1467,6 +1489,7 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
           'schematic.validateNetlist',
           'system.apiInventory',
           'system.inspectComponents',
+          'system.inspectWires',
           'api.call',
           'api.execute',
           'board.listLayers',

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -37,7 +37,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '50',
+    approxToolCount: '51',
     isDefault: false,
   },
   experimental: {

--- a/src/tools/L0_diagnostics_api.ts
+++ b/src/tools/L0_diagnostics_api.ts
@@ -125,6 +125,47 @@ function registerDiagnosticsApi(
   }
 
   registry.register({
+    name: 'easyeda_wire_probe',
+    title: 'Probe schematic wires',
+    description:
+      'Inspect live schematic wire objects, including line coordinates, net names, methods, and state getter values, to validate EasyEDA runtime mappings.',
+    profile: 'dev',
+    evidence: ['runtime-probe', 'pro-api-types'],
+    risk: 'low',
+    confirmWrite: false,
+    group: 'diagnostics',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+    inputSchema: z.object({
+      limit: z.number().int().min(1).max(50).default(10),
+    }),
+    outputSchema: z.object({
+      total: z.number().int().nonnegative(),
+      samples: z.array(z.unknown()),
+      not_available: z.boolean().optional(),
+      error: z.string().optional(),
+    }),
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const { limit } = z
+        .object({ limit: z.number().int().min(1).max(50).default(10) })
+        .parse(params);
+      try {
+        return await ctx.bridge.call('system.inspectWires', { limit });
+      } catch (err) {
+        return {
+          total: 0,
+          samples: [],
+          not_available: true,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+  });
+
+  registry.register({
     name: 'easyeda_component_probe',
     title: 'Probe schematic components',
     description:

--- a/src/tools/transaction.ts
+++ b/src/tools/transaction.ts
@@ -95,7 +95,14 @@ export function writePlanResponse(
   };
 }
 
+const openConfirmWriteOutputSchema = z.object({}).passthrough();
+
 export function registeredOutputSchema(tool: ToolDefinition): z.ZodType {
   if (!tool.confirmWrite) return tool.outputSchema;
-  return z.union([tool.outputSchema, writePlanOutputSchema]);
+
+  // The MCP SDK's JSON schema conversion currently fails for Zod unions in
+  // tool output schemas. Confirm-write tools can return either their declared
+  // output or a transaction-plan envelope, so expose an open object to the SDK
+  // and keep strict validation in ToolRegistry before returning content.
+  return openConfirmWriteOutputSchema;
 }

--- a/tests/unit/tools/diagnostics-api.test.ts
+++ b/tests/unit/tools/diagnostics-api.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { registerBuiltinTools } from '../../../src/tools/register.js';
+import { EnvSchema } from '../../../src/config/env.js';
+import { ToolRegistry } from '../../../src/tools/registry.js';
+import { type ToolContext } from '../../../src/tools/types.js';
+
+function createDevContext(bridgeCall = vi.fn()): ToolContext {
+  const config = EnvSchema.parse({ NODE_ENV: 'test', TOOL_PROFILE: 'dev' });
+
+  return {
+    profile: 'dev',
+    bridge: {
+      connected: true,
+      call: bridgeCall,
+    },
+    config,
+  } as unknown as ToolContext;
+}
+
+describe('diagnostics API tools', () => {
+  it('registers the read-only schematic wire probe in dev profile', async () => {
+    const config = EnvSchema.parse({ NODE_ENV: 'test', TOOL_PROFILE: 'dev' });
+    const registry = new ToolRegistry();
+    registry.setProfile('dev');
+    registerBuiltinTools(registry, config);
+    const tool = registry.get('easyeda_wire_probe');
+    const bridgeCall = vi.fn().mockResolvedValue({
+      total: 1,
+      samples: [{ primitiveId: 'w1', net: '+5V', line: [1, 2, 3, 4] }],
+    });
+
+    expect(tool).toBeDefined();
+    expect(tool?.confirmWrite).toBe(false);
+
+    const result = await tool?.handler(createDevContext(bridgeCall), { limit: 5 });
+
+    expect(bridgeCall).toHaveBeenCalledWith('system.inspectWires', { limit: 5 });
+    expect(result).toEqual({
+      total: 1,
+      samples: [{ primitiveId: 'w1', net: '+5V', line: [1, 2, 3, 4] }],
+    });
+  });
+
+  it('returns not_available when the bridge does not expose wire inspection', async () => {
+    const config = EnvSchema.parse({ NODE_ENV: 'test', TOOL_PROFILE: 'dev' });
+    const registry = new ToolRegistry();
+    registry.setProfile('dev');
+    registerBuiltinTools(registry, config);
+    const tool = registry.get('easyeda_wire_probe');
+    const bridgeCall = vi
+      .fn()
+      .mockRejectedValue(new Error('SCH_PrimitiveWire.getAll is not available'));
+
+    const result = await tool?.handler(createDevContext(bridgeCall), { limit: 5 });
+
+    expect(result).toMatchObject({
+      total: 0,
+      samples: [],
+      not_available: true,
+      error: 'SCH_PrimitiveWire.getAll is not available',
+    });
+  });
+});

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -4,6 +4,7 @@ import { ToolRegistry, ErrorCodes } from '../../../src/tools/registry.js';
 import { type ToolDefinition, type ToolContext } from '../../../src/tools/types.js';
 import { registerBuiltinTools } from '../../../src/tools/register.js';
 import { EnvSchema } from '../../../src/config/env.js';
+import { registeredOutputSchema, writePlanOutputSchema } from '../../../src/tools/transaction.js';
 
 // ── Default test config ───────────────────────────────────────────────────
 
@@ -586,5 +587,19 @@ describe('ToolRegistry', () => {
     expect(response.isError).toBe(true);
     expect(response.content[0].text).toContain('Bridge connection failed');
     expect(response.content[0].text).toContain('EasyEDA Pro is not running');
+  });
+});
+
+describe('registered output schema compatibility', () => {
+  it('uses an open object schema for confirmWrite tools to avoid SDK union conversion crashes', () => {
+    const tool = createMockTool('confirm_output_schema', 'core', { confirmWrite: true });
+    const schema = registeredOutputSchema(tool);
+
+    expect(schema.safeParse({ arbitrary: 'tool output' }).success).toBe(true);
+    expect(schema.safeParse({ success: true, transaction: {} }).success).toBe(true);
+  });
+
+  it('keeps transaction plan schema strict for internal validation', () => {
+    expect(writePlanOutputSchema.safeParse({ success: true, transaction: {} }).success).toBe(false);
   });
 });


### PR DESCRIPTION
Fixes the generic API call schema crash seen in MCP Inspector for confirm-write tools and adds a read-only dev-profile easyeda_wire_probe tool for inspecting EasyEDA v3 schematic wire runtime shape. Verification: format, typecheck, extension typecheck, lint, full test suite, build, metadata, extension package verify, docs build.