### PR TITLE
fix(extension): use marketplace-compatible bugs URL

### DIFF
--- a/easyeda-bridge-extension/extension.json
+++ b/easyeda-bridge-extension/extension.json
@@ -90,7 +90,5 @@
     "url": "https://github.com/oaslananka/easyeda-mcp-pro"
   },
   "homepage": "https://github.com/oaslananka/easyeda-mcp-pro#readme",
-  "bugs": {
-    "url": "https://github.com/oaslananka/easyeda-mcp-pro/issues"
-  }
+  "bugs": "https://github.com/oaslananka/easyeda-mcp-pro/issues"
 }

--- a/easyeda-bridge-extension/scripts/verify-dist.mjs
+++ b/easyeda-bridge-extension/scripts/verify-dist.mjs
@@ -106,6 +106,13 @@ if (!Array.isArray(manifest.keywords) || manifest.keywords.length < 5) {
   console.log(`OK: marketplace keywords (${manifest.keywords.length})`);
 }
 
+if (typeof manifest.bugs !== 'string' || !/^https?:\/\//.test(manifest.bugs)) {
+  console.error('MARKETPLACE BUGS FIELD INVALID: expected an HTTP(S) URL string');
+  ok = false;
+} else {
+  console.log('OK: marketplace bugs URL string');
+}
+
 const logoPath = join(root, 'images', 'logo.png');
 try {
   const { width, height } = readPngDimensions(logoPath);


### PR DESCRIPTION
Fixes EasyEDA Marketplace upload rejection: `Invalid bugs content`.

The EasyEDA extension manifest example uses `bugs` as an HTTP(S) URL string, not an object. This changes `extension.json` from `bugs.url` object form to a direct URL string and adds a marketplace verification check to prevent regressions.

Verification:
- format check
- typecheck
- extension typecheck
- lint
- build
- metadata check
- extension build and marketplace verify
- full test suite: 42 files / 562 tests
- docs build
