### PR TITLE
fix: infer EasyEDA v3 schematic nets from wire coordinates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,23 @@ jobs:
       - run: pnpm check:metadata
       - run: pnpm build:extension
       - run: pnpm verify:extension
+      - name: Pack PR test package
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir -p artifacts
+          npm pack --pack-destination artifacts
+      - name: Upload PR test artifact
+        if: github.event_name == 'pull_request'
+        # actions/upload-artifact v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: easyeda-mcp-pro-pr-${{ github.event.pull_request.number }}
+          path: |
+            artifacts/*.tgz
+            easyeda-bridge-extension.eext
+            easyeda-bridge-extension/easyeda-bridge-extension.checksums.json
+            easyeda-bridge-extension/dist/index.js
+          if-no-files-found: error
       - run: pnpm generate:tools-doc
       - run: git diff --exit-code docs/reference/tools.md
       - run: pnpm docs:build

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -32,6 +32,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_get_server_config`             | `core`  | `low`    | Return safe (redacted) server configuration. Secrets are never exposed.                                                                                                                                                                                                                                       |
 | `easyeda_get_tool_profiles`             | `core`  | `low`    | List available tool profiles and their descriptions.                                                                                                                                                                                                                                                          |
 | `easyeda_health_check`                  | `core`  | `low`    | Return server health status, including runtime version, active profile, bridge state, and config validity.                                                                                                                                                                                                    |
+| `easyeda_live_smoke_report`             | `dev`   | `low`    | Run a read-only live smoke report against the connected EasyEDA bridge and return status, API inventory, components, wires, and schematic nets in one response.                                                                                                                                               |
 | `easyeda_pcb_add_track`                 | `full`  | `high`   | Draw a copper track/trace segment on the PCB board.                                                                                                                                                                                                                                                           |
 | `easyeda_pcb_add_via`                   | `full`  | `high`   | Place a via to connect different copper layers on the PCB board.                                                                                                                                                                                                                                              |
 | `easyeda_pcb_add_zone`                  | `full`  | `high`   | Create a copper pour zone on a specific layer with clearance settings.                                                                                                                                                                                                                                        |
@@ -782,6 +783,38 @@ Returns a JSON object matching the schema:
   transport: any;
   bridge_connected: any;
   ups: any;
+}
+```
+
+---
+
+## `easyeda_live_smoke_report`
+
+**Profile:** `dev` | **Risk Level:** `low`
+
+> Run a read-only live smoke report against the connected EasyEDA bridge and return status, API inventory, components, wires, and schematic nets in one response.
+
+### Input Parameters
+
+| Parameter    | Type  | Required | Description |
+| ------------ | ----- | -------- | ----------- |
+| `projectId`  | `any` | Yes      |             |
+| `limit`      | `any` | Yes      |             |
+| `includeRaw` | `any` | Yes      |             |
+| `timeoutMs`  | `any` | Yes      |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  ok: any;
+  project_id: any;
+  generated_at: any;
+  checks: any;
+  summary: any;
+  raw: any;
 }
 ```
 

--- a/easyeda-bridge-extension/src/index.ts
+++ b/easyeda-bridge-extension/src/index.ts
@@ -451,6 +451,216 @@ function summarizeWirePrimitive(wire: unknown): Record<string, JsonValue | undef
   return output;
 }
 
+type SchematicPoint = { x: number; y: number };
+type SchematicNetNode = { component: string; pin: string; x?: number; y?: number; source?: string };
+type SchematicNetEntry = { netName: string; nodes: SchematicNetNode[] };
+
+type DisjointSet = {
+  parent: Map<string, string>;
+  find: (key: string) => string;
+  union: (a: string, b: string) => void;
+};
+
+function createDisjointSet(): DisjointSet {
+  const parent = new Map<string, string>();
+  const find = (key: string): string => {
+    if (!parent.has(key)) parent.set(key, key);
+    const currentParent = parent.get(key);
+    if (!currentParent || currentParent === key) return key;
+    const root = find(currentParent);
+    parent.set(key, root);
+    return root;
+  };
+
+  return {
+    parent,
+    find,
+    union: (a: string, b: string): void => {
+      const rootA = find(a);
+      const rootB = find(b);
+      if (rootA !== rootB) parent.set(rootB, rootA);
+    },
+  };
+}
+
+function pointKey(point: SchematicPoint): string {
+  return `${Math.round(point.x * 1000) / 1000},${Math.round(point.y * 1000) / 1000}`;
+}
+
+function parseLinePoints(line: unknown): SchematicPoint[] {
+  if (!Array.isArray(line)) return [];
+
+  if (line.every((item) => typeof item === 'number')) {
+    const points: SchematicPoint[] = [];
+    for (let i = 0; i + 1 < line.length; i += 2) {
+      const x = Number(line[i]);
+      const y = Number(line[i + 1]);
+      if (Number.isFinite(x) && Number.isFinite(y)) points.push({ x, y });
+    }
+    return points;
+  }
+
+  const points: SchematicPoint[] = [];
+  for (const item of line) {
+    if (!Array.isArray(item) || item.length < 2) continue;
+    const x = Number(item[0]);
+    const y = Number(item[1]);
+    if (Number.isFinite(x) && Number.isFinite(y)) points.push({ x, y });
+  }
+  return points;
+}
+
+function readStringMemberOrState(source: unknown, key: string, stateName: string): string {
+  const stateValue = readStateValue(source, stateName, 2);
+  if (typeof stateValue === 'string' && stateValue) return stateValue;
+  const directValue = readMember(source, key);
+  if (typeof directValue === 'string') return directValue;
+  if (typeof directValue === 'number') return String(directValue);
+  return '';
+}
+
+function readNumberMemberOrState(
+  source: unknown,
+  key: string,
+  stateName: string,
+): number | undefined {
+  const stateValue = readStateValue(source, stateName, 2);
+  if (typeof stateValue === 'number' && Number.isFinite(stateValue)) return stateValue;
+  const directValue = readMember(source, key);
+  if (typeof directValue === 'number' && Number.isFinite(directValue)) return directValue;
+  return undefined;
+}
+
+function ensureNetEntry(
+  netMap: Map<string, SchematicNetNode[]>,
+  netName: string,
+): SchematicNetNode[] {
+  const existing = netMap.get(netName);
+  if (existing) return existing;
+  const nodes: SchematicNetNode[] = [];
+  netMap.set(netName, nodes);
+  return nodes;
+}
+
+function pushUniqueNetNode(
+  netMap: Map<string, SchematicNetNode[]>,
+  netName: string,
+  node: SchematicNetNode,
+): void {
+  if (!netName || !node.component || !node.pin) return;
+  const nodes = ensureNetEntry(netMap, netName);
+  if (nodes.some((item) => item.component === node.component && item.pin === node.pin)) return;
+  nodes.push(node);
+}
+
+function readComponentType(component: unknown): string {
+  return readStringMemberOrState(component, 'componentType', 'ComponentType').toLowerCase();
+}
+
+function readComponentNet(component: unknown): string {
+  const directNet = readStringMemberOrState(component, 'net', 'Net');
+  if (directNet) return directNet;
+  const otherProperty = readMember(component, 'otherProperty');
+  if (isRecord(otherProperty)) {
+    return String(otherProperty.net ?? otherProperty.Net ?? '');
+  }
+  return '';
+}
+
+function readPrimitivePoint(source: unknown): SchematicPoint | undefined {
+  const x = readNumberMemberOrState(source, 'x', 'X');
+  const y = readNumberMemberOrState(source, 'y', 'Y');
+  if (x === undefined || y === undefined) return undefined;
+  return { x, y };
+}
+
+async function addCoordinateFallbackNets(
+  netMap: Map<string, SchematicNetNode[]>,
+  comps: unknown[],
+): Promise<void> {
+  const schWireClass = readFirstPath<any>([
+    'SCH_PrimitiveWire',
+    'SCH_PrimitiveWire3',
+    'sch_PrimitiveWire',
+  ]);
+  if (!schWireClass || typeof schWireClass.getAll !== 'function') return;
+
+  const wires = await schWireClass.getAll();
+  const wireItems = Array.isArray(wires) ? wires : [];
+  if (wireItems.length === 0) return;
+
+  const dsu = createDisjointSet();
+  const rootNetNames = new Map<string, Set<string>>();
+  const addNetLabel = (point: SchematicPoint, netName: string): void => {
+    if (!netName) return;
+    const root = dsu.find(pointKey(point));
+    const names = rootNetNames.get(root) ?? new Set<string>();
+    names.add(netName);
+    rootNetNames.set(root, names);
+    ensureNetEntry(netMap, netName);
+  };
+
+  for (const wire of wireItems) {
+    const wireSummary = summarizeWirePrimitive(wire);
+    const points = parseLinePoints(wireSummary.line);
+    if (points.length === 0) continue;
+
+    for (const point of points) dsu.find(pointKey(point));
+    for (let i = 1; i < points.length; i += 1) {
+      dsu.union(pointKey(points[i - 1]), pointKey(points[i]));
+    }
+
+    const netName = typeof wireSummary.net === 'string' ? wireSummary.net : '';
+    if (netName) addNetLabel(points[0], netName);
+  }
+
+  // Re-normalize root labels after all wire unions are known.
+  for (const [root, names] of Array.from(rootNetNames.entries())) {
+    const normalizedRoot = dsu.find(root);
+    if (normalizedRoot === root) continue;
+    const target = rootNetNames.get(normalizedRoot) ?? new Set<string>();
+    for (const name of names) target.add(name);
+    rootNetNames.set(normalizedRoot, target);
+    rootNetNames.delete(root);
+  }
+
+  for (const component of comps) {
+    if (readComponentType(component) !== 'netflag') continue;
+    const netName = readComponentNet(component);
+    const point = readPrimitivePoint(component);
+    if (!netName || !point) continue;
+    addNetLabel(point, netName);
+  }
+
+  for (const component of comps) {
+    const ref = readStringMemberOrState(component, 'designator', 'Designator');
+    if (!ref || typeof (component as { getAllPins?: unknown }).getAllPins !== 'function') continue;
+
+    try {
+      const pins = await (component as { getAllPins: () => Promise<unknown[]> }).getAllPins();
+      for (const pin of pins || []) {
+        const pinNumber = readStringMemberOrState(pin, 'pinNumber', 'PinNumber');
+        const point = readPrimitivePoint(pin);
+        if (!pinNumber || !point) continue;
+
+        const netNames = rootNetNames.get(dsu.find(pointKey(point)));
+        if (!netNames) continue;
+        for (const netName of netNames) {
+          pushUniqueNetNode(netMap, netName, {
+            component: ref,
+            pin: pinNumber,
+            x: point.x,
+            y: point.y,
+            source: 'coordinate-fallback',
+          });
+        }
+      }
+    } catch (error) {
+      logRecoverableError('failed to inspect schematic component pins for coordinate nets', error);
+    }
+  }
+}
+
 function inspectApiInventory(filter?: string): JsonValue {
   const normalizedFilter = filter?.toLowerCase().trim();
   const classMap = new Map<
@@ -599,7 +809,7 @@ async function listNetsApi(): Promise<unknown> {
   }
 
   const comps = await schCompClass.getAll(undefined, true);
-  const netMap = new Map<string, Array<{ component: string; pin: string }>>();
+  const netMap = new Map<string, SchematicNetNode[]>();
 
   for (const c of comps || []) {
     const ref = typeof c.getState_Designator === 'function' ? c.getState_Designator() : '';
@@ -620,10 +830,7 @@ async function listNetsApi(): Promise<unknown> {
         }
 
         if (netName) {
-          if (!netMap.has(netName)) {
-            netMap.set(netName, []);
-          }
-          netMap.get(netName)!.push({ component: ref, pin: pinNum });
+          pushUniqueNetNode(netMap, netName, { component: ref, pin: pinNum });
         }
       }
     } catch (e) {
@@ -636,16 +843,20 @@ async function listNetsApi(): Promise<unknown> {
       const allNets = await schNetClass.getAllNets();
       for (const n of allNets || []) {
         const netName = n.netName || n.net;
-        if (netName && !netMap.has(netName)) {
-          netMap.set(netName, []);
-        }
+        if (netName) ensureNetEntry(netMap, String(netName));
       }
     } catch (e) {
       logRecoverableError('failed to inspect schematic nets', e);
     }
   }
 
-  const result: any[] = [];
+  try {
+    await addCoordinateFallbackNets(netMap, comps || []);
+  } catch (error) {
+    logRecoverableError('failed to infer schematic nets from wire coordinates', error);
+  }
+
+  const result: SchematicNetEntry[] = [];
   for (const [netName, nodes] of netMap.entries()) {
     result.push({
       netName,

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -37,7 +37,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '51',
+    approxToolCount: '52',
     isDefault: false,
   },
   experimental: {

--- a/src/tools/L0_diagnostics_api.ts
+++ b/src/tools/L0_diagnostics_api.ts
@@ -15,6 +15,54 @@ function requiresWriteConfirmation(path: string): boolean {
   return writeMethodPattern.test(path);
 }
 
+type LiveSmokeStep = {
+  id: string;
+  method: string;
+  params: Record<string, unknown>;
+};
+
+type LiveSmokeCheck = {
+  id: string;
+  method: string;
+  ok: boolean;
+  duration_ms: number;
+  error?: string;
+};
+
+function summarizeTotal(payload: unknown): number | undefined {
+  if (!payload || typeof payload !== 'object') return undefined;
+  const total = (payload as { total?: unknown }).total;
+  return typeof total === 'number' ? total : undefined;
+}
+
+function summarizeNetNames(payload: unknown): string[] {
+  if (!Array.isArray(payload)) return [];
+  return payload
+    .map((item) =>
+      item && typeof item === 'object' ? (item as { netName?: unknown }).netName : undefined,
+    )
+    .filter((name): name is string => typeof name === 'string' && name.length > 0);
+}
+
+function summarizeApiInventory(payload: unknown): { total?: number; class_names?: string[] } {
+  if (!payload || typeof payload !== 'object') return {};
+  const data = payload as { total?: unknown; classes?: unknown };
+  const classNames = Array.isArray(data.classes)
+    ? data.classes
+        .map((item) =>
+          item && typeof item === 'object'
+            ? (item as { className?: unknown }).className
+            : undefined,
+        )
+        .filter((name): name is string => typeof name === 'string')
+        .slice(0, 25)
+    : undefined;
+  return {
+    total: typeof data.total === 'number' ? data.total : undefined,
+    class_names: classNames,
+  };
+}
+
 function registerDiagnosticsApi(
   registry: { register: (def: ToolDefinition) => void },
   config: EnvConfig,
@@ -123,6 +171,127 @@ function registerDiagnosticsApi(
       },
     });
   }
+
+  registry.register({
+    name: 'easyeda_live_smoke_report',
+    title: 'Run EasyEDA live smoke report',
+    description:
+      'Run a read-only live smoke report against the connected EasyEDA bridge and return status, API inventory, components, wires, and schematic nets in one response.',
+    profile: 'dev',
+    evidence: ['runtime-probe', 'inferred'],
+    risk: 'low',
+    confirmWrite: false,
+    group: 'diagnostics',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+    inputSchema: z.object({
+      projectId: z.string().default(''),
+      limit: z.number().int().min(1).max(100).default(10),
+      includeRaw: z.boolean().default(true),
+      timeoutMs: z.number().int().min(1000).max(60000).default(15000),
+    }),
+    outputSchema: z.object({
+      ok: z.boolean(),
+      project_id: z.string(),
+      generated_at: z.string(),
+      checks: z.array(
+        z.object({
+          id: z.string(),
+          method: z.string(),
+          ok: z.boolean(),
+          duration_ms: z.number().int().nonnegative(),
+          error: z.string().optional(),
+        }),
+      ),
+      summary: z.object({
+        api_class_count: z.number().optional(),
+        api_class_names: z.array(z.string()).optional(),
+        component_total: z.number().optional(),
+        wire_total: z.number().optional(),
+        net_total: z.number().optional(),
+        net_names: z.array(z.string()).optional(),
+      }),
+      raw: z
+        .object({
+          bridge_status: z.unknown().optional(),
+          api_inventory: z.unknown().optional(),
+          components: z.unknown().optional(),
+          wires: z.unknown().optional(),
+          nets: z.unknown().optional(),
+        })
+        .optional(),
+    }),
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const { projectId, limit, includeRaw, timeoutMs } = z
+        .object({
+          projectId: z.string().default(''),
+          limit: z.number().int().min(1).max(100).default(10),
+          includeRaw: z.boolean().default(true),
+          timeoutMs: z.number().int().min(1000).max(60000).default(15000),
+        })
+        .parse(params);
+
+      const steps: LiveSmokeStep[] = [
+        { id: 'bridge_status', method: 'system.getStatus', params: {} },
+        { id: 'api_inventory', method: 'system.apiInventory', params: {} },
+        { id: 'components', method: 'system.inspectComponents', params: { limit } },
+        { id: 'wires', method: 'system.inspectWires', params: { limit } },
+        { id: 'nets', method: 'schematic.listNets', params: { projectId } },
+      ];
+
+      const checks: LiveSmokeCheck[] = [];
+      const raw: Record<string, unknown> = {};
+
+      for (const step of steps) {
+        const startedAt = Date.now();
+        try {
+          raw[step.id] = await ctx.bridge.call(step.method, step.params, { timeoutMs });
+          checks.push({
+            id: step.id,
+            method: step.method,
+            ok: true,
+            duration_ms: Date.now() - startedAt,
+          });
+        } catch (err) {
+          checks.push({
+            id: step.id,
+            method: step.method,
+            ok: false,
+            duration_ms: Date.now() - startedAt,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
+
+      const apiSummary = summarizeApiInventory(raw.api_inventory);
+      return {
+        ok: checks.every((check) => check.ok),
+        project_id: projectId,
+        generated_at: new Date().toISOString(),
+        checks,
+        summary: {
+          api_class_count: apiSummary.total,
+          api_class_names: apiSummary.class_names,
+          component_total: summarizeTotal(raw.components),
+          wire_total: summarizeTotal(raw.wires),
+          net_total: Array.isArray(raw.nets) ? raw.nets.length : undefined,
+          net_names: summarizeNetNames(raw.nets),
+        },
+        raw: includeRaw
+          ? {
+              bridge_status: raw.bridge_status,
+              api_inventory: raw.api_inventory,
+              components: raw.components,
+              wires: raw.wires,
+              nets: raw.nets,
+            }
+          : undefined,
+      };
+    },
+  });
 
   registry.register({
     name: 'easyeda_wire_probe',

--- a/tests/unit/tools/diagnostics-api.test.ts
+++ b/tests/unit/tools/diagnostics-api.test.ts
@@ -17,6 +17,14 @@ function createDevContext(bridgeCall = vi.fn()): ToolContext {
   } as unknown as ToolContext;
 }
 
+function createDevRegistry(): ToolRegistry {
+  const config = EnvSchema.parse({ NODE_ENV: 'test', TOOL_PROFILE: 'dev' });
+  const registry = new ToolRegistry();
+  registry.setProfile('dev');
+  registerBuiltinTools(registry, config);
+  return registry;
+}
+
 describe('diagnostics API tools', () => {
   it('registers the read-only schematic wire probe in dev profile', async () => {
     const config = EnvSchema.parse({ NODE_ENV: 'test', TOOL_PROFILE: 'dev' });
@@ -59,5 +67,94 @@ describe('diagnostics API tools', () => {
       not_available: true,
       error: 'SCH_PrimitiveWire.getAll is not available',
     });
+  });
+
+  it('runs a consolidated EasyEDA live smoke report', async () => {
+    const registry = createDevRegistry();
+    const tool = registry.get('easyeda_live_smoke_report');
+    const bridgeCall = vi.fn(async (method: string) => {
+      switch (method) {
+        case 'system.getStatus':
+          return { connected: true, easyedaVersion: '3.2.149' };
+        case 'system.apiInventory':
+          return {
+            total: 2,
+            classes: [{ className: 'DMT_Board' }, { className: 'SCH_PrimitiveWire' }],
+          };
+        case 'system.inspectComponents':
+          return { total: 2, samples: [{ designator: 'R1' }] };
+        case 'system.inspectWires':
+          return { total: 2, samples: [{ primitiveId: 'wire-1', line: [360, 575, 285, 500] }] };
+        case 'schematic.listNets':
+          return [
+            { netName: 'GND', nodes: [{ component: 'R1', pin: '1' }] },
+            { netName: '+5V', nodes: [{ component: 'R1', pin: '2' }] },
+          ];
+        default:
+          throw new Error(`unexpected method: ${method}`);
+      }
+    });
+
+    const result = (await tool?.handler(createDevContext(bridgeCall), {
+      projectId: '',
+      limit: 10,
+      includeRaw: true,
+    })) as {
+      ok: boolean;
+      checks: Array<{ id: string; ok: boolean }>;
+      summary: {
+        component_total?: number;
+        wire_total?: number;
+        net_total?: number;
+        net_names?: string[];
+      };
+      raw?: { nets?: unknown };
+    };
+
+    expect(tool).toBeDefined();
+    expect(tool?.confirmWrite).toBe(false);
+    expect(result.ok).toBe(true);
+    expect(result.checks).toHaveLength(5);
+    expect(result.checks.every((check) => check.ok)).toBe(true);
+    expect(result.summary).toMatchObject({
+      component_total: 2,
+      wire_total: 2,
+      net_total: 2,
+      net_names: ['GND', '+5V'],
+    });
+    expect(result.raw?.nets).toEqual([
+      { netName: 'GND', nodes: [{ component: 'R1', pin: '1' }] },
+      { netName: '+5V', nodes: [{ component: 'R1', pin: '2' }] },
+    ]);
+    expect(bridgeCall).toHaveBeenCalledWith(
+      'schematic.listNets',
+      { projectId: '' },
+      { timeoutMs: 15000 },
+    );
+  });
+
+  it('keeps the live smoke report running and marks failed checks', async () => {
+    const registry = createDevRegistry();
+    const tool = registry.get('easyeda_live_smoke_report');
+    const bridgeCall = vi.fn(async (method: string) => {
+      if (method === 'system.inspectWires') throw new Error('wire inspection failed');
+      return method === 'schematic.listNets' ? [] : { total: 0 };
+    });
+
+    const result = (await tool?.handler(createDevContext(bridgeCall), {
+      includeRaw: false,
+    })) as {
+      ok: boolean;
+      checks: Array<{ id: string; ok: boolean; error?: string }>;
+      raw?: unknown;
+    };
+
+    expect(result.ok).toBe(false);
+    expect(result.checks.find((check) => check.id === 'wires')).toMatchObject({
+      ok: false,
+      error: 'wire inspection failed',
+    });
+    expect(result.raw).toBeUndefined();
+    expect(bridgeCall).toHaveBeenCalledTimes(5);
   });
 });


### PR DESCRIPTION
Draft test PR. Adds a coordinate/topology fallback for EasyEDA v3 schematic nets: builds a graph from SCH_PrimitiveWire line points, labels connected components from netflag coordinates, and maps component pin coordinates back to named nets. This is intentionally not released yet; it needs live EasyEDA v3.2.149 validation before merge/stable release. Local verification passed: format, typecheck, extension typecheck, lint, full tests, build, metadata, extension build/verify, docs build.