### PR TITLE
feat(erc): add semantic pin validation rules

### DIFF
--- a/docs/net-validation.md
+++ b/docs/net-validation.md
@@ -5,7 +5,7 @@ Semantic validation for EasyEDA Pro net/wire names and topology.
 ## Overview
 
 The net validation module inspects a schematic's net list and validates it
-against 10 electrical and naming-convention rules. It operates on a decoupled
+against 17 structural, naming-convention, and semantic ERC rules. It operates on a decoupled
 input type (`NetValidationEntry[]`) that can be fed from CircuitIR, the EasyEDA
 bridge, or test fixtures.
 
@@ -39,7 +39,7 @@ Each `NetValidationIssue` contains:
 
 ### 1. Floating Net (`NET_FLOATING`)
 
-**Severity:** error  
+**Severity:** error
 **Detects:** Nets with zero node connections.
 
 ```text
@@ -49,7 +49,7 @@ Net "FLOAT" (n2) has no node connections — it is floating
 
 ### 2. Duplicate Net Name (`NET_DUPLICATE_NAME`)
 
-**Severity:** error  
+**Severity:** error
 **Detects:** Two or more nets sharing the same name (case-insensitive).
 
 ```text
@@ -60,7 +60,7 @@ Net name "3V3" is used by 2 nets: n1, n2
 
 ### 3. Accidental Short (`NET_ACCIDENTAL_SHORT`)
 
-**Severity:** error  
+**Severity:** error
 **Detects:** The same device pin connected to multiple different nets.
 
 ```text
@@ -70,35 +70,35 @@ Device pin "U1:1" is connected to 2 different nets: NET_A, NET_B
 
 ### 4. Missing Power Net (`NET_MISSING_POWER`)
 
-**Severity:** error + warning  
+**Severity:** error + warning
 **Detects:** No net with `type=power` exists. Also warns when required
 power net names (`VIN`, `3V3`) are missing.
 
 ### 5. Missing Ground Net (`NET_MISSING_GROUND`)
 
-**Severity:** error + warning  
+**Severity:** error + warning
 **Detects:** No net with `type=ground` exists. Also warns when `GND` is missing.
 
 ### 6. Missing Hierarchical Port (`NET_MISSING_HIERARCHICAL_PORT`)
 
-**Severity:** error  
+**Severity:** error
 **Detects:** An interface/port references a signal name that does not match
 any net in the design.
 
 ### 7. Unconnected Required Pin (`NET_UNCONNECTED_REQUIRED_PIN`)
 
-**Severity:** warning  
+**Severity:** warning
 **Detects:** A device that has zero net connections anywhere.
 
 ### 8. Inconsistent Cross-Sheet Interface (`NET_INCONSISTENT_CROSS_SHEET`)
 
-**Severity:** error  
+**Severity:** error
 **Detects:** Two interfaces with the same name but different pin counts or
 mismatched signal names.
 
 ### 9. Naming Convention Violation (`NET_NAMING_CONVENTION`)
 
-**Severity:** warning  
+**Severity:** warning
 **Detects:** Power nets whose names do not match power rail conventions
 (e.g. `MY_RAIL` instead of `3V3` / `VCC`), or ground nets whose names
 do not match ground conventions (e.g. `RET` instead of `GND`).
@@ -108,10 +108,77 @@ categories (power, ground, analog, digital, clock, control, high-voltage).
 
 ### 10. Protected Domain (`NET_PROTECTED_DOMAIN`)
 
-**Severity:** error  
+**Severity:** error
 **Detects:** High-voltage nets with generic unprotected names (`L`, `N`)
 or nets classified in both high-voltage **and** digital/clock domains
 (safety hazard).
+
+### 11. Output Contention (`NET_OUTPUT_CONTENTION`)
+
+**Severity:** error
+**Detects:** Two or more actively-driven outputs tied to the same signal net.
+Open-drain / tri-state buses should be modeled explicitly instead of as
+push-pull outputs.
+
+### 12. Floating Input (`NET_FLOATING_INPUT`)
+
+**Severity:** warning
+**Detects:** Input-only signal nets with no active driver and no pull-up or
+pull-down resistor path to power/ground.
+
+### 13. Power Conflict (`NET_POWER_CONFLICT`)
+
+**Severity:** error
+**Detects:** Multiple `power_source` / `power_output` pins connected to the
+same rail.
+
+### 14. Passive-Only Signal (`NET_PASSIVE_ONLY`)
+
+**Severity:** warning
+**Detects:** Signal nets that only connect passive pins and therefore have no
+observable driver or receiver context.
+
+### 15. Required Power/Ground Pin (`NET_UNPOWERED_DEVICE`)
+
+**Severity:** error
+**Detects:** Required device pins that are unconnected, or required power/ground
+pins connected to the wrong net class.
+
+### 16. Missing Decoupling (`NET_MISSING_DECOUPLING`)
+
+**Severity:** warning
+**Detects:** Devices marked with `requiresDecoupling: true` where a power input
+rail has no detected capacitor bridging that rail to a ground net.
+
+### 17. Voltage Mismatch (`NET_VOLTAGE_MISMATCH`)
+
+**Severity:** error
+**Detects:** Pin metadata expected voltage conflicting with the connected net
+voltage. Net voltage may be supplied directly or inferred from names like `3V3`
+and `5V`.
+
+## Semantic Pin Model
+
+Semantic ERC is opt-in. The semantic rules activate when nodes include
+`electricalType`/`expectedVoltage`, devices include `pins`, or a device sets
+`requiresDecoupling`.
+
+```typescript
+type PinElectricalType =
+  | 'input'
+  | 'output'
+  | 'bidirectional'
+  | 'passive'
+  | 'power_input'
+  | 'power_output'
+  | 'power_source'
+  | 'open_drain'
+  | 'tri_state'
+  | 'no_connect';
+```
+
+Pin metadata can define required pins, expected net class, expected voltage, and
+intentional no-connect allowance.
 
 ## Error Codes
 
@@ -127,6 +194,13 @@ or nets classified in both high-voltage **and** digital/clock domains
 | `NET_INCONSISTENT_CROSS_SHEET`  | error    | 8      |
 | `NET_NAMING_CONVENTION`         | warning  | 9      |
 | `NET_PROTECTED_DOMAIN`          | error    | 10     |
+| `NET_OUTPUT_CONTENTION`         | error    | 11     |
+| `NET_FLOATING_INPUT`            | warning  | 12     |
+| `NET_POWER_CONFLICT`            | error    | 13     |
+| `NET_PASSIVE_ONLY`              | warning  | 14     |
+| `NET_UNPOWERED_DEVICE`          | error    | 15     |
+| `NET_MISSING_DECOUPLING`        | warning  | 16     |
+| `NET_VOLTAGE_MISMATCH`          | error    | 17     |
 
 ## Usage
 
@@ -162,6 +236,72 @@ if (!result.valid) {
   }
 }
 ```
+
+### Semantic ERC validation
+
+```typescript
+import { validateNets } from './net-validation/index.js';
+
+const result = validateNets({
+  nets: [
+    {
+      id: '3v3',
+      name: '3V3',
+      type: 'power',
+      nodes: [
+        { deviceRef: 'U1', pin: 'VDD' },
+        { deviceRef: 'C1', pin: '1' },
+      ],
+    },
+    {
+      id: 'gnd',
+      name: 'GND',
+      type: 'ground',
+      nodes: [
+        { deviceRef: 'U1', pin: 'GND' },
+        { deviceRef: 'C1', pin: '2' },
+      ],
+    },
+    {
+      id: 'enable',
+      name: 'ENABLE',
+      type: 'signal',
+      nodes: [{ deviceRef: 'U1', pin: 'EN' }],
+    },
+  ],
+  devices: [
+    {
+      id: 'U1',
+      ref: 'U1',
+      category: 'microcontroller',
+      requiresDecoupling: true,
+      pins: [
+        {
+          pin: 'VDD',
+          electricalType: 'power_input',
+          required: true,
+          expectedNetType: 'power',
+          expectedVoltage: 3.3,
+        },
+        { pin: 'GND', electricalType: 'power_input', required: true, expectedNetType: 'ground' },
+        { pin: 'EN', electricalType: 'input' },
+      ],
+    },
+    {
+      id: 'C1',
+      ref: 'C1',
+      category: 'capacitor',
+      pins: [
+        { pin: '1', electricalType: 'passive' },
+        { pin: '2', electricalType: 'passive' },
+      ],
+    },
+  ],
+});
+```
+
+The MCP tool `easyeda_semantic_erc_validate` exposes the same model to agents.
+It is read-only and does not call the EasyEDA bridge.
 
 ### Validate or throw
 
@@ -218,7 +358,7 @@ Reserved names (`GND`, `VCC`, `VDD`, etc.) are exempt from convention checks.
 
 ### `validateNets(input: NetValidationInput): NetValidationResult`
 
-Run all 10 validation rules. Returns errors and warnings.
+Run all 17 validation rules. Returns errors and warnings.
 
 ### `validateNetsOrThrow(input: NetValidationInput): NetValidationResult`
 
@@ -236,7 +376,7 @@ Same as `validateNets` but throws the first error on failure.
 src/net-validation/
 ├── errors.ts       — Error codes, issue interface, factory helpers
 ├── schema.ts       — Input types, naming convention patterns, domain maps
-├── validation.ts   — 10 validation rules, entry points
+├── validation.ts   — 17 validation rules, entry points
 ├── fixtures.ts     — Sample net data for tests
 └── index.ts        — Barrel exports
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -58,6 +58,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_schematic_place_component`     | `core`  | `medium` | Place a library component/device on the active schematic sheet.                                                                                                                                                                                                                                               |
 | `easyeda_schematic_search_device`       | `core`  | `low`    | Search for schematic symbols/devices in the EasyEDA library by keywords.                                                                                                                                                                                                                                      |
 | `easyeda_schematic_validate_netlist`    | `core`  | `low`    | Validate the EasyEDA Pro schematic netlist for connectivity issues. Reports net names, connected component references and pins, floating pins, graphical wires without netlist connectivity, and mismatches between visual wires and actual SCH_Net/SCH_Netlist entries. This is a read-only diagnostic tool. |
+| `easyeda_semantic_erc_validate`         | `core`  | `medium` | Run semantic electrical-rule validation over a netlist with pin electrical types to detect output contention, floating inputs, power conflicts, missing power pins, missing decoupling, and voltage-domain mismatches.                                                                                        |
 | `easyeda_wire_probe`                    | `dev`   | `low`    | Inspect live schematic wire objects, including line coordinates, net names, methods, and state getter values, to validate EasyEDA runtime mappings.                                                                                                                                                           |
 
 ---
@@ -1549,6 +1550,39 @@ Returns a JSON object matching the schema:
   warnings: any;
   not_available: any;
   error: any;
+}
+```
+
+---
+
+## `easyeda_semantic_erc_validate`
+
+**Profile:** `core` | **Risk Level:** `medium`
+
+> Run semantic electrical-rule validation over a netlist with pin electrical types to detect output contention, floating inputs, power conflicts, missing power pins, missing decoupling, and voltage-domain mismatches.
+
+### Input Parameters
+
+| Parameter    | Type  | Required | Description |
+| ------------ | ----- | -------- | ----------- |
+| `projectId`  | `any` | No       |             |
+| `nets`       | `any` | Yes      |             |
+| `devices`    | `any` | No       |             |
+| `interfaces` | `any` | No       |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  project_id: any;
+  passed: any;
+  error_count: any;
+  warning_count: any;
+  total_issues: any;
+  errors: any;
+  warnings: any;
 }
 ```
 

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -14,14 +14,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Core',
     description:
       'High-confidence tools: diagnostics, EasyEDA API inventory, schematic, BOM, DRC/ERC, board layers/stackup, Gerber export',
-    approxToolCount: '38',
+    approxToolCount: '39',
     isDefault: true,
   },
   pro: {
     name: 'pro',
     label: 'Pro',
     description: 'Adds pick-and-place, PDF, netlist export for manufacturing workflows',
-    approxToolCount: '41',
+    approxToolCount: '42',
     isDefault: false,
   },
   full: {
@@ -29,7 +29,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls for full runtime control without raw JavaScript execution',
-    approxToolCount: '48',
+    approxToolCount: '49',
     isDefault: false,
   },
   dev: {
@@ -37,14 +37,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '52',
+    approxToolCount: '53',
     isDefault: false,
   },
   experimental: {
     name: 'experimental',
     label: 'Experimental',
     description: 'MCP Apps, Tasks, simulation, autorouter, AI action plans',
-    approxToolCount: '50',
+    approxToolCount: '51',
     isDefault: false,
   },
 };

--- a/src/net-validation/errors.ts
+++ b/src/net-validation/errors.ts
@@ -43,6 +43,23 @@ export const NetValidationCode = {
   /** Net associated with AC/high-voltage lacks protective naming. */
   NetProtectedDomain: 'NET_PROTECTED_DOMAIN',
 
+  // ── Semantic ERC ─────────────────────────────────────────────────────
+
+  /** Multiple actively-driven outputs or power sources are tied together. */
+  NetOutputContention: 'NET_OUTPUT_CONTENTION',
+  /** A signal net has inputs but no driver, pull, or passive source. */
+  NetFloatingInput: 'NET_FLOATING_INPUT',
+  /** A power rail has conflicting power sources/regulators. */
+  NetPowerConflict: 'NET_POWER_CONFLICT',
+  /** A signal net only connects passive pins and cannot be driven. */
+  NetPassiveOnly: 'NET_PASSIVE_ONLY',
+  /** A required power/ground pin is missing or connected to the wrong class of net. */
+  NetUnpoweredDevice: 'NET_UNPOWERED_DEVICE',
+  /** A device marked as requiring decoupling has no local capacitor across rail and ground. */
+  NetMissingDecoupling: 'NET_MISSING_DECOUPLING',
+  /** A pin expected voltage is incompatible with the connected net voltage. */
+  NetVoltageMismatch: 'NET_VOLTAGE_MISMATCH',
+
   // ── General ──────────────────────────────────────────────────────────
 
   /** Validation could not be completed due to an internal error. */

--- a/src/net-validation/index.ts
+++ b/src/net-validation/index.ts
@@ -21,9 +21,12 @@ export {
 } from './schema.js';
 export type {
   NetValidationEntry,
+  NetValidationNode,
   DeviceValidationEntry,
   InterfaceValidationEntry,
   NetValidationInput,
+  PinElectricalType,
+  PinValidationMetadata,
 } from './schema.js';
 
 export { validateNets, validateNetsOrThrow } from './validation.js';

--- a/src/net-validation/schema.ts
+++ b/src/net-validation/schema.ts
@@ -156,6 +156,48 @@ export const NET_TYPE_EXPECTED_DOMAIN: Record<string, NetDomain[]> = {
  * so that validation can operate on net data from any source
  * (CircuitIR, EasyEDA bridge, hand-authored test data).
  */
+export type PinElectricalType =
+  | 'input'
+  | 'output'
+  | 'bidirectional'
+  | 'passive'
+  | 'power_input'
+  | 'power_output'
+  | 'power_source'
+  | 'open_drain'
+  | 'tri_state'
+  | 'no_connect';
+
+/** How a pin should be interpreted by semantic ERC. */
+export interface PinValidationMetadata {
+  /** Pin number or name as it appears in net nodes. */
+  pin: string;
+  /** Human-readable pin name, e.g. VDD, GND, EN, OUT. */
+  name?: string;
+  /** Electrical type used for compatibility checks. */
+  electricalType: PinElectricalType;
+  /** Whether this pin must be connected for the device to be valid. */
+  required?: boolean;
+  /** Expected net classification for required power/ground/signal pins. */
+  expectedNetType?: 'power' | 'signal' | 'ground';
+  /** Expected nominal voltage for voltage-domain checks. */
+  expectedVoltage?: number;
+  /** Whether this pin intentionally allows no-connect. */
+  noConnectAllowed?: boolean;
+}
+
+/** A connected device pin, optionally carrying semantic pin metadata. */
+export interface NetValidationNode {
+  deviceRef: string;
+  pin: string;
+  /** Optional per-node electrical type; device pin metadata takes precedence when both exist. */
+  electricalType?: PinElectricalType;
+  /** Optional human-readable pin name. */
+  pinName?: string;
+  /** Optional expected nominal voltage for this pin. */
+  expectedVoltage?: number;
+}
+
 export interface NetValidationEntry {
   /** Unique net identifier. */
   id: string;
@@ -163,8 +205,10 @@ export interface NetValidationEntry {
   name: string;
   /** Net type classification. */
   type: 'power' | 'signal' | 'ground';
+  /** Optional nominal voltage for voltage-domain checks. */
+  voltage?: number;
   /** Connected device pins, may be empty for floating nets. */
-  nodes: Array<{ deviceRef: string; pin: string }>;
+  nodes: NetValidationNode[];
 }
 
 /**
@@ -177,6 +221,10 @@ export interface DeviceValidationEntry {
   ref: string;
   /** Functional category for determining required pins. */
   category?: string;
+  /** Semantic pin metadata used by ERC rules. */
+  pins?: PinValidationMetadata[];
+  /** Require at least one local capacitor between each power input rail and ground. */
+  requiresDecoupling?: boolean;
 }
 
 /**

--- a/src/net-validation/validation.ts
+++ b/src/net-validation/validation.ts
@@ -1,7 +1,7 @@
 /**
  * Net validation — wire-name and topology validation rules.
  *
- * Implements 10 validation rules that operate on {@link NetValidationInput}
+ * Implements 17 validation rules that operate on {@link NetValidationInput}
  * and produce structured {@link NetValidationIssue}s.
  *
  * Rules:
@@ -28,8 +28,207 @@ import {
   RESERVED_NET_NAMES,
   NetDomain,
 } from './schema.js';
-import type { InterfaceValidationEntry, NetValidationInput, NetValidationEntry } from './schema.js';
+import type {
+  DeviceValidationEntry,
+  InterfaceValidationEntry,
+  NetValidationInput,
+  NetValidationEntry,
+  NetValidationNode,
+  PinElectricalType,
+  PinValidationMetadata,
+} from './schema.js';
 import type { NetValidationIssue } from './errors.js';
+
+// ── Semantic ERC helpers ───────────────────────────────────────────────────
+
+type ResolvedSemanticNode = NetValidationNode & {
+  device?: DeviceValidationEntry;
+  pinMetadata?: PinValidationMetadata;
+  electricalType?: PinElectricalType;
+  displayRef: string;
+};
+
+function normalizeKey(value: string): string {
+  return value.trim().toUpperCase();
+}
+
+function buildDeviceLookup(input: NetValidationInput): Map<string, DeviceValidationEntry> {
+  const devices = new Map<string, DeviceValidationEntry>();
+  for (const device of input.devices ?? []) {
+    devices.set(normalizeKey(device.id), device);
+    devices.set(normalizeKey(device.ref), device);
+  }
+  return devices;
+}
+
+function resolvePinMetadata(
+  device: DeviceValidationEntry | undefined,
+  node: NetValidationNode,
+): PinValidationMetadata | undefined {
+  if (!device?.pins) return undefined;
+  const pinKey = normalizeKey(node.pin);
+  return device.pins.find(
+    (pin) => normalizeKey(pin.pin) === pinKey || normalizeKey(pin.name ?? '') === pinKey,
+  );
+}
+
+function resolveSemanticNodes(
+  input: NetValidationInput,
+  net: NetValidationEntry,
+): ResolvedSemanticNode[] {
+  const devices = buildDeviceLookup(input);
+  return net.nodes.map((node) => {
+    const device = devices.get(normalizeKey(node.deviceRef));
+    const pinMetadata = resolvePinMetadata(device, node);
+    return {
+      ...node,
+      device,
+      pinMetadata,
+      electricalType: pinMetadata?.electricalType ?? node.electricalType,
+      expectedVoltage: pinMetadata?.expectedVoltage ?? node.expectedVoltage,
+      pinName: pinMetadata?.name ?? node.pinName,
+      displayRef: device?.ref ?? node.deviceRef,
+    };
+  });
+}
+
+function hasSemanticMetadata(input: NetValidationInput): boolean {
+  return (
+    input.nets.some(
+      (net) =>
+        net.voltage !== undefined ||
+        net.nodes.some(
+          (node) => node.electricalType !== undefined || node.expectedVoltage !== undefined,
+        ),
+    ) ||
+    (input.devices ?? []).some((device) =>
+      Boolean(device.pins?.length || device.requiresDecoupling),
+    )
+  );
+}
+
+function isActiveDriver(type: PinElectricalType | undefined): boolean {
+  return (
+    type === 'output' ||
+    type === 'bidirectional' ||
+    type === 'power_output' ||
+    type === 'power_source'
+  );
+}
+
+function isPowerSource(type: PinElectricalType | undefined): boolean {
+  return type === 'power_source' || type === 'power_output';
+}
+
+function isPassiveLike(type: PinElectricalType | undefined): boolean {
+  return type === 'passive';
+}
+
+function isNoConnect(type: PinElectricalType | undefined): boolean {
+  return type === 'no_connect';
+}
+
+function inferVoltageFromNetName(name: string): number | undefined {
+  const upper = name.toUpperCase();
+  const match = upper.match(/(^|[^0-9])([0-9]+)V([0-9]*)/);
+  if (match) {
+    const whole = Number(match[2]);
+    const fractional = match[3] ? Number(`0.${match[3]}`) : 0;
+    return whole + fractional;
+  }
+  if (/^VCC$|^VDD$/.test(upper)) return undefined;
+  if (/^GND$|GND\b|^VSS$/.test(upper)) return 0;
+  return undefined;
+}
+
+function netVoltage(net: NetValidationEntry): number | undefined {
+  return net.voltage ?? inferVoltageFromNetName(net.name);
+}
+
+function deviceHasOtherPinOnNetType(
+  input: NetValidationInput,
+  deviceRef: string,
+  excludedPin: string,
+  expectedType: 'power' | 'ground',
+): boolean {
+  const wantedRef = normalizeKey(deviceRef);
+  const excluded = normalizeKey(excludedPin);
+  return input.nets.some(
+    (net) =>
+      net.type === expectedType &&
+      net.nodes.some(
+        (node) => normalizeKey(node.deviceRef) === wantedRef && normalizeKey(node.pin) !== excluded,
+      ),
+  );
+}
+
+function passivePullExists(input: NetValidationInput, net: NetValidationEntry): boolean {
+  const semanticNodes = resolveSemanticNodes(input, net);
+  return semanticNodes.some((node) => {
+    if (!isPassiveLike(node.electricalType)) return false;
+    return (
+      deviceHasOtherPinOnNetType(input, node.deviceRef, node.pin, 'power') ||
+      deviceHasOtherPinOnNetType(input, node.deviceRef, node.pin, 'ground')
+    );
+  });
+}
+
+function connectedNetsByDevicePin(input: NetValidationInput): Map<string, NetValidationEntry[]> {
+  const map = new Map<string, NetValidationEntry[]>();
+  for (const net of input.nets) {
+    for (const node of net.nodes) {
+      const key = `${normalizeKey(node.deviceRef)}:${normalizeKey(node.pin)}`;
+      const existing = map.get(key) ?? [];
+      existing.push(net);
+      map.set(key, existing);
+    }
+  }
+  return map;
+}
+
+function connectedNetsForPin(
+  pinToNets: Map<string, NetValidationEntry[]>,
+  device: DeviceValidationEntry,
+  pin: string,
+): NetValidationEntry[] {
+  const matches = [
+    ...(pinToNets.get(`${normalizeKey(device.id)}:${normalizeKey(pin)}`) ?? []),
+    ...(pinToNets.get(`${normalizeKey(device.ref)}:${normalizeKey(pin)}`) ?? []),
+  ];
+  return [...new Map(matches.map((net) => [net.id, net])).values()];
+}
+
+function capacitorRefs(input: NetValidationInput): Set<string> {
+  const refs = new Set<string>();
+  for (const device of input.devices ?? []) {
+    const category = (device.category ?? '').toLowerCase();
+    if (
+      category === 'capacitor' ||
+      category === 'decoupling' ||
+      /^C[0-9A-Z_-]*/i.test(device.ref)
+    ) {
+      refs.add(normalizeKey(device.id));
+      refs.add(normalizeKey(device.ref));
+    }
+  }
+  return refs;
+}
+
+function hasDecouplingCapacitor(
+  input: NetValidationInput,
+  powerNet: NetValidationEntry,
+  groundNets: NetValidationEntry[],
+): boolean {
+  const capacitors = capacitorRefs(input);
+  if (capacitors.size === 0) return false;
+  const powerRefs = new Set(
+    powerNet.nodes.map((node) => normalizeKey(node.deviceRef)).filter((ref) => capacitors.has(ref)),
+  );
+  if (powerRefs.size === 0) return false;
+  return groundNets.some((groundNet) =>
+    groundNet.nodes.some((node) => powerRefs.has(normalizeKey(node.deviceRef))),
+  );
+}
 
 // ── Rule: floating nets ────────────────────────────────────────────────────
 
@@ -474,6 +673,313 @@ function checkProtectedDomain(input: NetValidationInput): NetValidationIssue[] {
   return issues;
 }
 
+// ── Semantic ERC: output contention ────────────────────────────────────────
+
+function checkOutputContention(input: NetValidationInput): NetValidationIssue[] {
+  if (!hasSemanticMetadata(input)) return [];
+  const issues: NetValidationIssue[] = [];
+
+  for (const net of input.nets) {
+    const semanticNodes = resolveSemanticNodes(input, net).filter(
+      (node) => !isNoConnect(node.electricalType),
+    );
+    const activeDrivers = semanticNodes.filter((node) => isActiveDriver(node.electricalType));
+
+    if (net.type === 'signal' && activeDrivers.length > 1) {
+      issues.push(
+        netError(
+          NetValidationCode.NetOutputContention,
+          `Signal net "${net.name}" has ${activeDrivers.length} active drivers: ${activeDrivers.map((node) => `${node.displayRef}:${node.pinName ?? node.pin}`).join(', ')}`,
+          {
+            netName: net.name,
+            componentRef: activeDrivers[0]?.displayRef,
+            pin: activeDrivers[0]?.pin,
+            remediationHint:
+              'Do not tie push-pull outputs together. Add arbitration, tri-state control, open-drain wiring with pull-up, or separate the nets.',
+            details: {
+              drivers: activeDrivers.map((node) => ({
+                componentRef: node.displayRef,
+                pin: node.pin,
+                pinName: node.pinName,
+                electricalType: node.electricalType,
+              })),
+            },
+          },
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
+// ── Semantic ERC: floating inputs ──────────────────────────────────────────
+
+function checkFloatingInputs(input: NetValidationInput): NetValidationIssue[] {
+  if (!hasSemanticMetadata(input)) return [];
+  const issues: NetValidationIssue[] = [];
+
+  for (const net of input.nets) {
+    if (net.type !== 'signal' || net.nodes.length === 0) continue;
+    const semanticNodes = resolveSemanticNodes(input, net).filter(
+      (node) => !isNoConnect(node.electricalType),
+    );
+    const inputNodes = semanticNodes.filter((node) => node.electricalType === 'input');
+    if (inputNodes.length === 0) continue;
+
+    const hasDriver = semanticNodes.some((node) => isActiveDriver(node.electricalType));
+    const hasPull = passivePullExists(input, net);
+    const hasOpenDrainBus =
+      semanticNodes.some((node) => node.electricalType === 'open_drain') && hasPull;
+
+    if (!hasDriver && !hasPull && !hasOpenDrainBus) {
+      issues.push(
+        netWarning(
+          NetValidationCode.NetFloatingInput,
+          `Signal net "${net.name}" connects input pins but has no active driver or pull resistor`,
+          {
+            netName: net.name,
+            componentRef: inputNodes[0]?.displayRef,
+            pin: inputNodes[0]?.pin,
+            remediationHint:
+              'Connect this input to a valid driver, add a pull-up/pull-down resistor, or explicitly mark it as no-connect if allowed.',
+            details: {
+              inputs: inputNodes.map((node) => ({
+                componentRef: node.displayRef,
+                pin: node.pin,
+                pinName: node.pinName,
+              })),
+            },
+          },
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
+// ── Semantic ERC: power rail conflicts ─────────────────────────────────────
+
+function checkPowerConflicts(input: NetValidationInput): NetValidationIssue[] {
+  if (!hasSemanticMetadata(input)) return [];
+  const issues: NetValidationIssue[] = [];
+
+  for (const net of input.nets) {
+    if (net.type !== 'power') continue;
+    const powerSources = resolveSemanticNodes(input, net).filter((node) =>
+      isPowerSource(node.electricalType),
+    );
+    if (powerSources.length > 1) {
+      issues.push(
+        netError(
+          NetValidationCode.NetPowerConflict,
+          `Power net "${net.name}" has ${powerSources.length} power sources tied together: ${powerSources.map((node) => `${node.displayRef}:${node.pinName ?? node.pin}`).join(', ')}`,
+          {
+            netName: net.name,
+            componentRef: powerSources[0]?.displayRef,
+            pin: powerSources[0]?.pin,
+            remediationHint:
+              'Verify that only one regulator/source drives this rail, or add ideal-diode/load-share circuitry before tying sources together.',
+            details: {
+              powerSources: powerSources.map((node) => ({
+                componentRef: node.displayRef,
+                pin: node.pin,
+                pinName: node.pinName,
+                electricalType: node.electricalType,
+              })),
+            },
+          },
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
+// ── Semantic ERC: passive-only signal nets ─────────────────────────────────
+
+function checkPassiveOnlySignalNets(input: NetValidationInput): NetValidationIssue[] {
+  if (!hasSemanticMetadata(input)) return [];
+  const issues: NetValidationIssue[] = [];
+
+  for (const net of input.nets) {
+    if (net.type !== 'signal' || net.nodes.length < 2) continue;
+    const semanticNodes = resolveSemanticNodes(input, net).filter(
+      (node) => node.electricalType !== undefined,
+    );
+    if (semanticNodes.length === 0) continue;
+    if (semanticNodes.every((node) => isPassiveLike(node.electricalType))) {
+      issues.push(
+        netWarning(
+          NetValidationCode.NetPassiveOnly,
+          `Signal net "${net.name}" only connects passive pins and has no active source or input`,
+          {
+            netName: net.name,
+            remediationHint:
+              'Confirm this is an intentional passive network node; otherwise connect it to an input/output pin or power/ground as appropriate.',
+            details: {
+              passiveNodes: semanticNodes.map((node) => ({
+                componentRef: node.displayRef,
+                pin: node.pin,
+              })),
+            },
+          },
+        ),
+      );
+    }
+  }
+
+  return issues;
+}
+
+// ── Semantic ERC: required device power/ground pins ────────────────────────
+
+function checkRequiredPowerPins(input: NetValidationInput): NetValidationIssue[] {
+  if (!hasSemanticMetadata(input)) return [];
+  const issues: NetValidationIssue[] = [];
+  const pinToNets = connectedNetsByDevicePin(input);
+
+  for (const device of input.devices ?? []) {
+    for (const pin of device.pins ?? []) {
+      if (!pin.required || pin.noConnectAllowed) continue;
+      const connectedNets = connectedNetsForPin(pinToNets, device, pin.pin);
+
+      if (connectedNets.length === 0) {
+        issues.push(
+          netError(
+            NetValidationCode.NetUnpoweredDevice,
+            `Required pin ${device.ref}:${pin.name ?? pin.pin} is not connected`,
+            {
+              componentRef: device.ref,
+              pin: pin.pin,
+              remediationHint:
+                pin.expectedNetType === 'power'
+                  ? 'Connect this required supply pin to the correct power rail.'
+                  : pin.expectedNetType === 'ground'
+                    ? 'Connect this required ground/reference pin to the correct ground net.'
+                    : 'Connect this required pin to the intended net or mark it noConnectAllowed when intentional.',
+              details: { expectedNetType: pin.expectedNetType, electricalType: pin.electricalType },
+            },
+          ),
+        );
+        continue;
+      }
+
+      if (pin.expectedNetType) {
+        for (const net of connectedNets) {
+          if (net.type !== pin.expectedNetType) {
+            issues.push(
+              netError(
+                NetValidationCode.NetUnpoweredDevice,
+                `Pin ${device.ref}:${pin.name ?? pin.pin} expects a ${pin.expectedNetType} net but is connected to ${net.type} net "${net.name}"`,
+                {
+                  netName: net.name,
+                  componentRef: device.ref,
+                  pin: pin.pin,
+                  remediationHint: `Move ${device.ref}:${pin.name ?? pin.pin} to a ${pin.expectedNetType} net or correct the pin metadata if the symbol is wrong.`,
+                  details: {
+                    expectedNetType: pin.expectedNetType,
+                    actualNetType: net.type,
+                    electricalType: pin.electricalType,
+                  },
+                },
+              ),
+            );
+          }
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+// ── Semantic ERC: decoupling ───────────────────────────────────────────────
+
+function checkMissingDecoupling(input: NetValidationInput): NetValidationIssue[] {
+  if (!hasSemanticMetadata(input)) return [];
+  const issues: NetValidationIssue[] = [];
+  const pinToNets = connectedNetsByDevicePin(input);
+  const groundNets = input.nets.filter((net) => net.type === 'ground');
+
+  for (const device of input.devices ?? []) {
+    if (!device.requiresDecoupling) continue;
+    const powerPins = (device.pins ?? []).filter(
+      (pin) =>
+        pin.expectedNetType === 'power' ||
+        (pin.electricalType === 'power_input' && pin.expectedNetType !== 'ground'),
+    );
+
+    for (const pin of powerPins) {
+      const connectedPowerNets = connectedNetsForPin(pinToNets, device, pin.pin).filter(
+        (net) => net.type === 'power',
+      );
+
+      for (const powerNet of connectedPowerNets) {
+        if (!hasDecouplingCapacitor(input, powerNet, groundNets)) {
+          issues.push(
+            netWarning(
+              NetValidationCode.NetMissingDecoupling,
+              `Device ${device.ref} power pin ${pin.name ?? pin.pin} on net "${powerNet.name}" has no detected local decoupling capacitor`,
+              {
+                netName: powerNet.name,
+                componentRef: device.ref,
+                pin: pin.pin,
+                remediationHint:
+                  'Add a local decoupling capacitor from this rail to ground near the IC/regulator supply pin, or mark the device as not requiring decoupling if intentional.',
+                details: { powerNet: powerNet.name, groundNets: groundNets.map((net) => net.name) },
+              },
+            ),
+          );
+        }
+      }
+    }
+  }
+
+  return issues;
+}
+
+// ── Semantic ERC: voltage mismatch ─────────────────────────────────────────
+
+function checkVoltageMismatches(input: NetValidationInput): NetValidationIssue[] {
+  if (!hasSemanticMetadata(input)) return [];
+  const issues: NetValidationIssue[] = [];
+
+  for (const net of input.nets) {
+    const voltage = netVoltage(net);
+    if (voltage === undefined) continue;
+
+    for (const node of resolveSemanticNodes(input, net)) {
+      const expectedVoltage = node.expectedVoltage;
+      if (expectedVoltage === undefined) continue;
+      if (Math.abs(expectedVoltage - voltage) > 0.15) {
+        issues.push(
+          netError(
+            NetValidationCode.NetVoltageMismatch,
+            `Pin ${node.displayRef}:${node.pinName ?? node.pin} expects ${expectedVoltage}V but net "${net.name}" is ${voltage}V`,
+            {
+              netName: net.name,
+              componentRef: node.displayRef,
+              pin: node.pin,
+              remediationHint:
+                'Connect this pin to the correct voltage domain or insert level shifting/regulation if the voltage mismatch is intentional.',
+              details: {
+                expectedVoltage,
+                actualVoltage: voltage,
+                electricalType: node.electricalType,
+              },
+            },
+          ),
+        );
+      }
+    }
+  }
+
+  return issues;
+}
+
 // ── Combine helper ─────────────────────────────────────────────────────────
 
 type RuleFn = (input: NetValidationInput) => NetValidationIssue[];
@@ -489,6 +995,13 @@ const RULES: RuleFn[] = [
   checkCrossSheetConsistency,
   checkNamingConventions,
   checkProtectedDomain,
+  checkOutputContention,
+  checkFloatingInputs,
+  checkPowerConflicts,
+  checkPassiveOnlySignalNets,
+  checkRequiredPowerPins,
+  checkMissingDecoupling,
+  checkVoltageMismatches,
 ];
 
 // ── Main entry point ───────────────────────────────────────────────────────
@@ -507,6 +1020,13 @@ const RULES: RuleFn[] = [
  *  8. Cross-sheet consistency   — error if same-name interfaces have different pinouts
  *  9. Naming convention         — warning if power/ground nets have non-standard names
  * 10. Protected domain          — error if high-voltage net lacks protective naming
+ * 11. Output contention        — error if multiple active outputs drive one signal
+ * 12. Floating input           — warning if input net has no driver or pull
+ * 13. Power conflict           — error if multiple sources drive one rail
+ * 14. Passive-only signal      — warning if a signal net has only passive nodes
+ * 15. Required power pins      — error if required pins are missing/miswired
+ * 16. Decoupling expectation   — warning if required local decoupling is absent
+ * 17. Voltage mismatch         — error if expected pin voltage conflicts with net voltage
  */
 export function validateNets(input: NetValidationInput): NetValidationResult {
   const errors: NetValidationIssue[] = [];

--- a/src/tools/L1_drc_erc.ts
+++ b/src/tools/L1_drc_erc.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 import { type ToolDefinition, type ToolContext } from './types.js';
 import { type EnvConfig } from '../config/env.js';
+import { validateNets } from '../net-validation/validation.js';
 
 function registerDrcErcTools(
   registry: { register: (def: ToolDefinition) => void },
@@ -200,6 +201,197 @@ function registerDrcErcTools(
           error: err instanceof Error ? err.message : String(err),
         };
       }
+    },
+  });
+
+  const semanticPinSchema = z.object({
+    pin: z.string(),
+    name: z.string().optional(),
+    electricalType: z.enum([
+      'input',
+      'output',
+      'bidirectional',
+      'passive',
+      'power_input',
+      'power_output',
+      'power_source',
+      'open_drain',
+      'tri_state',
+      'no_connect',
+    ]),
+    required: z.boolean().optional(),
+    expectedNetType: z.enum(['power', 'signal', 'ground']).optional(),
+    expectedVoltage: z.number().optional(),
+    noConnectAllowed: z.boolean().optional(),
+  });
+
+  const semanticNodeSchema = z.object({
+    deviceRef: z.string(),
+    pin: z.string(),
+    electricalType: semanticPinSchema.shape.electricalType.optional(),
+    pinName: z.string().optional(),
+    expectedVoltage: z.number().optional(),
+  });
+
+  const semanticNetSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    type: z.enum(['power', 'signal', 'ground']),
+    voltage: z.number().optional(),
+    nodes: z.array(semanticNodeSchema),
+  });
+
+  const semanticDeviceSchema = z.object({
+    id: z.string(),
+    ref: z.string(),
+    category: z.string().optional(),
+    pins: z.array(semanticPinSchema).optional(),
+    requiresDecoupling: z.boolean().optional(),
+  });
+
+  const semanticInterfaceSchema = z.object({
+    id: z.string(),
+    name: z.string(),
+    pinout: z.array(
+      z.object({
+        pin: z.string(),
+        signal: z.string(),
+        type: z.string().optional(),
+      }),
+    ),
+  });
+
+  const semanticIssueSchema = z.object({
+    code: z.string(),
+    message: z.string(),
+    severity: z.enum(['error', 'warning']),
+    path: z.string().optional(),
+    net_name: z.string().optional(),
+    component_ref: z.string().optional(),
+    pin: z.string().optional(),
+    remediation_hint: z.string(),
+    details: z.record(z.string(), z.unknown()).optional(),
+  });
+
+  registry.register({
+    name: 'easyeda_semantic_erc_validate',
+    title: 'Run semantic ERC validation',
+    description:
+      'Run semantic electrical-rule validation over a netlist with pin electrical types to detect output contention, floating inputs, power conflicts, missing power pins, missing decoupling, and voltage-domain mismatches.',
+    profile: 'core',
+    evidence: ['official-docs'],
+    risk: 'medium',
+    confirmWrite: false,
+    group: 'drc-erc',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    inputSchema: z.object({
+      projectId: z.string().optional(),
+      nets: z.array(semanticNetSchema),
+      devices: z.array(semanticDeviceSchema).optional(),
+      interfaces: z.array(semanticInterfaceSchema).optional(),
+    }),
+    outputSchema: z.object({
+      project_id: z.string(),
+      passed: z.boolean(),
+      error_count: z.number().int().nonnegative(),
+      warning_count: z.number().int().nonnegative(),
+      total_issues: z.number().int().nonnegative(),
+      errors: z.array(semanticIssueSchema),
+      warnings: z.array(semanticIssueSchema),
+    }),
+    handler: async (_ctx: ToolContext, params: unknown) => {
+      const parsed = params as {
+        projectId?: string;
+        nets: Array<{
+          id: string;
+          name: string;
+          type: 'power' | 'signal' | 'ground';
+          voltage?: number;
+          nodes: Array<{
+            deviceRef: string;
+            pin: string;
+            electricalType?:
+              | 'input'
+              | 'output'
+              | 'bidirectional'
+              | 'passive'
+              | 'power_input'
+              | 'power_output'
+              | 'power_source'
+              | 'open_drain'
+              | 'tri_state'
+              | 'no_connect';
+            pinName?: string;
+            expectedVoltage?: number;
+          }>;
+        }>;
+        devices?: Array<{
+          id: string;
+          ref: string;
+          category?: string;
+          pins?: Array<{
+            pin: string;
+            name?: string;
+            electricalType:
+              | 'input'
+              | 'output'
+              | 'bidirectional'
+              | 'passive'
+              | 'power_input'
+              | 'power_output'
+              | 'power_source'
+              | 'open_drain'
+              | 'tri_state'
+              | 'no_connect';
+            required?: boolean;
+            expectedNetType?: 'power' | 'signal' | 'ground';
+            expectedVoltage?: number;
+            noConnectAllowed?: boolean;
+          }>;
+          requiresDecoupling?: boolean;
+        }>;
+        interfaces?: Array<{
+          id: string;
+          name: string;
+          pinout: Array<{ pin: string; signal: string; type?: string }>;
+        }>;
+      };
+
+      const result = validateNets({
+        nets: parsed.nets,
+        devices: parsed.devices,
+        interfaces: parsed.interfaces,
+      });
+
+      const mapIssue = (issue: (typeof result.errors)[number]) => ({
+        code: issue.code,
+        message: issue.message,
+        severity: issue.severity,
+        path: issue.path,
+        net_name: issue.netName,
+        component_ref: issue.componentRef,
+        pin: issue.pin,
+        remediation_hint: issue.remediationHint,
+        details: issue.details,
+      });
+
+      const errors = result.errors.map(mapIssue);
+      const warnings = result.warnings.map(mapIssue);
+
+      return {
+        project_id: parsed.projectId ?? '',
+        passed: result.valid,
+        error_count: errors.length,
+        warning_count: warnings.length,
+        total_issues: errors.length + warnings.length,
+        errors,
+        warnings,
+      };
     },
   });
 

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -39,14 +39,14 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for core', () => {
-    expect(PROFILE_DEFINITIONS.core.approxToolCount).toBe('38');
+    expect(PROFILE_DEFINITIONS.core.approxToolCount).toBe('39');
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('41');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('42');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('48');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('49');
   });
 });

--- a/tests/unit/net-validation/net-validation.test.ts
+++ b/tests/unit/net-validation/net-validation.test.ts
@@ -240,3 +240,378 @@ describe('edge cases', () => {
     expect(result.errors.length).toBeGreaterThan(0);
   });
 });
+
+// ── Semantic ERC ───────────────────────────────────────────────────────────
+
+describe('semantic ERC', () => {
+  it('detects active output contention on a signal net', () => {
+    const result = validateNets({
+      nets: [
+        { id: 'pwr', name: '3V3', type: 'power', nodes: [{ deviceRef: 'U1', pin: 'VDD' }] },
+        { id: 'gnd', name: 'GND', type: 'ground', nodes: [{ deviceRef: 'U1', pin: 'GND' }] },
+        {
+          id: 'sig',
+          name: 'BUS_DRV',
+          type: 'signal',
+          nodes: [
+            { deviceRef: 'U1', pin: 'OUT' },
+            { deviceRef: 'U2', pin: 'OUT' },
+          ],
+        },
+      ],
+      devices: [
+        { id: 'U1', ref: 'U1', pins: [{ pin: 'OUT', electricalType: 'output' }] },
+        { id: 'U2', ref: 'U2', pins: [{ pin: 'OUT', electricalType: 'output' }] },
+      ],
+    });
+
+    const issues = result.errors.filter((e) => e.code === NetValidationCode.NetOutputContention);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].severity).toBe('error');
+    expect(issues[0].netName).toBe('BUS_DRV');
+    expect(issues[0].remediationHint).toContain('push-pull outputs');
+  });
+
+  it('warns on floating input nets that have no driver or pull resistor', () => {
+    const result = validateNets({
+      nets: [
+        { id: 'pwr', name: '3V3', type: 'power', nodes: [{ deviceRef: 'U1', pin: 'VDD' }] },
+        { id: 'gnd', name: 'GND', type: 'ground', nodes: [{ deviceRef: 'U1', pin: 'GND' }] },
+        { id: 'sig', name: 'ENABLE', type: 'signal', nodes: [{ deviceRef: 'U1', pin: 'EN' }] },
+      ],
+      devices: [
+        {
+          id: 'U1',
+          ref: 'U1',
+          pins: [
+            { pin: 'VDD', electricalType: 'power_input', expectedNetType: 'power' },
+            { pin: 'GND', electricalType: 'power_input', expectedNetType: 'ground' },
+            { pin: 'EN', electricalType: 'input' },
+          ],
+        },
+      ],
+    });
+
+    const issues = result.warnings.filter((e) => e.code === NetValidationCode.NetFloatingInput);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].componentRef).toBe('U1');
+    expect(issues[0].pin).toBe('EN');
+  });
+
+  it('does not warn for an input held by a pull-up resistor', () => {
+    const result = validateNets({
+      nets: [
+        {
+          id: 'pwr',
+          name: '3V3',
+          type: 'power',
+          nodes: [
+            { deviceRef: 'U1', pin: 'VDD' },
+            { deviceRef: 'R1', pin: '1' },
+          ],
+        },
+        { id: 'gnd', name: 'GND', type: 'ground', nodes: [{ deviceRef: 'U1', pin: 'GND' }] },
+        {
+          id: 'sig',
+          name: 'I2C_SDA',
+          type: 'signal',
+          nodes: [
+            { deviceRef: 'U1', pin: 'SDA' },
+            { deviceRef: 'R1', pin: '2' },
+          ],
+        },
+      ],
+      devices: [
+        {
+          id: 'U1',
+          ref: 'U1',
+          pins: [
+            { pin: 'VDD', electricalType: 'power_input', expectedNetType: 'power' },
+            { pin: 'GND', electricalType: 'power_input', expectedNetType: 'ground' },
+            { pin: 'SDA', electricalType: 'input' },
+          ],
+        },
+        {
+          id: 'R1',
+          ref: 'R1',
+          category: 'resistor',
+          pins: [
+            { pin: '1', electricalType: 'passive' },
+            { pin: '2', electricalType: 'passive' },
+          ],
+        },
+      ],
+    });
+
+    expect(
+      [...result.errors, ...result.warnings].filter(
+        (e) => e.code === NetValidationCode.NetFloatingInput,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('detects multiple power sources on the same power rail', () => {
+    const result = validateNets({
+      nets: [
+        {
+          id: 'pwr',
+          name: '3V3',
+          type: 'power',
+          nodes: [
+            { deviceRef: 'U1', pin: 'OUT' },
+            { deviceRef: 'U2', pin: 'OUT' },
+            { deviceRef: 'U3', pin: 'VDD' },
+          ],
+        },
+        { id: 'gnd', name: 'GND', type: 'ground', nodes: [{ deviceRef: 'U3', pin: 'GND' }] },
+      ],
+      devices: [
+        {
+          id: 'U1',
+          ref: 'U1',
+          category: 'regulator',
+          pins: [{ pin: 'OUT', electricalType: 'power_output' }],
+        },
+        {
+          id: 'U2',
+          ref: 'U2',
+          category: 'regulator',
+          pins: [{ pin: 'OUT', electricalType: 'power_output' }],
+        },
+        { id: 'U3', ref: 'U3', pins: [{ pin: 'VDD', electricalType: 'power_input' }] },
+      ],
+    });
+
+    const issues = result.errors.filter((e) => e.code === NetValidationCode.NetPowerConflict);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].message).toContain('power sources');
+  });
+
+  it('warns for passive-only signal nets', () => {
+    const result = validateNets({
+      nets: [
+        { id: 'pwr', name: '3V3', type: 'power', nodes: [{ deviceRef: 'U1', pin: 'VDD' }] },
+        { id: 'gnd', name: 'GND', type: 'ground', nodes: [{ deviceRef: 'U1', pin: 'GND' }] },
+        {
+          id: 'sig',
+          name: 'RC_NODE',
+          type: 'signal',
+          nodes: [
+            { deviceRef: 'R1', pin: '1' },
+            { deviceRef: 'C1', pin: '1' },
+          ],
+        },
+      ],
+      devices: [
+        { id: 'U1', ref: 'U1', pins: [{ pin: 'VDD', electricalType: 'power_input' }] },
+        {
+          id: 'R1',
+          ref: 'R1',
+          category: 'resistor',
+          pins: [{ pin: '1', electricalType: 'passive' }],
+        },
+        {
+          id: 'C1',
+          ref: 'C1',
+          category: 'capacitor',
+          pins: [{ pin: '1', electricalType: 'passive' }],
+        },
+      ],
+    });
+
+    const issues = result.warnings.filter((e) => e.code === NetValidationCode.NetPassiveOnly);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].netName).toBe('RC_NODE');
+  });
+
+  it('detects missing required power pins', () => {
+    const result = validateNets({
+      nets: [
+        { id: 'pwr', name: '3V3', type: 'power', nodes: [] },
+        { id: 'gnd', name: 'GND', type: 'ground', nodes: [{ deviceRef: 'U1', pin: 'GND' }] },
+      ],
+      devices: [
+        {
+          id: 'U1',
+          ref: 'U1',
+          category: 'microcontroller',
+          pins: [
+            {
+              pin: 'VDD',
+              name: 'VDD',
+              electricalType: 'power_input',
+              required: true,
+              expectedNetType: 'power',
+            },
+            {
+              pin: 'GND',
+              name: 'GND',
+              electricalType: 'power_input',
+              required: true,
+              expectedNetType: 'ground',
+            },
+          ],
+        },
+      ],
+    });
+
+    const issues = result.errors.filter((e) => e.code === NetValidationCode.NetUnpoweredDevice);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].componentRef).toBe('U1');
+    expect(issues[0].pin).toBe('VDD');
+  });
+
+  it('detects required power pins connected to the wrong net class', () => {
+    const result = validateNets({
+      nets: [
+        { id: 'pwr', name: '3V3', type: 'power', nodes: [{ deviceRef: 'U1', pin: 'GND' }] },
+        { id: 'gnd', name: 'GND', type: 'ground', nodes: [{ deviceRef: 'U1', pin: 'VDD' }] },
+      ],
+      devices: [
+        {
+          id: 'U1',
+          ref: 'U1',
+          pins: [
+            { pin: 'VDD', electricalType: 'power_input', required: true, expectedNetType: 'power' },
+            {
+              pin: 'GND',
+              electricalType: 'power_input',
+              required: true,
+              expectedNetType: 'ground',
+            },
+          ],
+        },
+      ],
+    });
+
+    const issues = result.errors.filter((e) => e.code === NetValidationCode.NetUnpoweredDevice);
+    expect(issues).toHaveLength(2);
+  });
+
+  it('warns when a device requiring decoupling has no capacitor across power and ground', () => {
+    const result = validateNets({
+      nets: [
+        { id: 'pwr', name: '3V3', type: 'power', nodes: [{ deviceRef: 'U1', pin: 'VDD' }] },
+        { id: 'gnd', name: 'GND', type: 'ground', nodes: [{ deviceRef: 'U1', pin: 'GND' }] },
+      ],
+      devices: [
+        {
+          id: 'U1',
+          ref: 'U1',
+          category: 'microcontroller',
+          requiresDecoupling: true,
+          pins: [
+            { pin: 'VDD', electricalType: 'power_input', required: true, expectedNetType: 'power' },
+            {
+              pin: 'GND',
+              electricalType: 'power_input',
+              required: true,
+              expectedNetType: 'ground',
+            },
+          ],
+        },
+      ],
+    });
+
+    const issues = result.warnings.filter((e) => e.code === NetValidationCode.NetMissingDecoupling);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].remediationHint).toContain('decoupling capacitor');
+  });
+
+  it('does not warn for required decoupling when a capacitor bridges power and ground', () => {
+    const result = validateNets({
+      nets: [
+        {
+          id: 'pwr',
+          name: '3V3',
+          type: 'power',
+          nodes: [
+            { deviceRef: 'U1', pin: 'VDD' },
+            { deviceRef: 'C1', pin: '1' },
+          ],
+        },
+        {
+          id: 'gnd',
+          name: 'GND',
+          type: 'ground',
+          nodes: [
+            { deviceRef: 'U1', pin: 'GND' },
+            { deviceRef: 'C1', pin: '2' },
+          ],
+        },
+      ],
+      devices: [
+        {
+          id: 'U1',
+          ref: 'U1',
+          category: 'microcontroller',
+          requiresDecoupling: true,
+          pins: [
+            { pin: 'VDD', electricalType: 'power_input', required: true, expectedNetType: 'power' },
+            {
+              pin: 'GND',
+              electricalType: 'power_input',
+              required: true,
+              expectedNetType: 'ground',
+            },
+          ],
+        },
+        {
+          id: 'C1',
+          ref: 'C1',
+          category: 'capacitor',
+          pins: [
+            { pin: '1', electricalType: 'passive' },
+            { pin: '2', electricalType: 'passive' },
+          ],
+        },
+      ],
+    });
+
+    expect(
+      [...result.errors, ...result.warnings].filter(
+        (e) => e.code === NetValidationCode.NetMissingDecoupling,
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('detects voltage-domain mismatches', () => {
+    const result = validateNets({
+      nets: [
+        {
+          id: 'pwr',
+          name: '5V',
+          type: 'power',
+          nodes: [{ deviceRef: 'U1', pin: 'VDD' }],
+        },
+        { id: 'gnd', name: 'GND', type: 'ground', nodes: [{ deviceRef: 'U1', pin: 'GND' }] },
+      ],
+      devices: [
+        {
+          id: 'U1',
+          ref: 'U1',
+          pins: [
+            {
+              pin: 'VDD',
+              electricalType: 'power_input',
+              required: true,
+              expectedNetType: 'power',
+              expectedVoltage: 3.3,
+            },
+            {
+              pin: 'GND',
+              electricalType: 'power_input',
+              required: true,
+              expectedNetType: 'ground',
+            },
+          ],
+        },
+      ],
+    });
+
+    const issues = result.errors.filter((e) => e.code === NetValidationCode.NetVoltageMismatch);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].details?.expectedVoltage).toBe(3.3);
+    expect(issues[0].details?.actualVoltage).toBe(5);
+  });
+});

--- a/tests/unit/tools/drc-erc.test.ts
+++ b/tests/unit/tools/drc-erc.test.ts
@@ -190,6 +190,135 @@ describe('DRC/ERC Tools', () => {
     expect(result?.passed).toBe(true);
   });
 
+  it('easyeda_semantic_erc_validate detects semantic ERC failures without bridge calls', async () => {
+    const tool = registry.get('easyeda_semantic_erc_validate');
+    expect(tool).toBeDefined();
+
+    const result = await tool?.handler(context, {
+      projectId: 'proj-semantic',
+      nets: [
+        {
+          id: 'pwr',
+          name: '3V3',
+          type: 'power',
+          nodes: [{ deviceRef: 'U1', pin: 'VDD' }],
+        },
+        {
+          id: 'gnd',
+          name: 'GND',
+          type: 'ground',
+          nodes: [{ deviceRef: 'U1', pin: 'GND' }],
+        },
+        {
+          id: 'sig',
+          name: 'BUS_DRV',
+          type: 'signal',
+          nodes: [
+            { deviceRef: 'U1', pin: 'OUT' },
+            { deviceRef: 'U2', pin: 'OUT' },
+          ],
+        },
+      ],
+      devices: [
+        { id: 'U1', ref: 'U1', pins: [{ pin: 'OUT', electricalType: 'output' }] },
+        { id: 'U2', ref: 'U2', pins: [{ pin: 'OUT', electricalType: 'output' }] },
+      ],
+    });
+
+    expect(bridgeCall).not.toHaveBeenCalled();
+    expect(result?.project_id).toBe('proj-semantic');
+    expect(result?.passed).toBe(false);
+    expect(result?.error_count).toBeGreaterThanOrEqual(1);
+    expect(result?.errors[0]).toMatchObject({
+      code: 'NET_OUTPUT_CONTENTION',
+      net_name: 'BUS_DRV',
+      severity: 'error',
+    });
+    expect(result?.errors[0].remediation_hint).toContain('push-pull outputs');
+  });
+
+  it('easyeda_semantic_erc_validate passes false-positive control with pull-up and decoupling', async () => {
+    const tool = registry.get('easyeda_semantic_erc_validate');
+    expect(tool).toBeDefined();
+
+    const result = await tool?.handler(context, {
+      projectId: 'proj-clean',
+      nets: [
+        {
+          id: 'pwr',
+          name: '3V3',
+          type: 'power',
+          nodes: [
+            { deviceRef: 'U1', pin: 'VDD' },
+            { deviceRef: 'R1', pin: '1' },
+            { deviceRef: 'C1', pin: '1' },
+          ],
+        },
+        {
+          id: 'gnd',
+          name: 'GND',
+          type: 'ground',
+          nodes: [
+            { deviceRef: 'U1', pin: 'GND' },
+            { deviceRef: 'C1', pin: '2' },
+          ],
+        },
+        {
+          id: 'sig',
+          name: 'I2C_SDA',
+          type: 'signal',
+          nodes: [
+            { deviceRef: 'U1', pin: 'SDA' },
+            { deviceRef: 'R1', pin: '2' },
+          ],
+        },
+      ],
+      devices: [
+        {
+          id: 'U1',
+          ref: 'U1',
+          requiresDecoupling: true,
+          pins: [
+            { pin: 'VDD', electricalType: 'power_input', required: true, expectedNetType: 'power' },
+            {
+              pin: 'GND',
+              electricalType: 'power_input',
+              required: true,
+              expectedNetType: 'ground',
+            },
+            { pin: 'SDA', electricalType: 'input' },
+          ],
+        },
+        {
+          id: 'R1',
+          ref: 'R1',
+          category: 'resistor',
+          pins: [
+            { pin: '1', electricalType: 'passive' },
+            { pin: '2', electricalType: 'passive' },
+          ],
+        },
+        {
+          id: 'C1',
+          ref: 'C1',
+          category: 'capacitor',
+          pins: [
+            { pin: '1', electricalType: 'passive' },
+            { pin: '2', electricalType: 'passive' },
+          ],
+        },
+      ],
+    });
+
+    expect(result?.passed).toBe(true);
+    expect(result?.error_count).toBe(0);
+    expect(
+      result?.warnings.filter((warning) =>
+        ['NET_FLOATING_INPUT', 'NET_MISSING_DECOUPLING'].includes(warning.code),
+      ),
+    ).toEqual([]);
+  });
+
   it('easyeda_rule_check_summary returns combined DRC+ERC summary', async () => {
     const tool = registry.get('easyeda_rule_check_summary');
     expect(tool).toBeDefined();


### PR DESCRIPTION
Implements #28 semantic ERC for pin electrical types, floating nets, and power conflicts.

Changes:
- Adds semantic pin metadata model: `PinElectricalType`, `PinValidationMetadata`, and semantic net nodes.
- Extends net validation from 10 to 17 rules.
- Adds semantic ERC checks for:
  - active output contention,
  - floating input nets,
  - power source conflicts,
  - passive-only signal nets,
  - missing or miswired required power/ground pins,
  - missing local decoupling for devices that require it,
  - voltage-domain mismatch.
- Adds read-only MCP tool `easyeda_semantic_erc_validate` so agents can validate semantic netlists directly.
- Keeps semantic checks opt-in to avoid false positives on legacy/simple netlists.
- Updates net-validation docs and generated tool reference.
- Updates profile counts and tests.

Verification:
- pnpm audit --audit-level low
- pnpm peers check
- pnpm format:check
- pnpm typecheck
- pnpm typecheck:extension
- pnpm lint
- pnpm lint:tools
- pnpm verify:tool-coverage
- pnpm test
- pnpm test:coverage
- pnpm build
- pnpm check:metadata
- pnpm build:extension
- pnpm verify:extension
- pnpm generate:tools-doc
- pnpm docs:build
- git diff --check

Local result: 42 test files / 586 tests passed.
