### PR TITLE
feat(pcb): add production review rules

### DIFF
--- a/docs/pcb-constraints.md
+++ b/docs/pcb-constraints.md
@@ -4,11 +4,11 @@ Constraint-driven validation for PCB board designs.
 
 ## Overview
 
-The PCB constraints module validates a PCB design against 12 constraint rules (4 errors, 8 warnings). It operates on a decoupled input type (`PcbConstraintInput`) that can be fed from CircuitIR, the EasyEDA bridge, or test fixtures.
+The PCB constraints module validates a PCB design against 23 board, fabrication, assembly, and testability rules. It operates on a decoupled input type (`PcbConstraintInput`) that can be fed from CircuitIR, the EasyEDA bridge, or test fixtures.
 
 The module supports two primary operations:
 
-- **`validatePcbConstraints()`** — run all 12 rules against board data and produce structured errors/warnings
+- **`validatePcbConstraints()`** — run all 23 rules against board data and produce structured errors/warnings
 - **`buildConstraintReport()`** — build a human-readable report from validation results, listing which constraints were checked and which require manual review
 
 ## Validation Model
@@ -45,7 +45,7 @@ Each `PcbConstraintIssue` contains:
 
 ### 1. Missing Board Outline (error)
 
-**Severity:** error  
+**Severity:** error
 **Detects:** Board outline polygon is not defined.
 
 ```text
@@ -55,7 +55,7 @@ Board outline is not defined
 
 ### 2. Board Outline Too Small (warning)
 
-**Severity:** warning  
+**Severity:** warning
 **Detects:** Board width or height below 5 mm.
 
 ```text
@@ -65,7 +65,7 @@ Board width (3mm) is below recommended minimum of 5mm
 
 ### 3. Missing Layer Stackup (warning)
 
-**Severity:** warning  
+**Severity:** warning
 **Detects:** No detailed layer stackup defined.
 
 ```text
@@ -75,7 +75,7 @@ Detailed layer stackup is not defined
 
 ### 4. Layer Count Mismatch (error)
 
-**Severity:** error  
+**Severity:** error
 **Detects:** Board has more than 2 layers but no detailed stackup defined.
 
 ```text
@@ -85,7 +85,7 @@ Board has 4 layers but no detailed stackup is defined
 
 ### 5. Missing Mounting Holes (warning)
 
-**Severity:** warning  
+**Severity:** warning
 **Detects:** Zero mounting holes defined.
 
 ```text
@@ -95,7 +95,7 @@ No mounting holes defined on the board
 
 ### 6. Missing Net Classes (warning)
 
-**Severity:** warning  
+**Severity:** warning
 **Detects:** No net classes with routing rules defined.
 
 ```text
@@ -105,7 +105,7 @@ No net classes with routing rules are defined
 
 ### 7. Invalid Clearance (warning)
 
-**Severity:** warning  
+**Severity:** warning
 **Detects:** Net classes defined but no clearance rules between them.
 
 ```text
@@ -115,7 +115,7 @@ Net classes are defined but no clearance rules between them
 
 ### 8. Keepout Violations (warning)
 
-**Severity:** warning  
+**Severity:** warning
 **Detects:** Placement zones defined but no keepout/restricted areas.
 
 ```text
@@ -125,7 +125,7 @@ Placement zones are defined but no keepout/restricted areas
 
 ### 9. Missing Placement Zones (warning)
 
-**Severity:** warning  
+**Severity:** warning
 **Detects:** Multi-layer board without placement zones.
 
 ```text
@@ -135,7 +135,7 @@ No placement zones defined for component grouping
 
 ### 10. Missing Manufacturing Constraints (warning)
 
-**Severity:** warning  
+**Severity:** warning
 **Detects:** Manufacturing process or production quantity not specified.
 
 ```text
@@ -145,7 +145,7 @@ Manufacturing process (lead-free/lead-based) is not specified
 
 ### 11. Fiducials Recommended (warning)
 
-**Severity:** warning  
+**Severity:** warning
 **Detects:** Board with mounting holes but no fiducial marks.
 
 ```text
@@ -155,13 +155,69 @@ No fiducial marks defined for SMT assembly
 
 ### 12. High-Voltage Clearance (error)
 
-**Severity:** error  
+**Severity:** error
 **Detects:** High-voltage domain without clearance/net-class rules.
 
 ```text
 High-voltage domain detected but no clearance rules defined
 → Define explicit creepage and clearance distances for high-voltage nets
 ```
+
+### 13. Drill File Missing (error)
+
+**Severity:** error
+**Detects:** Manufacturing package lacks NC drill / Excellon drill output.
+
+### 14. Copper-to-Edge Clearance (error)
+
+**Severity:** error
+**Detects:** Copper, vias, pads, or zones too close to the routed board edge.
+Default recommendation: at least `0.25mm` copper-to-edge clearance.
+
+### 15. Drill / Annular Ring Risk (warning)
+
+**Severity:** warning
+**Detects:** Minimum drill below `0.20mm` or annular ring below `0.10mm`.
+
+### 16. Soldermask Sliver (warning)
+
+**Severity:** warning
+**Detects:** Soldermask web/sliver below `0.10mm` or explicit sliver violations.
+
+### 17. Silkscreen Over Pad (warning)
+
+**Severity:** warning
+**Detects:** Silkscreen text/graphics overlapping exposed copper pads.
+
+### 18. Tooling Holes (warning)
+
+**Severity:** warning
+**Detects:** SMT assembly data present but fewer than two tooling holes are declared.
+
+### 19. Polarity / Orientation Marks (warning)
+
+**Severity:** warning
+**Detects:** Polarized or orientation-sensitive components without matching polarity marks.
+
+### 20. Component Spacing / Courtyard (warning)
+
+**Severity:** warning
+**Detects:** Component spacing or courtyard violations that can affect placement, soldering, or rework.
+
+### 21. Testpoint Coverage (warning)
+
+**Severity:** warning
+**Detects:** Critical nets missing accessible test pads. Default minimum coverage is `80%`.
+
+### 22. Programming Header Missing (error)
+
+**Severity:** error
+**Detects:** A design marked as requiring programming/debug access without a programming header or equivalent pads.
+
+### 23. Fabrication Notes Missing (warning)
+
+**Severity:** warning
+**Detects:** Missing fabrication notes for thickness, copper weight, finish, soldermask, impedance, panelization, or special instructions.
 
 ## Error Codes
 
@@ -179,6 +235,18 @@ High-voltage domain detected but no clearance rules defined
 | `PCB_MISSING_MANUFACTURING_CONSTRAINTS` | warning  | 10     |
 | `PCB_FIDUCIAL_REQUIRED`                 | warning  | 11     |
 | `PCB_HIGH_VOLTAGE_CLEARANCE`            | error    | 12     |
+| `PCB_DRILL_FILE_MISSING`                | error    | 13     |
+| `PCB_COPPER_EDGE_CLEARANCE`             | error    | 14     |
+| `PCB_DRILL_TOO_SMALL`                   | warning  | 15     |
+| `PCB_ANNULAR_RING_TOO_SMALL`            | warning  | 15     |
+| `PCB_SOLDERMASK_SLIVER`                 | warning  | 16     |
+| `PCB_SILKSCREEN_OVER_PAD`               | warning  | 17     |
+| `PCB_TOOLING_HOLE_MISSING`              | warning  | 18     |
+| `PCB_POLARITY_MARK_MISSING`             | warning  | 19     |
+| `PCB_COMPONENT_SPACING_VIOLATION`       | warning  | 20     |
+| `PCB_TESTPOINT_COVERAGE_LOW`            | warning  | 21     |
+| `PCB_PROGRAMMING_HEADER_MISSING`        | error    | 22     |
+| `PCB_FAB_NOTES_MISSING`                 | warning  | 23     |
 
 ## Usage
 
@@ -212,6 +280,45 @@ if (!result.valid) {
   }
 }
 ```
+
+### Production review data
+
+Production review fields are optional and only fire when the corresponding data is present.
+This lets live board probes, CircuitIR, or export manifests progressively add more manufacturing detail without creating false positives on simple board snapshots.
+
+```typescript
+const result = validatePcbConstraints({
+  widthMm: 60,
+  heightMm: 40,
+  layerCount: 2,
+  hasOutline: true,
+  hasLayerStack: true,
+  hasNetClasses: true,
+  hasClearanceRules: true,
+  hasDrillFile: true,
+  minCopperToEdgeMm: 0.35,
+  minDrillMm: 0.3,
+  minAnnularRingMm: 0.15,
+  minSolderMaskSliverMm: 0.12,
+  smtComponentCount: 12,
+  fiducialCount: 3,
+  toolingHoleCount: 2,
+  polarizedComponentCount: 4,
+  polarityMarkCount: 4,
+  criticalNetNames: ['GND', '3V3', 'RESET', 'SWDIO', 'SWCLK'],
+  testPointNets: ['GND', '3V3', 'RESET', 'SWDIO', 'SWCLK'],
+  requiresProgrammingHeader: true,
+  hasProgrammingHeader: true,
+  hasFabricationNotes: true,
+});
+```
+
+The MCP tool `easyeda_pcb_production_review` exposes the same review model to agents.
+`easyeda_export_gerbers` can also run the same review as an optional gate:
+
+- `mode: 'warn'` returns production findings but still exports.
+- `mode: 'block'` stops Gerber export when production errors exist.
+- `mode: 'off'` preserves the legacy export behavior.
 
 ### Constraint Reports
 
@@ -261,12 +368,13 @@ The converter handles:
 - `highVoltage` → `hasHighVoltage` (defaults to false)
 - `manufacturingProcess` + `manufacturing.process` → `manufacturingProcess`
 - `quantity` + `manufacturing.quantity` → `hasQuantity`
+- production review fields such as drill, copper-to-edge, soldermask, silkscreen, fiducials, tooling holes, test points, programming header, and fabrication notes are passed through directly
 
 ## API Reference
 
 ### `validatePcbConstraints(input: PcbConstraintInput): PcbConstraintResult`
 
-Run all 12 validation rules against board data. Returns errors and warnings.
+Run all 23 validation rules against board data. Returns errors and warnings.
 
 ### `buildConstraintReport(input: PcbConstraintInput, result: PcbConstraintResult): ConstraintReport`
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -41,6 +41,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_pcb_delete_component`          | `full`  | `high`   | Delete components from the PCB layout by their primitive IDs.                                                                                                                                                                                                                                                 |
 | `easyeda_pcb_modify_component`          | `full`  | `high`   | Modify component properties in the PCB layout.                                                                                                                                                                                                                                                                |
 | `easyeda_pcb_place_component`           | `full`  | `high`   | Place a component footprint on the active PCB layout.                                                                                                                                                                                                                                                         |
+| `easyeda_pcb_production_review`         | `core`  | `medium` | Run fabrication, assembly, and testability production review rules for PCB handoff. Reports severity-ranked DFM/DFA/DFT findings with actionable remediation before Gerber export or manufacturing submission.                                                                                                |
 | `easyeda_project_save`                  | `core`  | `medium` | Explicitly save the current EasyEDA Pro project. This ensures all netlist changes, net flags, pin connections, and other mutations are persisted to the project file. Save is never implicit — the caller must explicitly request it. Requires confirmWrite.                                                  |
 | `easyeda_rule_check_summary`            | `core`  | `low`    | Get a summary of all design and electrical rule check results for the project.                                                                                                                                                                                                                                |
 | `easyeda_run_self_test`                 | `core`  | `low`    | Run internal self-test to verify server integrity, config, and bridge connectivity.                                                                                                                                                                                                                           |
@@ -542,12 +543,13 @@ Returns a JSON object matching the schema:
 
 ### Input Parameters
 
-| Parameter      | Type  | Required | Description |
-| -------------- | ----- | -------- | ----------- |
-| `projectId`    | `any` | Yes      |             |
-| `drillFormat`  | `any` | No       |             |
-| `excludeLayer` | `any` | No       |             |
-| `ledPanel`     | `any` | No       |             |
+| Parameter          | Type  | Required | Description |
+| ------------------ | ----- | -------- | ----------- |
+| `projectId`        | `any` | Yes      |             |
+| `drillFormat`      | `any` | No       |             |
+| `excludeLayer`     | `any` | No       |             |
+| `ledPanel`         | `any` | No       |             |
+| `productionReview` | `any` | No       |             |
 
 ### Output Format
 
@@ -559,6 +561,8 @@ Returns a JSON object matching the schema:
   artifact_path: any;
   file_count: any;
   exported: any;
+  blocked_by_production_review: any;
+  production_review: any;
   not_available: any;
 }
 ```
@@ -1051,6 +1055,40 @@ Returns a JSON object matching the schema:
   success: any;
   primitiveId: any;
   error: any;
+}
+```
+
+---
+
+## `easyeda_pcb_production_review`
+
+**Profile:** `core` | **Risk Level:** `medium`
+
+> Run fabrication, assembly, and testability production review rules for PCB handoff. Reports severity-ranked DFM/DFA/DFT findings with actionable remediation before Gerber export or manufacturing submission.
+
+### Input Parameters
+
+| Parameter   | Type  | Required | Description |
+| ----------- | ----- | -------- | ----------- |
+| `projectId` | `any` | Yes      |             |
+| `boardData` | `any` | No       |             |
+| `gateMode`  | `any` | Yes      |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  project_id: any;
+  passed: any;
+  blocked: any;
+  gate_mode: any;
+  severity_counts: any;
+  errors: any;
+  warnings: any;
+  summary: any;
+  not_available: any;
 }
 ```
 

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -14,14 +14,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Core',
     description:
       'High-confidence tools: diagnostics, EasyEDA API inventory, schematic, BOM, DRC/ERC, board layers/stackup, Gerber export',
-    approxToolCount: '39',
+    approxToolCount: '40',
     isDefault: true,
   },
   pro: {
     name: 'pro',
     label: 'Pro',
     description: 'Adds pick-and-place, PDF, netlist export for manufacturing workflows',
-    approxToolCount: '42',
+    approxToolCount: '43',
     isDefault: false,
   },
   full: {
@@ -29,7 +29,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls for full runtime control without raw JavaScript execution',
-    approxToolCount: '49',
+    approxToolCount: '50',
     isDefault: false,
   },
   dev: {
@@ -37,14 +37,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '53',
+    approxToolCount: '54',
     isDefault: false,
   },
   experimental: {
     name: 'experimental',
     label: 'Experimental',
     description: 'MCP Apps, Tasks, simulation, autorouter, AI action plans',
-    approxToolCount: '51',
+    approxToolCount: '52',
     isDefault: false,
   },
 };

--- a/src/pcb-constraints/errors.ts
+++ b/src/pcb-constraints/errors.ts
@@ -129,6 +129,90 @@ export const PcbConstraintCodeMap: Record<string, PcbConstraintCodeEntry> = {
     remediationHint:
       'Define explicit creepage and clearance distances for high-voltage nets. Minimum 4mm clearance for 250V AC is recommended.',
   },
+
+  DRILL_FILE_MISSING: {
+    code: 'PCB_DRILL_FILE_MISSING',
+    message: 'NC drill file is missing from the manufacturing package',
+    severity: 'error',
+    remediationHint: 'Re-export the manufacturing package with Excellon/NC drill files included',
+  },
+  COPPER_EDGE_CLEARANCE: {
+    code: 'PCB_COPPER_EDGE_CLEARANCE',
+    message: 'Copper is too close to the board edge',
+    severity: 'error',
+    remediationHint:
+      'Move copper, zones, vias, and pads away from the routed board edge or increase the copper-to-edge clearance rule',
+  },
+  DRILL_TOO_SMALL: {
+    code: 'PCB_DRILL_TOO_SMALL',
+    message: 'Minimum drill diameter is below common fabrication capability',
+    severity: 'warning',
+    remediationHint:
+      'Increase finished drill diameter or confirm the selected fabricator supports the requested drill size',
+  },
+  ANNULAR_RING_TOO_SMALL: {
+    code: 'PCB_ANNULAR_RING_TOO_SMALL',
+    message: 'Annular ring is below recommended manufacturing minimum',
+    severity: 'warning',
+    remediationHint:
+      'Increase pad/via diameter or reduce drill size to maintain enough annular ring for registration tolerance',
+  },
+  SOLDERMASK_SLIVER: {
+    code: 'PCB_SOLDERMASK_SLIVER',
+    message: 'Soldermask sliver is below recommended minimum',
+    severity: 'warning',
+    remediationHint:
+      'Increase pad spacing, adjust soldermask expansion, or remove soldermask dams intentionally where supported',
+  },
+  SILKSCREEN_OVER_PAD: {
+    code: 'PCB_SILKSCREEN_OVER_PAD',
+    message: 'Silkscreen overlaps exposed copper pads',
+    severity: 'warning',
+    remediationHint:
+      'Move or clip silkscreen references/graphics so they do not print over solderable pads',
+  },
+  TOOLING_HOLE_MISSING: {
+    code: 'PCB_TOOLING_HOLE_MISSING',
+    message: 'Tooling holes are missing for assembly/panel fixture alignment',
+    severity: 'warning',
+    remediationHint:
+      'Add tooling holes or confirm the assembler will provide panel-level tooling holes during panelization',
+  },
+  POLARITY_MARK_MISSING: {
+    code: 'PCB_POLARITY_MARK_MISSING',
+    message: 'Polarity or orientation marks are missing for polarized components',
+    severity: 'warning',
+    remediationHint:
+      'Add clear silkscreen/courtyard polarity markers for diodes, LEDs, electrolytic capacitors, IC pin 1, and connectors',
+  },
+  COMPONENT_SPACING_VIOLATION: {
+    code: 'PCB_COMPONENT_SPACING_VIOLATION',
+    message: 'Component spacing/courtyard violations detected',
+    severity: 'warning',
+    remediationHint:
+      'Increase component-to-component spacing or review courtyard overlap for assembly nozzle, hand-solder, and rework access',
+  },
+  TESTPOINT_COVERAGE_LOW: {
+    code: 'PCB_TESTPOINT_COVERAGE_LOW',
+    message: 'Critical nets are missing test points',
+    severity: 'warning',
+    remediationHint:
+      'Add accessible test pads for power rails, ground, reset, boot, programming, clocks, and key interfaces',
+  },
+  PROGRAMMING_HEADER_MISSING: {
+    code: 'PCB_PROGRAMMING_HEADER_MISSING',
+    message: 'Programming/debug header is required but missing',
+    severity: 'error',
+    remediationHint:
+      'Add a programming/debug connector or documented test pads for SWD/JTAG/UART/BOOT/RESET access',
+  },
+  FAB_NOTES_MISSING: {
+    code: 'PCB_FAB_NOTES_MISSING',
+    message: 'Fabrication notes are missing from the handoff package',
+    severity: 'warning',
+    remediationHint:
+      'Add fabrication notes covering board thickness, copper weight, finish, soldermask color, impedance requirements, panelization, and special instructions',
+  },
 } as const;
 
 // ── Factory helpers ────────────────────────────────────────────────────────

--- a/src/pcb-constraints/types.ts
+++ b/src/pcb-constraints/types.ts
@@ -22,6 +22,18 @@ export type PcbConstraintCode =
   | 'PCB_MISSING_MANUFACTURING_CONSTRAINTS'
   | 'PCB_FIDUCIAL_REQUIRED'
   | 'PCB_HIGH_VOLTAGE_CLEARANCE'
+  | 'PCB_DRILL_FILE_MISSING'
+  | 'PCB_COPPER_EDGE_CLEARANCE'
+  | 'PCB_DRILL_TOO_SMALL'
+  | 'PCB_ANNULAR_RING_TOO_SMALL'
+  | 'PCB_SOLDERMASK_SLIVER'
+  | 'PCB_SILKSCREEN_OVER_PAD'
+  | 'PCB_TOOLING_HOLE_MISSING'
+  | 'PCB_POLARITY_MARK_MISSING'
+  | 'PCB_COMPONENT_SPACING_VIOLATION'
+  | 'PCB_TESTPOINT_COVERAGE_LOW'
+  | 'PCB_PROGRAMMING_HEADER_MISSING'
+  | 'PCB_FAB_NOTES_MISSING'
   | 'PCB_CONSTRAINT_INTERNAL';
 
 // ── Constraint issue ───────────────────────────────────────────────────────
@@ -100,6 +112,44 @@ export interface PcbConstraintInput {
   hasFiducials?: boolean;
   /** Whether test pads are defined. */
   hasTestPads?: boolean;
+  /** Whether the drill/NC drill file is present in the manufacturing package. */
+  hasDrillFile?: boolean;
+  /** Minimum copper-to-board-edge clearance observed in mm. */
+  minCopperToEdgeMm?: number;
+  /** Number of copper-to-edge clearance violations. */
+  copperToEdgeViolationCount?: number;
+  /** Minimum finished/mechanical drill diameter observed in mm. */
+  minDrillMm?: number;
+  /** Minimum annular ring observed in mm. */
+  minAnnularRingMm?: number;
+  /** Minimum soldermask web/sliver observed in mm. */
+  minSolderMaskSliverMm?: number;
+  /** Count of soldermask sliver violations. */
+  solderMaskSliverViolationCount?: number;
+  /** Count of silkscreen objects overlapping copper pads. */
+  silkscreenOverPadCount?: number;
+  /** Number of SMT components requiring assembly alignment. */
+  smtComponentCount?: number;
+  /** Count of global/local fiducials. Overrides hasFiducials when provided. */
+  fiducialCount?: number;
+  /** Count of tooling holes for panel/fixture assembly. */
+  toolingHoleCount?: number;
+  /** Number of polarized/orientation-sensitive components. */
+  polarizedComponentCount?: number;
+  /** Number of polarized components with explicit polarity/orientation marks. */
+  polarityMarkCount?: number;
+  /** Count of component courtyard/spacing violations. */
+  componentSpacingViolationCount?: number;
+  /** Critical nets that should be accessible for bring-up/test. */
+  criticalNetNames?: string[];
+  /** Nets that have test pads/probes. */
+  testPointNets?: string[];
+  /** Whether a programming/debug header is present when required. */
+  hasProgrammingHeader?: boolean;
+  /** Whether this design requires a programming/debug header. */
+  requiresProgrammingHeader?: boolean;
+  /** Whether fabrication notes are present in the handoff package. */
+  hasFabricationNotes?: boolean;
   /** Whether the design contains high-voltage domains. */
   hasHighVoltage?: boolean;
   /** Manufacturing process (lead-free, lead-based, mixed). */

--- a/src/pcb-constraints/validation.ts
+++ b/src/pcb-constraints/validation.ts
@@ -1,7 +1,7 @@
 /**
  * PCB constraint validation rules.
  *
- * Implements constraint checks that operate on {@link PcbConstraintInput}
+ * Implements production constraint checks that operate on {@link PcbConstraintInput}
  * and produce structured {@link PcbConstraintIssue}s.
  *
  * Rules:
@@ -17,12 +17,35 @@
  * 10. Missing manufacturing constraints (warning)
  * 11. Fiducials recommended for SMT (warning)
  * 12. High-voltage creepage/clearance (error)
+ * 13. Missing drill file (error)
+ * 14. Copper-to-edge clearance violations (error)
+ * 15. Drill/annular-ring manufacturing risk (warning)
+ * 16. Soldermask sliver risk (warning)
+ * 17. Silkscreen over exposed pads (warning)
+ * 18. Tooling holes for assembly/panel fixtures (warning)
+ * 19. Polarity/orientation marks (warning)
+ * 20. Component spacing/courtyard violations (warning)
+ * 21. Critical-net testpoint coverage (warning)
+ * 22. Programming/debug header access (error)
+ * 23. Fabrication notes completeness (warning)
  *
  * @module
  */
 
 import type { PcbConstraintInput, PcbConstraintIssue, PcbConstraintResult } from './types.js';
 import { pcbError, pcbWarning } from './errors.js';
+
+const MIN_COPPER_TO_EDGE_MM = 0.25;
+const MIN_DRILL_MM = 0.2;
+const MIN_ANNULAR_RING_MM = 0.1;
+const MIN_SOLDERMASK_SLIVER_MM = 0.1;
+const MIN_SMT_FIDUCIAL_COUNT = 3;
+const MIN_TOOLING_HOLE_COUNT = 2;
+const MIN_TESTPOINT_COVERAGE_RATIO = 0.8;
+
+function normalizedNetName(name: string): string {
+  return name.trim().toUpperCase();
+}
 
 // ── Rule: missing board outline ────────────────────────────────────────────
 
@@ -284,6 +307,281 @@ function checkHighVoltageClearance(input: PcbConstraintInput): PcbConstraintIssu
   return issues;
 }
 
+// ── Production review: drill file completeness ─────────────────────────────
+
+function checkDrillFile(input: PcbConstraintInput): PcbConstraintIssue[] {
+  if (input.hasDrillFile !== false) return [];
+  return [
+    pcbError('PCB_DRILL_FILE_MISSING', 'NC drill file is missing from the manufacturing package', {
+      remediationHint: 'Re-export the manufacturing package with Excellon/NC drill files included',
+      details: { hasDrillFile: input.hasDrillFile },
+    }),
+  ];
+}
+
+// ── Production review: copper-to-edge clearance ────────────────────────────
+
+function checkCopperToEdgeClearance(input: PcbConstraintInput): PcbConstraintIssue[] {
+  const issues: PcbConstraintIssue[] = [];
+  const violationCount = input.copperToEdgeViolationCount ?? 0;
+  const belowMinimum =
+    input.minCopperToEdgeMm !== undefined && input.minCopperToEdgeMm < MIN_COPPER_TO_EDGE_MM;
+
+  if (violationCount > 0 || belowMinimum) {
+    issues.push(
+      pcbError(
+        'PCB_COPPER_EDGE_CLEARANCE',
+        `Copper-to-edge clearance is below ${MIN_COPPER_TO_EDGE_MM}mm${input.minCopperToEdgeMm !== undefined ? ` (observed ${input.minCopperToEdgeMm}mm)` : ''}`,
+        {
+          remediationHint:
+            'Move copper, zones, vias, and pads away from the routed board edge or increase the copper-to-edge clearance rule',
+          details: {
+            minCopperToEdgeMm: input.minCopperToEdgeMm,
+            copperToEdgeViolationCount: violationCount,
+            recommendedMinimumMm: MIN_COPPER_TO_EDGE_MM,
+          },
+        },
+      ),
+    );
+  }
+
+  return issues;
+}
+
+// ── Production review: drill and annular ring capability ───────────────────
+
+function checkDrillManufacturability(input: PcbConstraintInput): PcbConstraintIssue[] {
+  const issues: PcbConstraintIssue[] = [];
+
+  if (input.minDrillMm !== undefined && input.minDrillMm < MIN_DRILL_MM) {
+    issues.push(
+      pcbWarning(
+        'PCB_DRILL_TOO_SMALL',
+        `Minimum drill diameter ${input.minDrillMm}mm is below common ${MIN_DRILL_MM}mm fabrication capability`,
+        {
+          remediationHint:
+            'Increase finished drill diameter or confirm the selected fabricator supports the requested drill size',
+          details: { minDrillMm: input.minDrillMm, recommendedMinimumMm: MIN_DRILL_MM },
+        },
+      ),
+    );
+  }
+
+  if (input.minAnnularRingMm !== undefined && input.minAnnularRingMm < MIN_ANNULAR_RING_MM) {
+    issues.push(
+      pcbWarning(
+        'PCB_ANNULAR_RING_TOO_SMALL',
+        `Minimum annular ring ${input.minAnnularRingMm}mm is below recommended ${MIN_ANNULAR_RING_MM}mm`,
+        {
+          remediationHint:
+            'Increase pad/via diameter or reduce drill size to maintain enough annular ring for registration tolerance',
+          details: {
+            minAnnularRingMm: input.minAnnularRingMm,
+            recommendedMinimumMm: MIN_ANNULAR_RING_MM,
+          },
+        },
+      ),
+    );
+  }
+
+  return issues;
+}
+
+// ── Production review: soldermask sliver ───────────────────────────────────
+
+function checkSolderMaskSliver(input: PcbConstraintInput): PcbConstraintIssue[] {
+  const violationCount = input.solderMaskSliverViolationCount ?? 0;
+  const belowMinimum =
+    input.minSolderMaskSliverMm !== undefined &&
+    input.minSolderMaskSliverMm < MIN_SOLDERMASK_SLIVER_MM;
+  if (!belowMinimum && violationCount === 0) return [];
+
+  return [
+    pcbWarning(
+      'PCB_SOLDERMASK_SLIVER',
+      `Soldermask sliver is below ${MIN_SOLDERMASK_SLIVER_MM}mm${input.minSolderMaskSliverMm !== undefined ? ` (observed ${input.minSolderMaskSliverMm}mm)` : ''}`,
+      {
+        remediationHint:
+          'Increase pad spacing, adjust soldermask expansion, or remove soldermask dams intentionally where supported',
+        details: {
+          minSolderMaskSliverMm: input.minSolderMaskSliverMm,
+          solderMaskSliverViolationCount: violationCount,
+          recommendedMinimumMm: MIN_SOLDERMASK_SLIVER_MM,
+        },
+      },
+    ),
+  ];
+}
+
+// ── Production review: silkscreen over pads ────────────────────────────────
+
+function checkSilkscreenOverPads(input: PcbConstraintInput): PcbConstraintIssue[] {
+  const count = input.silkscreenOverPadCount ?? 0;
+  if (count <= 0) return [];
+  return [
+    pcbWarning(
+      'PCB_SILKSCREEN_OVER_PAD',
+      `${count} silkscreen object${count === 1 ? '' : 's'} overlap exposed copper pads`,
+      {
+        remediationHint:
+          'Move or clip silkscreen references/graphics so they do not print over solderable pads',
+        details: { silkscreenOverPadCount: count },
+      },
+    ),
+  ];
+}
+
+// ── Production review: assembly fixtures/fiducials ─────────────────────────
+
+function checkAssemblyAlignmentFeatures(input: PcbConstraintInput): PcbConstraintIssue[] {
+  const issues: PcbConstraintIssue[] = [];
+  const smtCount = input.smtComponentCount ?? 0;
+  const fiducialCount = input.fiducialCount ?? (input.hasFiducials ? MIN_SMT_FIDUCIAL_COUNT : 0);
+  const toolingHoleCount = input.toolingHoleCount ?? 0;
+
+  if (smtCount > 0 && fiducialCount < MIN_SMT_FIDUCIAL_COUNT) {
+    issues.push(
+      pcbWarning(
+        'PCB_FIDUCIAL_REQUIRED',
+        `SMT assembly has ${fiducialCount} fiducial(s); at least ${MIN_SMT_FIDUCIAL_COUNT} are recommended`,
+        {
+          remediationHint:
+            'Add at least 3 fiducial marks (global, near board corners) for pick-and-place machine alignment',
+          details: {
+            smtComponentCount: smtCount,
+            fiducialCount,
+            recommendedMinimum: MIN_SMT_FIDUCIAL_COUNT,
+          },
+        },
+      ),
+    );
+  }
+
+  if (smtCount > 0 && toolingHoleCount < MIN_TOOLING_HOLE_COUNT) {
+    issues.push(
+      pcbWarning(
+        'PCB_TOOLING_HOLE_MISSING',
+        `Assembly tooling holes are below recommended count (${toolingHoleCount}/${MIN_TOOLING_HOLE_COUNT})`,
+        {
+          remediationHint:
+            'Add tooling holes or confirm the assembler will provide panel-level tooling holes during panelization',
+          details: {
+            smtComponentCount: smtCount,
+            toolingHoleCount,
+            recommendedMinimum: MIN_TOOLING_HOLE_COUNT,
+          },
+        },
+      ),
+    );
+  }
+
+  return issues;
+}
+
+// ── Production review: polarity/orientation marks ──────────────────────────
+
+function checkPolarityMarks(input: PcbConstraintInput): PcbConstraintIssue[] {
+  const polarizedCount = input.polarizedComponentCount ?? 0;
+  const markedCount = input.polarityMarkCount ?? 0;
+  const missingCount = Math.max(0, polarizedCount - markedCount);
+  if (missingCount === 0) return [];
+
+  return [
+    pcbWarning(
+      'PCB_POLARITY_MARK_MISSING',
+      `${missingCount} polarized/orientation-sensitive component${missingCount === 1 ? '' : 's'} lack polarity/orientation marks`,
+      {
+        remediationHint:
+          'Add clear silkscreen/courtyard polarity markers for diodes, LEDs, electrolytic capacitors, IC pin 1, and connectors',
+        details: {
+          polarizedComponentCount: polarizedCount,
+          polarityMarkCount: markedCount,
+          missingCount,
+        },
+      },
+    ),
+  ];
+}
+
+// ── Production review: component spacing/courtyard ─────────────────────────
+
+function checkComponentSpacing(input: PcbConstraintInput): PcbConstraintIssue[] {
+  const count = input.componentSpacingViolationCount ?? 0;
+  if (count <= 0) return [];
+  return [
+    pcbWarning(
+      'PCB_COMPONENT_SPACING_VIOLATION',
+      `${count} component spacing/courtyard violation${count === 1 ? '' : 's'} detected`,
+      {
+        remediationHint:
+          'Increase component-to-component spacing or review courtyard overlap for assembly nozzle, hand-solder, and rework access',
+        details: { componentSpacingViolationCount: count },
+      },
+    ),
+  ];
+}
+
+// ── Production review: testpoint coverage ──────────────────────────────────
+
+function checkTestpointCoverage(input: PcbConstraintInput): PcbConstraintIssue[] {
+  const criticalNets = [...new Set((input.criticalNetNames ?? []).map(normalizedNetName))];
+  if (criticalNets.length === 0) return [];
+  const testPointNets = new Set((input.testPointNets ?? []).map(normalizedNetName));
+  const missing = criticalNets.filter((net) => !testPointNets.has(net));
+  const coverage = (criticalNets.length - missing.length) / criticalNets.length;
+
+  if (coverage < MIN_TESTPOINT_COVERAGE_RATIO) {
+    return [
+      pcbWarning(
+        'PCB_TESTPOINT_COVERAGE_LOW',
+        `Critical-net testpoint coverage is ${(coverage * 100).toFixed(0)}%; ${missing.length} critical net(s) are missing test access`,
+        {
+          remediationHint:
+            'Add accessible test pads for power rails, ground, reset, boot, programming, clocks, and key interfaces',
+          details: {
+            criticalNetCount: criticalNets.length,
+            testPointNetCount: testPointNets.size,
+            missingCriticalNets: missing,
+            coverageRatio: coverage,
+            recommendedMinimumRatio: MIN_TESTPOINT_COVERAGE_RATIO,
+          },
+        },
+      ),
+    ];
+  }
+
+  return [];
+}
+
+// ── Production review: programming/debug access ────────────────────────────
+
+function checkProgrammingHeader(input: PcbConstraintInput): PcbConstraintIssue[] {
+  if (!input.requiresProgrammingHeader || input.hasProgrammingHeader !== false) return [];
+  return [
+    pcbError('PCB_PROGRAMMING_HEADER_MISSING', 'Programming/debug header is required but missing', {
+      remediationHint:
+        'Add a programming/debug connector or documented test pads for SWD/JTAG/UART/BOOT/RESET access',
+      details: {
+        requiresProgrammingHeader: true,
+        hasProgrammingHeader: input.hasProgrammingHeader,
+      },
+    }),
+  ];
+}
+
+// ── Production review: fabrication notes ───────────────────────────────────
+
+function checkFabricationNotes(input: PcbConstraintInput): PcbConstraintIssue[] {
+  if (input.hasFabricationNotes !== false) return [];
+  return [
+    pcbWarning('PCB_FAB_NOTES_MISSING', 'Fabrication notes are missing from the handoff package', {
+      remediationHint:
+        'Add fabrication notes covering board thickness, copper weight, finish, soldermask color, impedance requirements, panelization, and special instructions',
+      details: { hasFabricationNotes: input.hasFabricationNotes },
+    }),
+  ];
+}
+
 // ── Combine helper ─────────────────────────────────────────────────────────
 
 type RuleFn = (input: PcbConstraintInput) => PcbConstraintIssue[];
@@ -301,6 +599,17 @@ const RULES: RuleFn[] = [
   checkMissingManufacturingConstraints,
   checkFiducials,
   checkHighVoltageClearance,
+  checkDrillFile,
+  checkCopperToEdgeClearance,
+  checkDrillManufacturability,
+  checkSolderMaskSliver,
+  checkSilkscreenOverPads,
+  checkAssemblyAlignmentFeatures,
+  checkPolarityMarks,
+  checkComponentSpacing,
+  checkTestpointCoverage,
+  checkProgrammingHeader,
+  checkFabricationNotes,
 ];
 
 // ── Main entry point ───────────────────────────────────────────────────────
@@ -308,7 +617,7 @@ const RULES: RuleFn[] = [
 /**
  * Run all PCB constraint validation rules against board data.
  *
- * Orchestrates 12 rules:
+ * Orchestrates 23 rules:
  *   1. Missing outline         — error  if board outline is not defined
  *   2. Outline too small       — warning if dimensions are below 5mm
  *   3. Missing stackup         — warning if no detailed layer stack
@@ -321,6 +630,17 @@ const RULES: RuleFn[] = [
  *  10. Missing mfg constraints — warning if process/quantity unspecified
  *  11. Fiducials recommended   — warning if SMT board without fiducials
  *  12. High-voltage clearance  — error  if HV domain without proper clearance
+ *  13. Drill file              — error  if NC drill file is missing
+ *  14. Copper edge clearance   — error  if copper is too close to board edge
+ *  15. Drill/annular ring      — warning if process dimensions are risky
+ *  16. Soldermask sliver       — warning if soldermask web is too small
+ *  17. Silkscreen over pad     — warning if silkscreen overlaps exposed pads
+ *  18. Tooling holes           — warning if assembly tooling holes are missing
+ *  19. Polarity marks          — warning if orientation-sensitive parts lack marks
+ *  20. Component spacing       — warning if courtyard/spacing violations exist
+ *  21. Testpoint coverage      — warning if critical nets lack test access
+ *  22. Programming header      — error  if required debug/programming access is missing
+ *  23. Fabrication notes       — warning if handoff notes are missing
  */
 export function validatePcbConstraints(input: PcbConstraintInput): PcbConstraintResult {
   const errors: PcbConstraintIssue[] = [];
@@ -451,6 +771,25 @@ export function fromPcbIntent(pcb: {
   mountingHoles?: unknown[];
   fiducials?: unknown[];
   testPads?: unknown[];
+  hasDrillFile?: boolean;
+  minCopperToEdgeMm?: number;
+  copperToEdgeViolationCount?: number;
+  minDrillMm?: number;
+  minAnnularRingMm?: number;
+  minSolderMaskSliverMm?: number;
+  solderMaskSliverViolationCount?: number;
+  silkscreenOverPadCount?: number;
+  smtComponentCount?: number;
+  fiducialCount?: number;
+  toolingHoleCount?: number;
+  polarizedComponentCount?: number;
+  polarityMarkCount?: number;
+  componentSpacingViolationCount?: number;
+  criticalNetNames?: string[];
+  testPointNets?: string[];
+  hasProgrammingHeader?: boolean;
+  requiresProgrammingHeader?: boolean;
+  hasFabricationNotes?: boolean;
   manufacturingProcess?: string;
   manufacturing?: { process?: string; quantity?: number };
   quantity?: number;
@@ -471,6 +810,25 @@ export function fromPcbIntent(pcb: {
     hasPlacementZones: !!(pcb.placementZones && pcb.placementZones.length > 0),
     hasFiducials: !!(pcb.fiducials && pcb.fiducials.length > 0),
     hasTestPads: !!(pcb.testPads && pcb.testPads.length > 0),
+    hasDrillFile: pcb.hasDrillFile,
+    minCopperToEdgeMm: pcb.minCopperToEdgeMm,
+    copperToEdgeViolationCount: pcb.copperToEdgeViolationCount,
+    minDrillMm: pcb.minDrillMm,
+    minAnnularRingMm: pcb.minAnnularRingMm,
+    minSolderMaskSliverMm: pcb.minSolderMaskSliverMm,
+    solderMaskSliverViolationCount: pcb.solderMaskSliverViolationCount,
+    silkscreenOverPadCount: pcb.silkscreenOverPadCount,
+    smtComponentCount: pcb.smtComponentCount,
+    fiducialCount: pcb.fiducialCount ?? pcb.fiducials?.length,
+    toolingHoleCount: pcb.toolingHoleCount,
+    polarizedComponentCount: pcb.polarizedComponentCount,
+    polarityMarkCount: pcb.polarityMarkCount,
+    componentSpacingViolationCount: pcb.componentSpacingViolationCount,
+    criticalNetNames: pcb.criticalNetNames,
+    testPointNets: pcb.testPointNets,
+    hasProgrammingHeader: pcb.hasProgrammingHeader,
+    requiresProgrammingHeader: pcb.requiresProgrammingHeader,
+    hasFabricationNotes: pcb.hasFabricationNotes,
     hasHighVoltage: pcb.highVoltage ?? false,
     manufacturingProcess: pcb.manufacturingProcess ?? pcb.manufacturing?.process,
     hasQuantity:

--- a/src/tools/L1_export.ts
+++ b/src/tools/L1_export.ts
@@ -1,6 +1,46 @@
 import { z } from 'zod';
 import { type ToolDefinition, type ToolContext } from './types.js';
 import { type EnvConfig } from '../config/env.js';
+import { validatePcbConstraints } from '../pcb-constraints/index.js';
+import type { PcbConstraintInput } from '../pcb-constraints/types.js';
+
+const productionReviewBoardDataSchema = z.object({}).passthrough();
+
+const productionReviewIssueSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  severity: z.string(),
+  remediationHint: z.string(),
+});
+
+function runProductionReview(
+  boardData: Partial<PcbConstraintInput> | undefined,
+  mode: 'off' | 'warn' | 'block' | undefined,
+) {
+  if (!mode || mode === 'off') return undefined;
+  const result = validatePcbConstraints((boardData ?? {}) as PcbConstraintInput);
+  const errors = result.errors.map((issue) => ({
+    code: issue.code,
+    message: issue.message,
+    severity: issue.severity,
+    remediationHint: issue.remediationHint,
+  }));
+  const warnings = result.warnings.map((issue) => ({
+    code: issue.code,
+    message: issue.message,
+    severity: issue.severity,
+    remediationHint: issue.remediationHint,
+  }));
+  return {
+    mode,
+    passed: result.valid,
+    blocked: mode === 'block' && errors.length > 0,
+    error_count: errors.length,
+    warning_count: warnings.length,
+    errors,
+    warnings,
+  };
+}
 
 function registerExportTools(
   registry: { register: (def: ToolDefinition) => void },
@@ -26,22 +66,58 @@ function registerExportTools(
       drillFormat: z.enum(['excellon', 'millimeter', 'inch']).optional(),
       excludeLayer: z.array(z.string()).optional(),
       ledPanel: z.boolean().optional(),
+      productionReview: z
+        .object({
+          mode: z.enum(['off', 'warn', 'block']).default('warn'),
+          boardData: productionReviewBoardDataSchema.optional(),
+        })
+        .optional(),
     }),
     outputSchema: z.object({
       project_id: z.string(),
       artifact_path: z.string().optional(),
       file_count: z.number().int().nonnegative().optional(),
       exported: z.boolean(),
+      blocked_by_production_review: z.boolean().optional(),
+      production_review: z
+        .object({
+          mode: z.string(),
+          passed: z.boolean(),
+          blocked: z.boolean(),
+          error_count: z.number().int().nonnegative(),
+          warning_count: z.number().int().nonnegative(),
+          errors: z.array(productionReviewIssueSchema),
+          warnings: z.array(productionReviewIssueSchema),
+        })
+        .optional(),
       not_available: z.boolean().optional(),
     }),
     handler: async (ctx: ToolContext, params: unknown) => {
-      const { projectId, drillFormat, excludeLayer, ledPanel } = params as {
+      const { projectId, drillFormat, excludeLayer, ledPanel, productionReview } = params as {
         projectId: string;
         drillFormat?: string;
         excludeLayer?: string[];
         ledPanel?: boolean;
+        productionReview?: {
+          mode?: 'off' | 'warn' | 'block';
+          boardData?: Partial<PcbConstraintInput>;
+        };
       };
       try {
+        const productionReviewResult = runProductionReview(
+          productionReview?.boardData,
+          productionReview?.mode,
+        );
+
+        if (productionReviewResult?.blocked) {
+          return {
+            project_id: projectId,
+            exported: false,
+            blocked_by_production_review: true,
+            production_review: productionReviewResult,
+          };
+        }
+
         const result = await ctx.bridge.call('board.exportGerbers', {
           projectId,
           drillFormat,
@@ -54,11 +130,16 @@ function registerExportTools(
           artifact_path: data.artifactPath,
           file_count: data.fileCount,
           exported: true,
+          production_review: productionReviewResult,
         };
       } catch (err) {
         return {
           project_id: projectId,
           exported: false,
+          production_review: runProductionReview(
+            productionReview?.boardData,
+            productionReview?.mode,
+          ),
           not_available: true,
           error: err instanceof Error ? err.message : String(err),
         };

--- a/src/tools/L1_pcb_constraints.ts
+++ b/src/tools/L1_pcb_constraints.ts
@@ -4,6 +4,70 @@ import { type EnvConfig } from '../config/env.js';
 import { validatePcbConstraints, buildConstraintReport } from '../pcb-constraints/index.js';
 import type { PcbConstraintInput } from '../pcb-constraints/types.js';
 
+const pcbBoardDataSchema = z.object({
+  widthMm: z.number().nonnegative().optional(),
+  heightMm: z.number().nonnegative().optional(),
+  layerCount: z.number().int().nonnegative().optional(),
+  hasOutline: z.boolean().optional(),
+  mountingHoleCount: z.number().int().nonnegative().optional(),
+  hasLayerStack: z.boolean().optional(),
+  hasNetClasses: z.boolean().optional(),
+  hasClearanceRules: z.boolean().optional(),
+  hasKeepoutAreas: z.boolean().optional(),
+  hasPlacementZones: z.boolean().optional(),
+  hasFiducials: z.boolean().optional(),
+  hasTestPads: z.boolean().optional(),
+  hasDrillFile: z.boolean().optional(),
+  minCopperToEdgeMm: z.number().nonnegative().optional(),
+  copperToEdgeViolationCount: z.number().int().nonnegative().optional(),
+  minDrillMm: z.number().nonnegative().optional(),
+  minAnnularRingMm: z.number().nonnegative().optional(),
+  minSolderMaskSliverMm: z.number().nonnegative().optional(),
+  solderMaskSliverViolationCount: z.number().int().nonnegative().optional(),
+  silkscreenOverPadCount: z.number().int().nonnegative().optional(),
+  smtComponentCount: z.number().int().nonnegative().optional(),
+  fiducialCount: z.number().int().nonnegative().optional(),
+  toolingHoleCount: z.number().int().nonnegative().optional(),
+  polarizedComponentCount: z.number().int().nonnegative().optional(),
+  polarityMarkCount: z.number().int().nonnegative().optional(),
+  componentSpacingViolationCount: z.number().int().nonnegative().optional(),
+  criticalNetNames: z.array(z.string()).optional(),
+  testPointNets: z.array(z.string()).optional(),
+  hasProgrammingHeader: z.boolean().optional(),
+  requiresProgrammingHeader: z.boolean().optional(),
+  hasFabricationNotes: z.boolean().optional(),
+  hasHighVoltage: z.boolean().optional(),
+  manufacturingProcess: z.string().optional(),
+  hasQuantity: z.boolean().optional(),
+});
+
+const pcbIssueSchema = z.object({
+  code: z.string(),
+  message: z.string(),
+  severity: z.string(),
+  path: z.string().optional(),
+  remediationHint: z.string(),
+  details: z.record(z.string(), z.unknown()).optional(),
+});
+
+function mapPcbIssue(issue: {
+  code: string;
+  message: string;
+  severity: string;
+  path?: string;
+  remediationHint: string;
+  details?: Record<string, unknown>;
+}) {
+  return {
+    code: issue.code,
+    message: issue.message,
+    severity: issue.severity,
+    path: issue.path,
+    remediationHint: issue.remediationHint,
+    details: issue.details,
+  };
+}
+
 /**
  * Fetch board data from the live EasyEDA bridge when no explicit boardData is provided.
  * Queries dimensions, layers, and stackup in parallel via Promise.allSettled.
@@ -80,47 +144,13 @@ function registerPcbConstraintTools(
     },
     inputSchema: z.object({
       projectId: z.string(),
-      boardData: z
-        .object({
-          widthMm: z.number().nonnegative().optional(),
-          heightMm: z.number().nonnegative().optional(),
-          layerCount: z.number().int().nonnegative().optional(),
-          hasOutline: z.boolean().optional(),
-          mountingHoleCount: z.number().int().nonnegative().optional(),
-          hasLayerStack: z.boolean().optional(),
-          hasNetClasses: z.boolean().optional(),
-          hasClearanceRules: z.boolean().optional(),
-          hasKeepoutAreas: z.boolean().optional(),
-          hasPlacementZones: z.boolean().optional(),
-          hasFiducials: z.boolean().optional(),
-          hasTestPads: z.boolean().optional(),
-          hasHighVoltage: z.boolean().optional(),
-          manufacturingProcess: z.string().optional(),
-          hasQuantity: z.boolean().optional(),
-        })
-        .optional(),
+      boardData: pcbBoardDataSchema.optional(),
     }),
     outputSchema: z.object({
       project_id: z.string(),
       valid: z.boolean(),
-      errors: z.array(
-        z.object({
-          code: z.string(),
-          message: z.string(),
-          severity: z.string(),
-          path: z.string().optional(),
-          remediationHint: z.string(),
-        }),
-      ),
-      warnings: z.array(
-        z.object({
-          code: z.string(),
-          message: z.string(),
-          severity: z.string(),
-          path: z.string().optional(),
-          remediationHint: z.string(),
-        }),
-      ),
+      errors: z.array(pcbIssueSchema),
+      warnings: z.array(pcbIssueSchema),
       summary: z.object({
         totalChecks: z.number(),
         passed: z.number(),
@@ -150,26 +180,102 @@ function registerPcbConstraintTools(
         return {
           project_id: projectId,
           valid: result.valid,
-          errors: result.errors.map((e) => ({
-            code: e.code,
-            message: e.message,
-            severity: e.severity,
-            path: e.path,
-            remediationHint: e.remediationHint,
-          })),
-          warnings: result.warnings.map((w) => ({
-            code: w.code,
-            message: w.message,
-            severity: w.severity,
-            path: w.path,
-            remediationHint: w.remediationHint,
-          })),
+          errors: result.errors.map(mapPcbIssue),
+          warnings: result.warnings.map(mapPcbIssue),
           summary: result.summary,
         };
       } catch (err) {
         return {
           project_id: projectId,
           valid: false,
+          errors: [],
+          warnings: [],
+          summary: { totalChecks: 0, passed: 0, failed: 0, notApplicable: 0 },
+          not_available: true,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+  });
+
+  registry.register({
+    name: 'easyeda_pcb_production_review',
+    title: 'Run PCB production review',
+    description:
+      'Run fabrication, assembly, and testability production review rules for PCB handoff. Reports severity-ranked DFM/DFA/DFT findings with actionable remediation before Gerber export or manufacturing submission.',
+    profile: 'core',
+    evidence: ['inferred'],
+    risk: 'medium',
+    confirmWrite: false,
+    group: 'pcb-constraints',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    inputSchema: z.object({
+      projectId: z.string(),
+      boardData: pcbBoardDataSchema.optional(),
+      gateMode: z.enum(['warn', 'block', 'off']).default('warn'),
+    }),
+    outputSchema: z.object({
+      project_id: z.string(),
+      passed: z.boolean(),
+      blocked: z.boolean(),
+      gate_mode: z.string(),
+      severity_counts: z.object({
+        errors: z.number().int().nonnegative(),
+        warnings: z.number().int().nonnegative(),
+        total: z.number().int().nonnegative(),
+      }),
+      errors: z.array(pcbIssueSchema),
+      warnings: z.array(pcbIssueSchema),
+      summary: z.object({
+        totalChecks: z.number(),
+        passed: z.number(),
+        failed: z.number(),
+        notApplicable: z.number(),
+      }),
+      not_available: z.boolean().optional(),
+    }),
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const { projectId, boardData, gateMode } = params as {
+        projectId: string;
+        boardData?: Partial<PcbConstraintInput>;
+        gateMode?: 'warn' | 'block' | 'off';
+      };
+
+      try {
+        const input = boardData
+          ? (boardData as PcbConstraintInput)
+          : await fetchBoardDataFromBridge(ctx, projectId);
+        const result = validatePcbConstraints(input);
+        const errors = result.errors.map(mapPcbIssue);
+        const warnings = result.warnings.map(mapPcbIssue);
+        const mode = gateMode ?? 'warn';
+
+        return {
+          project_id: projectId,
+          passed: result.valid,
+          blocked: mode === 'block' && errors.length > 0,
+          gate_mode: mode,
+          severity_counts: {
+            errors: errors.length,
+            warnings: warnings.length,
+            total: errors.length + warnings.length,
+          },
+          errors,
+          warnings,
+          summary: result.summary,
+        };
+      } catch (err) {
+        return {
+          project_id: projectId,
+          passed: false,
+          blocked: gateMode === 'block',
+          gate_mode: gateMode ?? 'warn',
+          severity_counts: { errors: 0, warnings: 0, total: 0 },
           errors: [],
           warnings: [],
           summary: { totalChecks: 0, passed: 0, failed: 0, notApplicable: 0 },
@@ -197,25 +303,7 @@ function registerPcbConstraintTools(
     },
     inputSchema: z.object({
       projectId: z.string(),
-      boardData: z
-        .object({
-          widthMm: z.number().nonnegative().optional(),
-          heightMm: z.number().nonnegative().optional(),
-          layerCount: z.number().int().nonnegative().optional(),
-          hasOutline: z.boolean().optional(),
-          mountingHoleCount: z.number().int().nonnegative().optional(),
-          hasLayerStack: z.boolean().optional(),
-          hasNetClasses: z.boolean().optional(),
-          hasClearanceRules: z.boolean().optional(),
-          hasKeepoutAreas: z.boolean().optional(),
-          hasPlacementZones: z.boolean().optional(),
-          hasFiducials: z.boolean().optional(),
-          hasTestPads: z.boolean().optional(),
-          hasHighVoltage: z.boolean().optional(),
-          manufacturingProcess: z.string().optional(),
-          hasQuantity: z.boolean().optional(),
-        })
-        .optional(),
+      boardData: pcbBoardDataSchema.optional(),
     }),
     outputSchema: z.object({
       project_id: z.string(),

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -39,14 +39,14 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for core', () => {
-    expect(PROFILE_DEFINITIONS.core.approxToolCount).toBe('39');
+    expect(PROFILE_DEFINITIONS.core.approxToolCount).toBe('40');
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('42');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('43');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('49');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('50');
   });
 });

--- a/tests/unit/pcb-constraints/pcb-constraints.test.ts
+++ b/tests/unit/pcb-constraints/pcb-constraints.test.ts
@@ -181,6 +181,137 @@ describe('warnings', () => {
   });
 });
 
+// ── Production review rules ────────────────────────────────────────────────
+
+describe('production review rules', () => {
+  it('rejects missing drill files', () => {
+    const result = validatePcbConstraints(makeInput({ hasDrillFile: false }));
+    const err = result.errors.find((e) => e.code === 'PCB_DRILL_FILE_MISSING');
+    expect(err).toBeDefined();
+    expect(err!.remediationHint).toContain('NC drill');
+  });
+
+  it('rejects copper-to-edge clearance violations', () => {
+    const result = validatePcbConstraints(
+      makeInput({ minCopperToEdgeMm: 0.1, copperToEdgeViolationCount: 2 }),
+    );
+    const err = result.errors.find((e) => e.code === 'PCB_COPPER_EDGE_CLEARANCE');
+    expect(err).toBeDefined();
+    expect(err!.details?.recommendedMinimumMm).toBe(0.25);
+  });
+
+  it('warns for drill and annular-ring manufacturability risk', () => {
+    const result = validatePcbConstraints(makeInput({ minDrillMm: 0.15, minAnnularRingMm: 0.05 }));
+    expect(result.warnings.some((w) => w.code === 'PCB_DRILL_TOO_SMALL')).toBe(true);
+    expect(result.warnings.some((w) => w.code === 'PCB_ANNULAR_RING_TOO_SMALL')).toBe(true);
+  });
+
+  it('warns for soldermask slivers and silkscreen over pads', () => {
+    const result = validatePcbConstraints(
+      makeInput({
+        minSolderMaskSliverMm: 0.05,
+        solderMaskSliverViolationCount: 3,
+        silkscreenOverPadCount: 2,
+      }),
+    );
+    expect(result.warnings.some((w) => w.code === 'PCB_SOLDERMASK_SLIVER')).toBe(true);
+    expect(result.warnings.some((w) => w.code === 'PCB_SILKSCREEN_OVER_PAD')).toBe(true);
+  });
+
+  it('warns for missing SMT fiducials and tooling holes', () => {
+    const result = validatePcbConstraints(
+      makeInput({ smtComponentCount: 24, fiducialCount: 1, toolingHoleCount: 0 }),
+    );
+    expect(result.warnings.some((w) => w.code === 'PCB_FIDUCIAL_REQUIRED')).toBe(true);
+    expect(result.warnings.some((w) => w.code === 'PCB_TOOLING_HOLE_MISSING')).toBe(true);
+  });
+
+  it('warns for missing polarity marks and component spacing violations', () => {
+    const result = validatePcbConstraints(
+      makeInput({
+        polarizedComponentCount: 6,
+        polarityMarkCount: 4,
+        componentSpacingViolationCount: 2,
+      }),
+    );
+    expect(result.warnings.some((w) => w.code === 'PCB_POLARITY_MARK_MISSING')).toBe(true);
+    expect(result.warnings.some((w) => w.code === 'PCB_COMPONENT_SPACING_VIOLATION')).toBe(true);
+  });
+
+  it('warns when critical nets lack testpoint coverage', () => {
+    const result = validatePcbConstraints(
+      makeInput({
+        criticalNetNames: ['GND', '3V3', 'RESET', 'SWDIO', 'SWCLK'],
+        testPointNets: ['GND', '3V3'],
+      }),
+    );
+    const warn = result.warnings.find((w) => w.code === 'PCB_TESTPOINT_COVERAGE_LOW');
+    expect(warn).toBeDefined();
+    expect(warn!.details?.missingCriticalNets).toEqual(['RESET', 'SWDIO', 'SWCLK']);
+  });
+
+  it('rejects missing programming/debug header when required', () => {
+    const result = validatePcbConstraints(
+      makeInput({ requiresProgrammingHeader: true, hasProgrammingHeader: false }),
+    );
+    const err = result.errors.find((e) => e.code === 'PCB_PROGRAMMING_HEADER_MISSING');
+    expect(err).toBeDefined();
+    expect(err!.severity).toBe('error');
+  });
+
+  it('warns when fabrication notes are missing', () => {
+    const result = validatePcbConstraints(makeInput({ hasFabricationNotes: false }));
+    const warn = result.warnings.find((w) => w.code === 'PCB_FAB_NOTES_MISSING');
+    expect(warn).toBeDefined();
+  });
+
+  it('passes production review false-positive control for complete production data', () => {
+    const result = validatePcbConstraints(
+      makeInput({
+        hasDrillFile: true,
+        minCopperToEdgeMm: 0.35,
+        copperToEdgeViolationCount: 0,
+        minDrillMm: 0.3,
+        minAnnularRingMm: 0.15,
+        minSolderMaskSliverMm: 0.12,
+        solderMaskSliverViolationCount: 0,
+        silkscreenOverPadCount: 0,
+        smtComponentCount: 12,
+        fiducialCount: 3,
+        toolingHoleCount: 2,
+        polarizedComponentCount: 4,
+        polarityMarkCount: 4,
+        componentSpacingViolationCount: 0,
+        criticalNetNames: ['GND', '3V3', 'RESET', 'SWDIO', 'SWCLK'],
+        testPointNets: ['GND', '3V3', 'RESET', 'SWDIO', 'SWCLK'],
+        requiresProgrammingHeader: true,
+        hasProgrammingHeader: true,
+        hasFabricationNotes: true,
+      }),
+    );
+
+    expect(result.valid).toBe(true);
+    expect(
+      [...result.errors, ...result.warnings].filter((issue) =>
+        [
+          'PCB_DRILL_FILE_MISSING',
+          'PCB_COPPER_EDGE_CLEARANCE',
+          'PCB_DRILL_TOO_SMALL',
+          'PCB_ANNULAR_RING_TOO_SMALL',
+          'PCB_SOLDERMASK_SLIVER',
+          'PCB_SILKSCREEN_OVER_PAD',
+          'PCB_TOOLING_HOLE_MISSING',
+          'PCB_POLARITY_MARK_MISSING',
+          'PCB_COMPONENT_SPACING_VIOLATION',
+          'PCB_TESTPOINT_COVERAGE_LOW',
+          'PCB_PROGRAMMING_HEADER_MISSING',
+          'PCB_FAB_NOTES_MISSING',
+        ].includes(issue.code),
+      ),
+    ).toEqual([]);
+  });
+});
+
 // ── Summary ────────────────────────────────────────────────────────────────
 
 describe('validation summary', () => {
@@ -291,6 +422,13 @@ describe('fromPcbIntent', () => {
       manufacturingProcess: 'standard',
       quantity: 100,
       highVoltage: false,
+      hasDrillFile: true,
+      minCopperToEdgeMm: 0.35,
+      criticalNetNames: ['GND', '3V3'],
+      testPointNets: ['GND', '3V3'],
+      hasProgrammingHeader: true,
+      requiresProgrammingHeader: true,
+      hasFabricationNotes: true,
     };
     const input = fromPcbIntent(intent as Parameters<typeof fromPcbIntent>[0]);
     expect(input.hasOutline).toBe(true);
@@ -305,6 +443,12 @@ describe('fromPcbIntent', () => {
     expect(input.manufacturingProcess).toBe('standard');
     expect(input.hasQuantity).toBe(true);
     expect(input.hasHighVoltage).toBe(false);
+    expect(input.hasDrillFile).toBe(true);
+    expect(input.minCopperToEdgeMm).toBe(0.35);
+    expect(input.criticalNetNames).toEqual(['GND', '3V3']);
+    expect(input.hasProgrammingHeader).toBe(true);
+    expect(input.requiresProgrammingHeader).toBe(true);
+    expect(input.hasFabricationNotes).toBe(true);
   });
 
   it('converts highVoltage flag', () => {
@@ -330,6 +474,18 @@ describe('PcbConstraintCodeMap', () => {
       'NO_MOUNTING_HOLES',
       'NO_LAYER_STACK',
       'MANUFACTURING_OPTIONS_WARNING',
+      'DRILL_FILE_MISSING',
+      'COPPER_EDGE_CLEARANCE',
+      'DRILL_TOO_SMALL',
+      'ANNULAR_RING_TOO_SMALL',
+      'SOLDERMASK_SLIVER',
+      'SILKSCREEN_OVER_PAD',
+      'TOOLING_HOLE_MISSING',
+      'POLARITY_MARK_MISSING',
+      'COMPONENT_SPACING_VIOLATION',
+      'TESTPOINT_COVERAGE_LOW',
+      'PROGRAMMING_HEADER_MISSING',
+      'FAB_NOTES_MISSING',
     ];
     for (const c of codes) {
       expect(PcbConstraintCodeMap[c as keyof typeof PcbConstraintCodeMap]).toBeDefined();

--- a/tests/unit/tools/export.test.ts
+++ b/tests/unit/tools/export.test.ts
@@ -35,6 +35,73 @@ describe('Export Tools', () => {
     };
   });
 
+  it('easyeda_export_gerbers warns with production review findings but still exports in warn mode', async () => {
+    const tool = registry.get('easyeda_export_gerbers');
+    expect(tool).toBeDefined();
+
+    bridgeCall.mockResolvedValue({ artifactPath: 'artifacts/gerbers.zip', fileCount: 12 });
+
+    const result = await tool?.handler(context, {
+      projectId: 'proj-123',
+      productionReview: {
+        mode: 'warn',
+        boardData: {
+          hasOutline: true,
+          hasLayerStack: true,
+          hasNetClasses: true,
+          hasClearanceRules: true,
+          hasKeepoutAreas: true,
+          hasPlacementZones: true,
+          hasFiducials: true,
+          mountingHoleCount: 4,
+          manufacturingProcess: 'standard',
+          hasQuantity: true,
+          hasDrillFile: false,
+        },
+      },
+    });
+
+    expect(bridgeCall).toHaveBeenCalledWith('board.exportGerbers', {
+      projectId: 'proj-123',
+      drillFormat: undefined,
+      excludeLayer: undefined,
+      ledPanel: undefined,
+    });
+    expect(result?.exported).toBe(true);
+    expect(result?.production_review?.passed).toBe(false);
+    expect(result?.production_review?.errors[0].code).toBe('PCB_DRILL_FILE_MISSING');
+  });
+
+  it('easyeda_export_gerbers blocks before bridge export when production review is in block mode', async () => {
+    const tool = registry.get('easyeda_export_gerbers');
+    expect(tool).toBeDefined();
+
+    const result = await tool?.handler(context, {
+      projectId: 'proj-123',
+      productionReview: {
+        mode: 'block',
+        boardData: {
+          hasOutline: true,
+          hasLayerStack: true,
+          hasNetClasses: true,
+          hasClearanceRules: true,
+          hasKeepoutAreas: true,
+          hasPlacementZones: true,
+          hasFiducials: true,
+          mountingHoleCount: 4,
+          manufacturingProcess: 'standard',
+          hasQuantity: true,
+          hasDrillFile: false,
+        },
+      },
+    });
+
+    expect(bridgeCall).not.toHaveBeenCalled();
+    expect(result?.exported).toBe(false);
+    expect(result?.blocked_by_production_review).toBe(true);
+    expect(result?.production_review?.blocked).toBe(true);
+  });
+
   it('easyeda_export_pick_place should call correct bridge method and return result', async () => {
     const tool = registry.get('easyeda_export_pick_place');
     expect(tool).toBeDefined();

--- a/tests/unit/tools/pcb-constraints.test.ts
+++ b/tests/unit/tools/pcb-constraints.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ToolRegistry } from '../../../src/tools/registry.js';
+import { type ToolContext } from '../../../src/tools/types.js';
+import { registerPcbConstraintTools } from '../../../src/tools/L1_pcb_constraints.js';
+import { EnvSchema } from '../../../src/config/env.js';
+
+describe('PCB constraint tools', () => {
+  let registry: ToolRegistry;
+  let context: ToolContext;
+  let bridgeCall: ReturnType<
+    typeof vi.fn<(method: string, params?: unknown, opts?: unknown) => Promise<unknown>>
+  >;
+
+  beforeEach(() => {
+    registry = new ToolRegistry();
+    const config = EnvSchema.parse({ NODE_ENV: 'test' });
+    registerPcbConstraintTools(registry, config);
+
+    bridgeCall = vi.fn();
+    context = {
+      profile: 'core',
+      bridge: {
+        connected: true,
+        call: bridgeCall,
+      },
+      config: {
+        bridgeTimeoutMs: 1000,
+        artifactDir: '.easyeda-mcp-pro/artifacts',
+        bridgeHost: '127.0.0.1',
+        bridgePort: 49620,
+      },
+      vendors: {
+        lcsc: null,
+        jlcpcb: null,
+        mouser: null,
+        digikey: null,
+      },
+    };
+  });
+
+  it('registers production review tool', () => {
+    expect(registry.get('easyeda_pcb_constraint_check')).toBeDefined();
+    expect(registry.get('easyeda_pcb_constraint_report')).toBeDefined();
+    expect(registry.get('easyeda_pcb_production_review')).toBeDefined();
+  });
+
+  it('easyeda_pcb_production_review returns severity-ranked production findings', async () => {
+    const tool = registry.get('easyeda_pcb_production_review');
+    expect(tool).toBeDefined();
+
+    const result = await tool?.handler(context, {
+      projectId: 'pcb-prod-1',
+      gateMode: 'warn',
+      boardData: {
+        widthMm: 60,
+        heightMm: 40,
+        layerCount: 2,
+        hasOutline: true,
+        mountingHoleCount: 4,
+        hasLayerStack: true,
+        hasNetClasses: true,
+        hasClearanceRules: true,
+        hasKeepoutAreas: true,
+        hasPlacementZones: true,
+        hasFiducials: true,
+        hasTestPads: true,
+        hasHighVoltage: false,
+        manufacturingProcess: 'standard',
+        hasQuantity: true,
+        hasDrillFile: false,
+        minCopperToEdgeMm: 0.1,
+        criticalNetNames: ['GND', '3V3', 'RESET'],
+        testPointNets: ['GND'],
+      },
+    });
+
+    expect(bridgeCall).not.toHaveBeenCalled();
+    expect(result?.project_id).toBe('pcb-prod-1');
+    expect(result?.passed).toBe(false);
+    expect(result?.blocked).toBe(false);
+    expect(result?.severity_counts.errors).toBeGreaterThanOrEqual(2);
+    expect(result?.errors.map((e: { code: string }) => e.code)).toEqual(
+      expect.arrayContaining(['PCB_DRILL_FILE_MISSING', 'PCB_COPPER_EDGE_CLEARANCE']),
+    );
+    expect(
+      result?.warnings.some((w: { code: string }) => w.code === 'PCB_TESTPOINT_COVERAGE_LOW'),
+    ).toBe(true);
+  });
+
+  it('easyeda_pcb_production_review blocks in block mode when errors exist', async () => {
+    const tool = registry.get('easyeda_pcb_production_review');
+    const result = await tool?.handler(context, {
+      projectId: 'pcb-prod-2',
+      gateMode: 'block',
+      boardData: {
+        hasOutline: true,
+        hasLayerStack: true,
+        hasNetClasses: true,
+        hasClearanceRules: true,
+        hasKeepoutAreas: true,
+        hasPlacementZones: true,
+        hasFiducials: true,
+        mountingHoleCount: 4,
+        manufacturingProcess: 'standard',
+        hasQuantity: true,
+        hasDrillFile: false,
+      },
+    });
+
+    expect(result?.blocked).toBe(true);
+    expect(result?.gate_mode).toBe('block');
+  });
+});


### PR DESCRIPTION
Implements #33 PCB production review rules.

Changes:
- Extends PCB constraint validation from 12 to 23 rules.
- Adds production review checks for:
  - missing NC drill files,
  - copper-to-edge clearance,
  - small drill diameter,
  - small annular ring,
  - soldermask slivers,
  - silkscreen over exposed pads,
  - SMT fiducials and tooling holes,
  - polarity/orientation marks,
  - component spacing/courtyard violations,
  - critical-net testpoint coverage,
  - missing programming/debug header,
  - missing fabrication notes.
- Adds `easyeda_pcb_production_review` as a read-only MCP tool with severity-ranked DFM/DFA/DFT output.
- Adds optional production review gate to `easyeda_export_gerbers`:
  - `warn` mode returns findings but still exports,
  - `block` mode stops export before bridge call when production errors exist,
  - `off` mode preserves legacy behavior.
- Extends `PcbConstraintInput` with fabrication/assembly/testability fields.
- Updates PCB constraints docs and generated tools reference.
- Adds false-positive controls for complete production-ready data.

Verification:
- pnpm audit --audit-level low
- pnpm peers check
- pnpm format:check
- pnpm typecheck
- pnpm typecheck:extension
- pnpm lint
- pnpm lint:tools
- pnpm verify:tool-coverage
- pnpm test
- pnpm test:coverage
- pnpm build
- pnpm check:metadata
- pnpm build:extension
- pnpm verify:extension
- pnpm generate:tools-doc
- pnpm docs:build
- git diff --check

Local result: 43 test files / 601 tests passed.
