### PR TITLE
feat(export): enforce manufacturing package manifest checks

### DIFF
--- a/docs/export-manifest.md
+++ b/docs/export-manifest.md
@@ -27,6 +27,9 @@ interface ExportManifestInput {
   generatedAt: string; // ISO-8601 generation timestamp
   serverVersion?: string; // Server/tool version
   bridgeMetadata?: Record<string, unknown>; // EasyEDA bridge metadata
+  projectMetadata?: ExportProjectMetadata; // project / EasyEDA version metadata
+  manufacturingPolicy?: ManufacturingExportPolicy; // strict handoff checks
+  assemblyConsistency?: AssemblyConsistencyMetadata; // BOM / PNP cross-check data
   artifacts: ExportManifestEntry[]; // Exported files
   expectedArtifacts?: ExpectedArtifact[]; // Expected file descriptors
 }
@@ -40,10 +43,12 @@ interface ExportManifestEntry {
   relativePath?: string; // Path relative to export root
   fileType: ArtifactType; // Type (gerber, drill, bom, etc.)
   purpose: string; // Human-readable description
+  role?: ExportArtifactRole; // Manufacturing role, e.g. board-outline
   sourceProject?: string; // Project UUID this artifact came from
   generatedByTool?: string; // Tool name (e.g. "easyeda-export-gerbers")
   timestamp?: string; // ISO-8601 generation time
-  checksum?: string; // SHA-256 or MD5 checksum
+  checksum?: string; // SHA-256, SHA-512, or MD5 checksum
+  checksumAlgorithm?: 'sha256' | 'sha512' | 'md5';
   fileSize?: number; // Size in bytes
   required: boolean; // Whether this file is required
   stale: boolean; // Whether this artifact is outdated
@@ -56,6 +61,7 @@ interface ExportManifestEntry {
 interface ExpectedArtifact {
   filename: string; // Expected file name
   fileType: ArtifactType; // Expected file type
+  role?: ExportArtifactRole; // Expected manufacturing role
   minSizeBytes?: number; // Minimum acceptable size
   required?: boolean; // Whether missing = error (default: true)
 }
@@ -76,22 +82,30 @@ interface ExpectedArtifact {
 
 ## Validation Rules
 
-The module runs 10 validation rules against an `ExportManifestInput`:
+The module runs structural and manufacturing handoff validation rules against an `ExportManifestInput`:
 
-| #   | Rule                   | Severity | Description                                                       |
-| --- | ---------------------- | -------- | ----------------------------------------------------------------- |
-| 1   | Invalid version        | error    | Manifest version must be valid semver (e.g. `1.0.0`)              |
-| 2   | Missing source project | error    | `sourceProjectId` must be non-empty                               |
-|     |                        | warning  | Each artifact should have `sourceProject`                         |
-| 3   | Missing timestamp      | error    | `generatedAt` must be non-empty                                   |
-|     |                        | warning  | Each artifact should have `timestamp`                             |
-| 4   | Missing purpose        | warning  | Each artifact should have a human-readable `purpose`              |
-| 5   | Empty file             | error    | Artifacts with `fileSize: 0` are rejected                         |
-| 6   | Stale file             | warning  | Artifacts flagged `stale: true` need re-export                    |
-| 7   | Checksum mismatch      | error    | When `checksum` uses `"expected:actual"` format and values differ |
-| 8   | Missing required file  | error    | Required `expectedArtifacts` not found in `artifacts`             |
-| 9   | Unexpected file        | warning  | Artifact in output but not in `expectedArtifacts`                 |
-| 10  | Wrong file type        | error    | Artifact `fileType` doesn't match `expectedArtifacts` entry       |
+| #   | Rule                        | Severity | Description                                                       |
+| --- | --------------------------- | -------- | ----------------------------------------------------------------- |
+| 1   | Invalid version             | error    | Manifest version must be valid semver (e.g. `1.0.0`)              |
+| 2   | Missing source project      | error    | `sourceProjectId` must be non-empty                               |
+|     |                             | warning  | Each artifact should have `sourceProject`                         |
+| 3   | Missing timestamp           | error    | `generatedAt` must be non-empty                                   |
+|     |                             | warning  | Each artifact should have `timestamp`                             |
+| 4   | Missing purpose             | warning  | Each artifact should have a human-readable `purpose`              |
+| 5   | Empty file                  | error    | Artifacts with `fileSize: 0` are rejected                         |
+| 6   | Stale file                  | warning  | Artifacts flagged `stale: true` need re-export                    |
+| 7   | Checksum mismatch           | error    | When `checksum` uses `"expected:actual"` format and values differ |
+| 8   | Missing required file       | error    | Required `expectedArtifacts` not found in `artifacts`             |
+| 9   | Unexpected file             | warning  | Artifact in output but not in `expectedArtifacts`                 |
+| 10  | Wrong file type             | error    | Artifact `fileType` doesn't match `expectedArtifacts` entry       |
+| 11  | Missing checksum            | error    | Required artifact lacks checksum when strict policy requires it   |
+| 12  | Missing file size           | error    | Required artifact lacks file size metadata                        |
+| 13  | Missing generation metadata | error    | Required artifact lacks source/tool/timestamp metadata            |
+| 14  | Missing required role       | error    | Required manufacturing role is absent                             |
+| 15  | Missing board outline       | error    | Board outline/mechanical artifact is absent                       |
+| 16  | Missing drill file          | error    | Required NC drill artifact is absent                              |
+| 17  | BOM/PNP mismatch            | error    | Pick-and-place designators are not represented in BOM             |
+| 18  | Missing project metadata    | error    | EasyEDA/project/server metadata is absent in strict policy        |
 
 ### Validation Report
 
@@ -116,6 +130,13 @@ interface ExportManifestSummary {
   missingPurposes: number;
   missingTimestamps: number;
   missingSourceProjects: number;
+  missingChecksums: number;
+  missingFileSizes: number;
+  missingRequiredRoles: number;
+  missingBoardOutlines: number;
+  missingDrillFiles: number;
+  bomPnpMismatches: number;
+  missingProjectMetadata: number;
 }
 ```
 
@@ -159,6 +180,75 @@ const entry = {
   stale: false,
 };
 ```
+
+## Manufacturing Handoff Policy
+
+For fabrication/assembly packages, pass a strict `manufacturingPolicy` so the manifest validator can block incomplete packages before handoff:
+
+```typescript
+import {
+  ArtifactType,
+  ExportArtifactRole,
+  validateExportManifest,
+} from 'easyeda-mcp-pro/export-manifest';
+
+const result = validateExportManifest({
+  version: '1.0.0',
+  sourceProjectId: 'proj-abc-123',
+  sourceProjectName: 'Regulator Board',
+  generatedAt: new Date().toISOString(),
+  serverVersion: '0.6.10',
+  projectMetadata: {
+    projectId: 'proj-abc-123',
+    projectName: 'Regulator Board',
+    easyedaVersion: '3.2.149',
+    bridgeVersion: '1.0.0',
+    revision: 'A',
+  },
+  manufacturingPolicy: {
+    requiredRoles: [
+      ExportArtifactRole.TopCopper,
+      ExportArtifactRole.BottomCopper,
+      ExportArtifactRole.BoardOutline,
+      ExportArtifactRole.DrillPlated,
+      ExportArtifactRole.Bom,
+      ExportArtifactRole.PickPlace,
+    ],
+    requireChecksums: true,
+    requireFileSizes: true,
+    requireGenerationMetadata: true,
+    requireProjectMetadata: true,
+    requireBomPnpConsistency: true,
+  },
+  assemblyConsistency: {
+    bomDesignators: ['R1', 'C1', 'U1'],
+    pnpDesignators: ['R1', 'C1', 'U1'],
+  },
+  artifacts: [
+    {
+      filename: 'board-Edge.Cuts.gbr',
+      fileType: ArtifactType.Gerber,
+      role: ExportArtifactRole.BoardOutline,
+      purpose: 'Board outline',
+      sourceProject: 'proj-abc-123',
+      generatedByTool: 'easyeda-export-gerbers',
+      timestamp: new Date().toISOString(),
+      checksum: '<sha256>',
+      checksumAlgorithm: 'sha256',
+      fileSize: 4096,
+      required: true,
+      stale: false,
+    },
+  ],
+});
+```
+
+Strict policy blocks handoff when:
+
+- required copper, outline, drill, BOM, or pick-and-place roles are missing;
+- required artifacts lack checksum, file size, source, tool, or timestamp metadata;
+- EasyEDA/project/server metadata is missing;
+- pick-and-place contains assembly designators that are not represented in the BOM.
 
 ## CI-Safe Fixture Workflow
 
@@ -219,9 +309,9 @@ expectations. The `golden-smoke.test.ts` suite verifies:
 - **Checksum format**: The `"expected:actual"` convention is ad-hoc. A structured
   `{ expectedChecksum: string, actualChecksum: string }` field would be cleaner but
   is deferred for schema compatibility.
-- **No real file I/O**: The module validates the manifest structure only — it does
+- **No real file I/O**: The module validates the manifest structure and metadata only — it does
   not read actual files from disk to verify sizes, existence, or checksums.
-  External callers should pass the actual values obtained from the file system.
+  Export callers must pass the actual values obtained from the file system or export response.
 - **Semver strictness**: The version regex allows pre-release tags but does not
   support build metadata (`+` suffix). Extend `SEMVER_RE` in `validation.ts` if needed.
 - **No cross-artifact deduplication**: If the same filename appears in multiple

--- a/src/export-manifest/errors.ts
+++ b/src/export-manifest/errors.ts
@@ -31,6 +31,23 @@ export const ExportManifestCode = {
   /** Artifact's declared file type does not match its content/name. */
   WRONG_FILE_TYPE: 'WRONG_FILE_TYPE',
 
+  /** Required artifact is missing checksum metadata. */
+  MISSING_CHECKSUM: 'MISSING_CHECKSUM',
+  /** Required artifact is missing file size metadata. */
+  MISSING_FILE_SIZE: 'MISSING_FILE_SIZE',
+  /** Required artifact is missing generation metadata. */
+  MISSING_GENERATION_METADATA: 'MISSING_GENERATION_METADATA',
+  /** Required manufacturing artifact role is missing from the package. */
+  MISSING_REQUIRED_ROLE: 'MISSING_REQUIRED_ROLE',
+  /** Board outline artifact is missing or invalid. */
+  MISSING_BOARD_OUTLINE: 'MISSING_BOARD_OUTLINE',
+  /** Drill artifact is missing or invalid. */
+  MISSING_DRILL_FILE: 'MISSING_DRILL_FILE',
+  /** BOM and pick-and-place designators are inconsistent. */
+  BOM_PNP_MISMATCH: 'BOM_PNP_MISMATCH',
+  /** Manifest lacks required project / EasyEDA metadata. */
+  MISSING_PROJECT_METADATA: 'MISSING_PROJECT_METADATA',
+
   // ── Metadata errors ────────────────────────────────────────────────────
 
   /** Artifact is missing a human-readable purpose description. */

--- a/src/export-manifest/index.ts
+++ b/src/export-manifest/index.ts
@@ -4,10 +4,13 @@
  * @module
  */
 
-export { ArtifactType } from './types.js';
+export { ArtifactType, ExportArtifactRole } from './types.js';
 export type {
   ExportManifestEntry,
   ExpectedArtifact,
+  ExportProjectMetadata,
+  AssemblyConsistencyMetadata,
+  ManufacturingExportPolicy,
   ExportManifestInput,
   ExportManifestIssue,
   ExportManifestSummary,

--- a/src/export-manifest/types.ts
+++ b/src/export-manifest/types.ts
@@ -35,6 +35,33 @@ export enum ArtifactType {
   DrcReport = 'drc-report',
 }
 
+/**
+ * Manufacturing handoff role for an export artifact.
+ *
+ * File extensions alone are often ambiguous. Roles let the validator check
+ * that a fabrication package has the required copper, mask, drill, outline,
+ * assembly, and documentation artifacts.
+ */
+export enum ExportArtifactRole {
+  TopCopper = 'top-copper',
+  BottomCopper = 'bottom-copper',
+  InnerCopper = 'inner-copper',
+  TopSolderMask = 'top-solder-mask',
+  BottomSolderMask = 'bottom-solder-mask',
+  TopSilkscreen = 'top-silkscreen',
+  BottomSilkscreen = 'bottom-silkscreen',
+  BoardOutline = 'board-outline',
+  DrillPlated = 'drill-plated',
+  DrillNonPlated = 'drill-nonplated',
+  Bom = 'bom',
+  PickPlace = 'pick-place',
+  SchematicPdf = 'schematic-pdf',
+  BoardPdf = 'board-pdf',
+  Netlist = 'netlist',
+  DrcReport = 'drc-report',
+  ErcReport = 'erc-report',
+}
+
 // ── Manifest entry ─────────────────────────────────────────────────────────
 
 /**
@@ -52,14 +79,18 @@ export interface ExportManifestEntry {
   fileType: ArtifactType;
   /** Human-readable purpose (e.g. "Top copper layer"). */
   purpose: string;
+  /** Manufacturing role used for package completeness checks. */
+  role?: ExportArtifactRole;
   /** Source project identifier. */
   sourceProject?: string;
   /** Tool that generated this artifact (e.g. "easyeda-export-gerbers"). */
   generatedByTool?: string;
   /** ISO-8601 timestamp when this artifact was generated. */
   timestamp?: string;
-  /** Hex-encoded SHA-256 or MD5 checksum. */
+  /** Hex-encoded checksum, preferably SHA-256. */
   checksum?: string;
+  /** Algorithm used to compute checksum. */
+  checksumAlgorithm?: 'sha256' | 'sha512' | 'md5';
   /** File size in bytes. */
   fileSize?: number;
   /** Whether this artifact is required for the export to be valid. */
@@ -80,10 +111,58 @@ export interface ExpectedArtifact {
   filename: string;
   /** Expected file type. */
   fileType: ArtifactType;
+  /** Expected manufacturing role. */
+  role?: ExportArtifactRole;
   /** Minimum acceptable file size in bytes. */
   minSizeBytes?: number;
   /** Whether this artifact is required (missing = validation error). */
   required?: boolean;
+}
+
+// ── Manufacturing policy ───────────────────────────────────────────────────
+
+/** Project metadata captured at export time. */
+export interface ExportProjectMetadata {
+  /** EasyEDA project id or repository-specific project id. */
+  projectId: string;
+  /** Human-readable project name. */
+  projectName?: string;
+  /** EasyEDA editor/runtime version when available. */
+  easyedaVersion?: string;
+  /** EasyEDA bridge extension version when available. */
+  bridgeVersion?: string;
+  /** Source document or board id when available. */
+  documentId?: string;
+  /** Board revision or release identifier. */
+  revision?: string;
+}
+
+/** Assembly cross-check metadata for BOM and pick-and-place consistency. */
+export interface AssemblyConsistencyMetadata {
+  /** BOM designators extracted from the exported BOM. */
+  bomDesignators?: string[];
+  /** Pick-and-place designators extracted from the centroid file. */
+  pnpDesignators?: string[];
+  /** Expected BOM row/designator count. */
+  expectedBomDesignatorCount?: number;
+  /** Expected pick-and-place row/designator count. */
+  expectedPnpDesignatorCount?: number;
+}
+
+/** Manufacturing package validation policy. */
+export interface ManufacturingExportPolicy {
+  /** Required artifact roles for this export profile. */
+  requiredRoles?: ExportArtifactRole[];
+  /** Require each required artifact to include checksum metadata. */
+  requireChecksums?: boolean;
+  /** Require each required artifact to include non-zero fileSize. */
+  requireFileSizes?: boolean;
+  /** Require each required artifact to include generatedByTool and timestamp. */
+  requireGenerationMetadata?: boolean;
+  /** Require manifest-level EasyEDA and project metadata. */
+  requireProjectMetadata?: boolean;
+  /** Require BOM and pick-and-place designator consistency checks. */
+  requireBomPnpConsistency?: boolean;
 }
 
 // ── Validation input ───────────────────────────────────────────────────────
@@ -107,6 +186,12 @@ export interface ExportManifestInput {
   serverVersion?: string;
   /** EasyEDA / bridge metadata if available. */
   bridgeMetadata?: Record<string, unknown>;
+  /** Structured project metadata captured at export time. */
+  projectMetadata?: ExportProjectMetadata;
+  /** Manufacturing package policy for strict handoff checks. */
+  manufacturingPolicy?: ManufacturingExportPolicy;
+  /** Optional assembly data used to compare BOM and pick-and-place outputs. */
+  assemblyConsistency?: AssemblyConsistencyMetadata;
   /** Artifacts produced by the export. */
   artifacts: ExportManifestEntry[];
   /** Expected artifacts for comparison-based validation. */
@@ -172,6 +257,20 @@ export interface ExportManifestSummary {
   missingTimestamps: number;
   /** Count of artifacts missing a source project reference. */
   missingSourceProjects: number;
+  /** Count of artifacts missing checksum metadata. */
+  missingChecksums: number;
+  /** Count of artifacts missing file size metadata. */
+  missingFileSizes: number;
+  /** Count of missing manufacturing roles. */
+  missingRequiredRoles: number;
+  /** Count of board outline package errors. */
+  missingBoardOutlines: number;
+  /** Count of drill package errors. */
+  missingDrillFiles: number;
+  /** Count of BOM / pick-and-place consistency errors. */
+  bomPnpMismatches: number;
+  /** Count of manifest/project metadata errors. */
+  missingProjectMetadata: number;
 }
 
 /**

--- a/src/export-manifest/validation.ts
+++ b/src/export-manifest/validation.ts
@@ -15,11 +15,16 @@
  *  8. Missing required file     — error when expected artifact not found in output
  *  9. Unexpected file           — warning when output file not in expected set
  * 10. Wrong file type           — error when artifact type doesn't match expected
+ * 11. Missing artifact metadata — error/warning for missing checksum, size, or generator data
+ * 12. Manufacturing roles       — error when required board outline, drill, or layer roles are missing
+ * 13. Project metadata          — error when EasyEDA/project metadata is required but absent
+ * 14. BOM/PNP consistency       — error when pick-and-place designators are not represented in BOM
  *
  * @module
  */
 
 import { ExportManifestCode, manifestError, manifestWarning } from './errors.js';
+import { ExportArtifactRole } from './types.js';
 import type { ExportManifestIssue } from './types.js';
 import type { ExportManifestInput, ExportManifestReport, ExportManifestSummary } from './types.js';
 
@@ -355,6 +360,323 @@ function checkWrongFileTypes(input: ExportManifestInput): ExportManifestIssue[] 
   return issues;
 }
 
+// ── Rule: required artifact metadata ────────────────────────────────────────
+
+function checkRequiredArtifactMetadata(input: ExportManifestInput): ExportManifestIssue[] {
+  const issues: ExportManifestIssue[] = [];
+  const policy = input.manufacturingPolicy;
+
+  if (!policy) return issues;
+
+  for (const [i, artifact] of input.artifacts.entries()) {
+    if (!artifact.required) continue;
+
+    if (policy.requireChecksums && (!artifact.checksum || artifact.checksum.trim().length === 0)) {
+      issues.push(
+        manifestError(
+          ExportManifestCode.MISSING_CHECKSUM,
+          `Required artifact "${artifact.filename}" is missing checksum metadata`,
+          {
+            path: `artifacts[${i}].checksum`,
+            artifactPath: artifact.filename,
+            artifactType: artifact.fileType,
+            remediationHint:
+              'Compute and store a SHA-256 checksum for every required export artifact before manufacturing handoff',
+          },
+        ),
+      );
+    }
+
+    if (policy.requireChecksums && artifact.checksum && !artifact.checksumAlgorithm) {
+      issues.push(
+        manifestWarning(
+          ExportManifestCode.MISSING_CHECKSUM,
+          `Artifact "${artifact.filename}" has a checksum but no checksumAlgorithm`,
+          {
+            path: `artifacts[${i}].checksumAlgorithm`,
+            artifactPath: artifact.filename,
+            artifactType: artifact.fileType,
+            remediationHint: 'Set checksumAlgorithm to sha256, sha512, or md5; sha256 is preferred',
+          },
+        ),
+      );
+    }
+
+    if (policy.requireFileSizes && artifact.fileSize === undefined) {
+      issues.push(
+        manifestError(
+          ExportManifestCode.MISSING_FILE_SIZE,
+          `Required artifact "${artifact.filename}" is missing fileSize metadata`,
+          {
+            path: `artifacts[${i}].fileSize`,
+            artifactPath: artifact.filename,
+            artifactType: artifact.fileType,
+            remediationHint:
+              'Record the actual file size from disk so empty/truncated package artifacts can be detected',
+          },
+        ),
+      );
+    }
+
+    if (policy.requireGenerationMetadata) {
+      const missingFields = [
+        !artifact.generatedByTool ? 'generatedByTool' : undefined,
+        !artifact.timestamp ? 'timestamp' : undefined,
+        !artifact.sourceProject ? 'sourceProject' : undefined,
+      ].filter((field): field is string => Boolean(field));
+
+      if (missingFields.length > 0) {
+        issues.push(
+          manifestError(
+            ExportManifestCode.MISSING_GENERATION_METADATA,
+            `Required artifact "${artifact.filename}" is missing generation metadata: ${missingFields.join(', ')}`,
+            {
+              path: `artifacts[${i}]`,
+              artifactPath: artifact.filename,
+              artifactType: artifact.fileType,
+              remediationHint:
+                'Record sourceProject, generatedByTool, and timestamp for every required artifact so the package is reproducible and auditable',
+              details: { missingFields },
+            },
+          ),
+        );
+      }
+    }
+  }
+
+  return issues;
+}
+
+// ── Rule: expected role mismatch ────────────────────────────────────────────
+
+function checkExpectedRoles(input: ExportManifestInput): ExportManifestIssue[] {
+  const issues: ExportManifestIssue[] = [];
+  if (!input.expectedArtifacts || input.expectedArtifacts.length === 0) return issues;
+
+  const artifactByFilename = new Map(
+    input.artifacts.map((artifact) => [artifact.filename, artifact]),
+  );
+
+  for (const [i, expected] of input.expectedArtifacts.entries()) {
+    if (!expected.role) continue;
+    const artifact = artifactByFilename.get(expected.filename);
+    if (!artifact) continue;
+    if (artifact.role !== expected.role) {
+      issues.push(
+        manifestError(
+          ExportManifestCode.MISSING_REQUIRED_ROLE,
+          `Artifact "${expected.filename}" has role "${artifact.role ?? '<missing>'}" but expected "${expected.role}"`,
+          {
+            path: `expectedArtifacts[${i}].role`,
+            artifactPath: expected.filename,
+            artifactType: expected.fileType,
+            remediationHint:
+              'Assign the correct manufacturing role to the artifact so package completeness checks can reason about layers and assembly outputs',
+            details: { actualRole: artifact.role, expectedRole: expected.role },
+          },
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
+// ── Rule: manufacturing required roles ──────────────────────────────────────
+
+function checkManufacturingRoles(input: ExportManifestInput): ExportManifestIssue[] {
+  const issues: ExportManifestIssue[] = [];
+  const requiredRoles = input.manufacturingPolicy?.requiredRoles ?? [];
+  if (requiredRoles.length === 0) return issues;
+
+  const presentRoles = new Set(input.artifacts.map((artifact) => artifact.role).filter(Boolean));
+
+  for (const requiredRole of requiredRoles) {
+    if (presentRoles.has(requiredRole)) continue;
+
+    let code: ExportManifestCode = ExportManifestCode.MISSING_REQUIRED_ROLE;
+    let message = `Required manufacturing artifact role "${requiredRole}" is missing from the export package`;
+    let hint =
+      'Re-run the export or add the missing artifact to the package manifest before manufacturing handoff';
+
+    if (requiredRole === ExportArtifactRole.BoardOutline) {
+      code = ExportManifestCode.MISSING_BOARD_OUTLINE;
+      message = 'Board outline artifact is missing from the manufacturing export package';
+      hint =
+        'Export the board outline/mechanical layer; fabrication packages without a board outline should not be handed off';
+    } else if (
+      requiredRole === ExportArtifactRole.DrillPlated ||
+      requiredRole === ExportArtifactRole.DrillNonPlated
+    ) {
+      code = ExportManifestCode.MISSING_DRILL_FILE;
+      message = `Required drill artifact role "${requiredRole}" is missing from the manufacturing export package`;
+      hint =
+        'Export the required NC drill file and verify it is non-empty before fabrication handoff';
+    }
+
+    issues.push(
+      manifestError(code, message, {
+        path: 'manufacturingPolicy.requiredRoles',
+        artifactType: requiredRole,
+        remediationHint: hint,
+        details: { requiredRole },
+      }),
+    );
+
+    if (code !== ExportManifestCode.MISSING_REQUIRED_ROLE) {
+      issues.push(
+        manifestError(
+          ExportManifestCode.MISSING_REQUIRED_ROLE,
+          `Required manufacturing artifact role "${requiredRole}" is missing from the export package`,
+          {
+            path: 'manufacturingPolicy.requiredRoles',
+            artifactType: requiredRole,
+            remediationHint: hint,
+            details: { requiredRole },
+          },
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
+// ── Rule: project / EasyEDA metadata ────────────────────────────────────────
+
+function checkProjectMetadata(input: ExportManifestInput): ExportManifestIssue[] {
+  const issues: ExportManifestIssue[] = [];
+  if (!input.manufacturingPolicy?.requireProjectMetadata) return issues;
+
+  const metadata = input.projectMetadata;
+  const missingFields = [
+    !metadata?.projectId ? 'projectMetadata.projectId' : undefined,
+    !metadata?.projectName && !input.sourceProjectName ? 'projectMetadata.projectName' : undefined,
+    !metadata?.easyedaVersion ? 'projectMetadata.easyedaVersion' : undefined,
+    !metadata?.bridgeVersion ? 'projectMetadata.bridgeVersion' : undefined,
+    !input.serverVersion ? 'serverVersion' : undefined,
+  ].filter((field): field is string => Boolean(field));
+
+  if (missingFields.length > 0) {
+    issues.push(
+      manifestError(
+        ExportManifestCode.MISSING_PROJECT_METADATA,
+        `Manufacturing manifest is missing required project/EasyEDA metadata: ${missingFields.join(', ')}`,
+        {
+          path: 'projectMetadata',
+          remediationHint:
+            'Attach EasyEDA version, bridge version, server version, project id, and project name to the manifest before releasing manufacturing files',
+          details: { missingFields },
+        },
+      ),
+    );
+  }
+
+  return issues;
+}
+
+// ── Rule: BOM / pick-and-place consistency ──────────────────────────────────
+
+function normalizeDesignator(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+function checkBomPnpConsistency(input: ExportManifestInput): ExportManifestIssue[] {
+  const issues: ExportManifestIssue[] = [];
+  const consistency = input.assemblyConsistency;
+  if (!input.manufacturingPolicy?.requireBomPnpConsistency && !consistency) return issues;
+
+  const artifactsByRole = new Set(input.artifacts.map((artifact) => artifact.role).filter(Boolean));
+  const hasBom = artifactsByRole.has(ExportArtifactRole.Bom);
+  const hasPnp = artifactsByRole.has(ExportArtifactRole.PickPlace);
+
+  if (input.manufacturingPolicy?.requireBomPnpConsistency && (!hasBom || !hasPnp)) {
+    const missing = [
+      !hasBom ? ExportArtifactRole.Bom : undefined,
+      !hasPnp ? ExportArtifactRole.PickPlace : undefined,
+    ].filter((role): role is ExportArtifactRole => Boolean(role));
+    issues.push(
+      manifestError(
+        ExportManifestCode.BOM_PNP_MISMATCH,
+        `BOM / pick-and-place consistency was requested but package is missing: ${missing.join(', ')}`,
+        {
+          path: 'artifacts',
+          remediationHint:
+            'Export both BOM and pick-and-place files before running assembly consistency checks',
+          details: { missingRoles: missing },
+        },
+      ),
+    );
+  }
+
+  if (!consistency) return issues;
+
+  const bomDesignators = new Set((consistency.bomDesignators ?? []).map(normalizeDesignator));
+  const pnpDesignators = new Set((consistency.pnpDesignators ?? []).map(normalizeDesignator));
+
+  if (
+    consistency.expectedBomDesignatorCount !== undefined &&
+    bomDesignators.size !== consistency.expectedBomDesignatorCount
+  ) {
+    issues.push(
+      manifestError(
+        ExportManifestCode.BOM_PNP_MISMATCH,
+        `BOM designator count mismatch: expected ${consistency.expectedBomDesignatorCount}, got ${bomDesignators.size}`,
+        {
+          path: 'assemblyConsistency.expectedBomDesignatorCount',
+          remediationHint:
+            'Regenerate the BOM or update the expected designator count from the exported file parser',
+          details: {
+            expected: consistency.expectedBomDesignatorCount,
+            actual: bomDesignators.size,
+          },
+        },
+      ),
+    );
+  }
+
+  if (
+    consistency.expectedPnpDesignatorCount !== undefined &&
+    pnpDesignators.size !== consistency.expectedPnpDesignatorCount
+  ) {
+    issues.push(
+      manifestError(
+        ExportManifestCode.BOM_PNP_MISMATCH,
+        `Pick-and-place designator count mismatch: expected ${consistency.expectedPnpDesignatorCount}, got ${pnpDesignators.size}`,
+        {
+          path: 'assemblyConsistency.expectedPnpDesignatorCount',
+          remediationHint:
+            'Regenerate the pick-and-place file or update the expected designator count from the exported file parser',
+          details: {
+            expected: consistency.expectedPnpDesignatorCount,
+            actual: pnpDesignators.size,
+          },
+        },
+      ),
+    );
+  }
+
+  const missingFromBom = [...pnpDesignators].filter(
+    (designator) => !bomDesignators.has(designator),
+  );
+  if (missingFromBom.length > 0) {
+    issues.push(
+      manifestError(
+        ExportManifestCode.BOM_PNP_MISMATCH,
+        `Pick-and-place contains designators not present in BOM: ${missingFromBom.join(', ')}`,
+        {
+          path: 'assemblyConsistency.pnpDesignators',
+          remediationHint:
+            'Ensure every placed assembly designator is represented in the BOM, or explicitly mark non-BOM mechanical/fiducial rows as excluded before handoff',
+          details: { missingFromBom },
+        },
+      ),
+    );
+  }
+
+  return issues;
+}
+
 // ── Combine helper ──────────────────────────────────────────────────────────
 
 type RuleFn = (input: ExportManifestInput) => ExportManifestIssue[];
@@ -370,6 +692,11 @@ const RULES: RuleFn[] = [
   checkMissingRequiredFiles,
   checkUnexpectedFiles,
   checkWrongFileTypes,
+  checkRequiredArtifactMetadata,
+  checkExpectedRoles,
+  checkManufacturingRoles,
+  checkProjectMetadata,
+  checkBomPnpConsistency,
 ];
 
 // ── Summary builder ─────────────────────────────────────────────────────────
@@ -400,6 +727,18 @@ function buildSummary(
     missingSourceProjects: issues.filter(
       (i) => i.code === ExportManifestCode.MISSING_SOURCE_PROJECT,
     ).length,
+    missingChecksums: issues.filter((i) => i.code === ExportManifestCode.MISSING_CHECKSUM).length,
+    missingFileSizes: issues.filter((i) => i.code === ExportManifestCode.MISSING_FILE_SIZE).length,
+    missingRequiredRoles: issues.filter((i) => i.code === ExportManifestCode.MISSING_REQUIRED_ROLE)
+      .length,
+    missingBoardOutlines: issues.filter((i) => i.code === ExportManifestCode.MISSING_BOARD_OUTLINE)
+      .length,
+    missingDrillFiles: issues.filter((i) => i.code === ExportManifestCode.MISSING_DRILL_FILE)
+      .length,
+    bomPnpMismatches: issues.filter((i) => i.code === ExportManifestCode.BOM_PNP_MISMATCH).length,
+    missingProjectMetadata: issues.filter(
+      (i) => i.code === ExportManifestCode.MISSING_PROJECT_METADATA,
+    ).length,
   };
 }
 
@@ -421,6 +760,10 @@ function buildSummary(
  *  8. Missing required file      — error when expected artifact not in output
  *  9. Unexpected file            — warning when output file not in expected set
  * 10. Wrong file type            — error when artifact type !== expected type
+ * 11. Required metadata        — error when manufacturing policy requires missing checksums, sizes, or generation metadata
+ * 12. Manufacturing roles      — error when required board outline, drill, layer, BOM, or pick-place roles are missing
+ * 13. Project metadata         — error when EasyEDA/project metadata required by policy is absent
+ * 14. BOM/PNP consistency      — error when assembly designator data is inconsistent
  */
 export function validateExportManifest(input: ExportManifestInput): ExportManifestReport {
   const issues: ExportManifestIssue[] = [];

--- a/tests/unit/export-manifest/export-manifest.test.ts
+++ b/tests/unit/export-manifest/export-manifest.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, expect } from 'vitest';
 import { validateExportManifest } from '../../../src/export-manifest/validation.js';
 import { ExportManifestCode } from '../../../src/export-manifest/errors.js';
-import { ArtifactType } from '../../../src/export-manifest/types.js';
+import { ArtifactType, ExportArtifactRole } from '../../../src/export-manifest/types.js';
 import type {
   ExportManifestInput,
   ExportManifestEntry,
@@ -20,9 +20,12 @@ function makeArtifact(overrides?: Partial<ExportManifestEntry>): ExportManifestE
     filename: 'ESP32-S3-Board-F.Cu.gbr',
     fileType: ArtifactType.Gerber,
     purpose: 'Top copper layer',
+    role: ExportArtifactRole.TopCopper,
     sourceProject: 'proj-esp32-s3-001',
     generatedByTool: 'easyeda-export-gerbers',
     timestamp: '2026-06-11T21:00:01.000Z',
+    checksum: 'a'.repeat(64),
+    checksumAlgorithm: 'sha256',
     fileSize: 4096,
     required: true,
     stale: false,
@@ -42,6 +45,7 @@ function makeInput(overrides?: Partial<ExportManifestInput>): ExportManifestInpu
       {
         filename: 'ESP32-S3-Board-F.Cu.gbr',
         fileType: ArtifactType.Gerber,
+        role: ExportArtifactRole.TopCopper,
         required: true,
       },
     ],
@@ -408,6 +412,181 @@ describe('validateExportManifest', () => {
     expect(result.summary.missingPurposes).toBe(1);
     expect(result.summary.missingTimestamps).toBe(1);
     expect(result.summary.missingSourceProjects).toBeGreaterThanOrEqual(1);
+  });
+
+  // ── Manufacturing package checks ─────────────────────────────────────────
+
+  function makeManufacturingInput(overrides?: Partial<ExportManifestInput>): ExportManifestInput {
+    const artifacts: ExportManifestEntry[] = [
+      makeArtifact({
+        filename: 'board-F.Cu.gbr',
+        role: ExportArtifactRole.TopCopper,
+        purpose: 'Top copper layer',
+      }),
+      makeArtifact({
+        filename: 'board-B.Cu.gbr',
+        role: ExportArtifactRole.BottomCopper,
+        purpose: 'Bottom copper layer',
+      }),
+      makeArtifact({
+        filename: 'board-Edge.Cuts.gbr',
+        role: ExportArtifactRole.BoardOutline,
+        purpose: 'Board outline',
+      }),
+      makeArtifact({
+        filename: 'board.drl',
+        fileType: ArtifactType.Drill,
+        role: ExportArtifactRole.DrillPlated,
+        purpose: 'Plated NC drill file',
+      }),
+      makeArtifact({
+        filename: 'bom.csv',
+        fileType: ArtifactType.Bom,
+        role: ExportArtifactRole.Bom,
+        purpose: 'Bill of materials',
+      }),
+      makeArtifact({
+        filename: 'pnp.csv',
+        fileType: ArtifactType.Pnp,
+        role: ExportArtifactRole.PickPlace,
+        purpose: 'Pick-and-place centroid file',
+      }),
+    ];
+
+    return makeInput({
+      serverVersion: '0.6.10',
+      projectMetadata: {
+        projectId: 'proj-esp32-s3-001',
+        projectName: 'ESP32-S3 Sensor Board',
+        easyedaVersion: '3.2.149',
+        bridgeVersion: '1.0.0',
+        revision: 'A',
+      },
+      manufacturingPolicy: {
+        requiredRoles: [
+          ExportArtifactRole.TopCopper,
+          ExportArtifactRole.BottomCopper,
+          ExportArtifactRole.BoardOutline,
+          ExportArtifactRole.DrillPlated,
+          ExportArtifactRole.Bom,
+          ExportArtifactRole.PickPlace,
+        ],
+        requireChecksums: true,
+        requireFileSizes: true,
+        requireGenerationMetadata: true,
+        requireProjectMetadata: true,
+        requireBomPnpConsistency: true,
+      },
+      assemblyConsistency: {
+        bomDesignators: ['R1', 'C1', 'U1'],
+        pnpDesignators: ['R1', 'C1', 'U1'],
+        expectedBomDesignatorCount: 3,
+        expectedPnpDesignatorCount: 3,
+      },
+      artifacts,
+      expectedArtifacts: artifacts.map((artifact) => ({
+        filename: artifact.filename,
+        fileType: artifact.fileType,
+        role: artifact.role,
+        required: artifact.required,
+      })),
+      ...overrides,
+    });
+  }
+
+  it('should pass a complete manufacturing handoff package', () => {
+    const result = validateExportManifest(makeManufacturingInput());
+
+    expect(result.valid).toBe(true);
+    expect(result.summary.missingRequiredRoles).toBe(0);
+    expect(result.summary.missingBoardOutlines).toBe(0);
+    expect(result.summary.missingDrillFiles).toBe(0);
+    expect(result.summary.bomPnpMismatches).toBe(0);
+    expect(result.summary.missingProjectMetadata).toBe(0);
+  });
+
+  it('should fail when manufacturing package misses board outline and drill artifacts', () => {
+    const input = makeManufacturingInput();
+    const result = validateExportManifest({
+      ...input,
+      artifacts: input.artifacts.filter(
+        (artifact) =>
+          artifact.role !== ExportArtifactRole.BoardOutline &&
+          artifact.role !== ExportArtifactRole.DrillPlated,
+      ),
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.summary.missingBoardOutlines).toBe(1);
+    expect(result.summary.missingDrillFiles).toBe(1);
+    expect(result.summary.missingRequiredRoles).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should fail required manufacturing artifacts without checksums or file sizes', () => {
+    const input = makeManufacturingInput();
+    const result = validateExportManifest({
+      ...input,
+      artifacts: [
+        {
+          ...input.artifacts[0]!,
+          checksum: undefined,
+          checksumAlgorithm: undefined,
+          fileSize: undefined,
+        },
+        ...input.artifacts.slice(1),
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.summary.missingChecksums).toBe(1);
+    expect(result.summary.missingFileSizes).toBe(1);
+  });
+
+  it('should fail when project and EasyEDA metadata are missing from a strict package', () => {
+    const result = validateExportManifest(
+      makeManufacturingInput({ projectMetadata: undefined, serverVersion: undefined }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.summary.missingProjectMetadata).toBe(1);
+    expect(result.issues.some((i) => i.code === ExportManifestCode.MISSING_PROJECT_METADATA)).toBe(
+      true,
+    );
+  });
+
+  it('should fail when pick-and-place contains designators not represented in BOM', () => {
+    const result = validateExportManifest(
+      makeManufacturingInput({
+        assemblyConsistency: {
+          bomDesignators: ['R1', 'C1'],
+          pnpDesignators: ['R1', 'C1', 'U1'],
+          expectedBomDesignatorCount: 2,
+          expectedPnpDesignatorCount: 3,
+        },
+      }),
+    );
+
+    expect(result.valid).toBe(false);
+    expect(result.summary.bomPnpMismatches).toBe(1);
+    expect(result.issues.some((i) => i.code === ExportManifestCode.BOM_PNP_MISMATCH)).toBe(true);
+  });
+
+  it('should fail when expected artifact role does not match actual artifact role', () => {
+    const input = makeManufacturingInput();
+    const result = validateExportManifest({
+      ...input,
+      expectedArtifacts: [
+        {
+          filename: 'board-F.Cu.gbr',
+          fileType: ArtifactType.Gerber,
+          role: ExportArtifactRole.BottomCopper,
+          required: true,
+        },
+      ],
+    });
+
+    expect(result.valid).toBe(false);
+    expect(result.summary.missingRequiredRoles).toBe(1);
   });
 
   // ── Edge cases ──────────────────────────────────────────────────────────


### PR DESCRIPTION
Implements #34 manufacturing export package verification.

Changes:
- Adds `ExportArtifactRole` so manufacturing artifacts can be checked by role, not only extension/type.
- Adds strict `manufacturingPolicy` for handoff validation.
- Adds structured `projectMetadata` for EasyEDA/project/server provenance.
- Adds `assemblyConsistency` for BOM versus pick-and-place designator checks.
- Adds validation errors for missing checksum, file size, generation metadata, board outline, drill file, required roles, project metadata, and BOM/PNP mismatch.
- Updates export manifest docs with strict handoff policy and examples.
- Adds manufacturing package unit tests covering complete packages and invalid handoff cases.

Verification:
- pnpm audit --audit-level low
- pnpm peers check
- pnpm format:check
- pnpm typecheck
- pnpm typecheck:extension
- pnpm lint
- pnpm lint:tools
- pnpm verify:tool-coverage
- pnpm test
- pnpm test:coverage
- pnpm build
- pnpm check:metadata
- pnpm build:extension
- pnpm verify:extension
- pnpm docs:build
- git diff --check

Local result: 42 test files / 568 tests passed.
