### PR TITLE
feat: add layout planning tools

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -30,6 +30,8 @@ export default defineConfig({
           { text: 'BOM Sourcing', link: '/examples/bom-sourcing' },
           { text: 'Manufacturing Review', link: '/examples/manufacturing-review' },
           { text: 'Power Tree Analyzer', link: '/power-tree' },
+          { text: 'High-Level PCB Layout', link: '/high-level-pcb-layout' },
+          { text: 'High-Level PCB Layout', link: '/high-level-pcb-layout' },
           { text: 'Claude Prompts', link: '/examples/claude-prompts' },
         ],
       },

--- a/docs/high-level-pcb-layout.md
+++ b/docs/high-level-pcb-layout.md
@@ -1,0 +1,144 @@
+# High-Level PCB Layout Tools
+
+High-level PCB layout tools turn agent intent into previewable, constraint-checked layout operations before any PCB mutation is applied.
+
+These tools sit above the primitive PCB operations such as component placement and track creation. They are intended for safer agent workflows where a plan must be reviewed before write operations run.
+
+## Tools
+
+```text
+easyeda_pcb_place_component_group
+easyeda_pcb_route_path_plan
+```
+
+Both tools are high-risk write-capable tools, but they support a preview-first workflow:
+
+- `mode: 'preview'` creates a plan and does not call the EasyEDA bridge.
+- `mode: 'apply'` applies the generated operations only when `confirmWrite: true` is present.
+- Constraint errors block apply before any bridge call.
+- Every output includes a transaction id, operations, issues, and a human-readable summary.
+
+## Component group placement
+
+`easyeda_pcb_place_component_group` places multiple components on a grid starting from an anchor point.
+
+It validates:
+
+- board dimensions;
+- component dimensions and references;
+- board boundary fit;
+- keepout overlap;
+- spacing/collision risk.
+
+Preview example:
+
+```json
+{
+  "mode": "preview",
+  "board": { "widthMm": 60, "heightMm": 40 },
+  "anchor": { "x": 10, "y": 10 },
+  "columns": 2,
+  "spacingMm": 4,
+  "components": [
+    { "ref": "U1", "primitiveId": "p-u1", "widthMm": 6, "heightMm": 6 },
+    { "ref": "C1", "primitiveId": "p-c1", "widthMm": 2, "heightMm": 1.2 }
+  ]
+}
+```
+
+Apply example:
+
+```json
+{
+  "mode": "apply",
+  "confirmWrite": true,
+  "board": { "widthMm": 60, "heightMm": 40 },
+  "anchor": { "x": 10, "y": 10 },
+  "components": [{ "ref": "U1", "primitiveId": "p-u1", "widthMm": 6, "heightMm": 6 }]
+}
+```
+
+If a component would be outside the board or inside a keepout, the tool returns `blocked: true` and does not call the bridge.
+
+## Route path planning
+
+`easyeda_pcb_route_path_plan` creates a constrained route path for one net from a waypoint list.
+
+It validates:
+
+- at least two waypoints;
+- positive trace width;
+- minimum trace width constraint;
+- optional maximum path length;
+- optional board boundary;
+- optional keepout crossing.
+
+Preview example:
+
+```json
+{
+  "mode": "preview",
+  "netName": "GND",
+  "layer": 1,
+  "widthMm": 0.4,
+  "board": { "widthMm": 60, "heightMm": 40 },
+  "waypoints": [
+    { "x": 5, "y": 5 },
+    { "x": 15, "y": 5 },
+    { "x": 15, "y": 15 }
+  ]
+}
+```
+
+Apply example:
+
+```json
+{
+  "mode": "apply",
+  "confirmWrite": true,
+  "netName": "GND",
+  "layer": 1,
+  "widthMm": 0.4,
+  "waypoints": [
+    { "x": 0, "y": 0 },
+    { "x": 10, "y": 0 }
+  ]
+}
+```
+
+If a route leaves the board, crosses a keepout, or violates minimum width, apply is blocked before `pcb.addTrack` is called.
+
+## Output shape
+
+Both tools return:
+
+```typescript
+{
+  success: boolean;
+  project_id: string;
+  transaction_id: string;
+  mode: 'preview' | 'apply';
+  applied: boolean;
+  blocked: boolean;
+  operations: Array<{ method: string; params: Record<string, unknown> }>;
+  issues: Array<{
+    code: string;
+    severity: 'error' | 'warning' | 'info';
+    message: string;
+    remediationHint: string;
+    details?: Record<string, unknown>;
+  }>;
+  summary: string;
+}
+```
+
+## Safety model
+
+These tools follow the same safety policy as primitive PCB writes:
+
+1. Generate a previewable plan first.
+2. Review operations and issues.
+3. Apply only with `mode: 'apply'` and `confirmWrite: true`.
+4. Run read-only DRC/ERC, production review, and export checks after applying.
+
+The tools are intentionally conservative. When geometry is ambiguous, they prefer blocking the plan over applying potentially unsafe layout changes.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -41,7 +41,9 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_pcb_delete_component`          | `full`  | `high`   | Delete components from the PCB layout by their primitive IDs.                                                                                                                                                                                                                                                 |
 | `easyeda_pcb_modify_component`          | `full`  | `high`   | Modify component properties in the PCB layout.                                                                                                                                                                                                                                                                |
 | `easyeda_pcb_place_component`           | `full`  | `high`   | Place a component footprint on the active PCB layout.                                                                                                                                                                                                                                                         |
+| `easyeda_pcb_place_component_group`     | `full`  | `high`   | Create a high-level, constraint-checked placement plan for a group of components and optionally apply it after explicit confirmation.                                                                                                                                                                         |
 | `easyeda_pcb_production_review`         | `core`  | `medium` | Run fabrication, assembly, and testability production review rules for PCB handoff. Reports severity-ranked DFM/DFA/DFT findings with actionable remediation before Gerber export or manufacturing submission.                                                                                                |
+| `easyeda_pcb_route_path_plan`           | `full`  | `high`   | Create a high-level, constraint-checked route path plan for one net and optionally apply it after explicit confirmation.                                                                                                                                                                                      |
 | `easyeda_power_tree_analyze`            | `core`  | `medium` | Analyze supply sources, regulators, loads, protection, bulk capacitance, current budget, dropout, and regulator thermal risk. Returns machine-readable issues and a human-readable summary.                                                                                                                   |
 | `easyeda_project_save`                  | `core`  | `medium` | Explicitly save the current EasyEDA Pro project. This ensures all netlist changes, net flags, pin connections, and other mutations are persisted to the project file. Save is never implicit — the caller must explicitly request it. Requires confirmWrite.                                                  |
 | `easyeda_rule_check_summary`            | `core`  | `low`    | Get a summary of all design and electrical rule check results for the project.                                                                                                                                                                                                                                |
@@ -1061,6 +1063,51 @@ Returns a JSON object matching the schema:
 
 ---
 
+## `easyeda_pcb_place_component_group`
+
+**Profile:** `full` | **Risk Level:** `high`
+
+> Create a high-level, constraint-checked placement plan for a group of components and optionally apply it after explicit confirmation.
+
+### Input Parameters
+
+| Parameter      | Type  | Required | Description |
+| -------------- | ----- | -------- | ----------- |
+| `projectId`    | `any` | No       |             |
+| `mode`         | `any` | Yes      |             |
+| `board`        | `any` | Yes      |             |
+| `anchor`       | `any` | Yes      |             |
+| `columns`      | `any` | No       |             |
+| `spacingMm`    | `any` | No       |             |
+| `layer`        | `any` | Yes      |             |
+| `minSpacingMm` | `any` | No       |             |
+| `components`   | `any` | Yes      |             |
+| `keepouts`     | `any` | No       |             |
+| `confirmWrite` | `any` | No       |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  success: any;
+  project_id: any;
+  transaction_id: any;
+  mode: any;
+  applied: any;
+  blocked: any;
+  placements: any;
+  operations: any;
+  apply_results: any;
+  issues: any;
+  summary: any;
+  error: any;
+}
+```
+
+---
+
 ## `easyeda_pcb_production_review`
 
 **Profile:** `core` | **Risk Level:** `medium`
@@ -1090,6 +1137,54 @@ Returns a JSON object matching the schema:
   warnings: any;
   summary: any;
   not_available: any;
+}
+```
+
+---
+
+## `easyeda_pcb_route_path_plan`
+
+**Profile:** `full` | **Risk Level:** `high`
+
+> Create a high-level, constraint-checked route path plan for one net and optionally apply it after explicit confirmation.
+
+### Input Parameters
+
+| Parameter      | Type  | Required | Description |
+| -------------- | ----- | -------- | ----------- |
+| `projectId`    | `any` | No       |             |
+| `mode`         | `any` | Yes      |             |
+| `board`        | `any` | No       |             |
+| `netName`      | `any` | Yes      |             |
+| `layer`        | `any` | Yes      |             |
+| `widthMm`      | `any` | Yes      |             |
+| `waypoints`    | `any` | Yes      |             |
+| `keepouts`     | `any` | No       |             |
+| `maxLengthMm`  | `any` | No       |             |
+| `minWidthMm`   | `any` | No       |             |
+| `confirmWrite` | `any` | No       |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  success: any;
+  project_id: any;
+  transaction_id: any;
+  mode: any;
+  applied: any;
+  blocked: any;
+  net_name: any;
+  layer: any;
+  width_mm: any;
+  path_length_mm: any;
+  operations: any;
+  apply_results: any;
+  issues: any;
+  summary: any;
+  error: any;
 }
 ```
 

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -29,7 +29,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls for full runtime control without raw JavaScript execution',
-    approxToolCount: '51',
+    approxToolCount: '53',
     isDefault: false,
   },
   dev: {
@@ -37,14 +37,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '55',
+    approxToolCount: '57',
     isDefault: false,
   },
   experimental: {
     name: 'experimental',
     label: 'Experimental',
     description: 'MCP Apps, Tasks, simulation, autorouter, AI action plans',
-    approxToolCount: '53',
+    approxToolCount: '55',
     isDefault: false,
   },
 };

--- a/src/pcb-layout/index.ts
+++ b/src/pcb-layout/index.ts
@@ -1,0 +1,2 @@
+export { planComponentGroupPlacement, planRoutePath } from './planner.js';
+export type * from './types.js';

--- a/src/pcb-layout/planner.ts
+++ b/src/pcb-layout/planner.ts
@@ -1,0 +1,358 @@
+import { createHash } from 'node:crypto';
+import type {
+  BoardBox,
+  ComponentGroupPlacementInput,
+  ComponentGroupPlacementPlan,
+  LayoutIssue,
+  PlannedComponentPlacement,
+  PointMm,
+  RectMm,
+  RoutePathInput,
+  RoutePathPlan,
+} from './types.js';
+
+function txId(prefix: string, payload: unknown): string {
+  return `${prefix}_${createHash('sha256').update(JSON.stringify(payload)).digest('hex').slice(0, 16)}`;
+}
+
+function issue(
+  code: LayoutIssue['code'],
+  severity: LayoutIssue['severity'],
+  message: string,
+  remediationHint: string,
+  details?: Record<string, unknown>,
+): LayoutIssue {
+  return { code, severity, message, remediationHint, details };
+}
+
+function rectsOverlap(a: RectMm, b: RectMm): boolean {
+  return (
+    a.x < b.x + b.widthMm &&
+    a.x + a.widthMm > b.x &&
+    a.y < b.y + b.heightMm &&
+    a.y + a.heightMm > b.y
+  );
+}
+
+function pointInsideRect(point: PointMm, rect: RectMm): boolean {
+  return (
+    point.x >= rect.x &&
+    point.x <= rect.x + rect.widthMm &&
+    point.y >= rect.y &&
+    point.y <= rect.y + rect.heightMm
+  );
+}
+
+function rectInsideBoard(rect: RectMm, board: BoardBox): boolean {
+  return (
+    rect.x >= 0 &&
+    rect.y >= 0 &&
+    rect.x + rect.widthMm <= board.widthMm &&
+    rect.y + rect.heightMm <= board.heightMm
+  );
+}
+
+function pointInsideBoard(point: PointMm, board: BoardBox): boolean {
+  return point.x >= 0 && point.y >= 0 && point.x <= board.widthMm && point.y <= board.heightMm;
+}
+
+function inflate(rect: RectMm, amount: number): RectMm {
+  return {
+    x: rect.x - amount,
+    y: rect.y - amount,
+    widthMm: rect.widthMm + amount * 2,
+    heightMm: rect.heightMm + amount * 2,
+    name: rect.name,
+  };
+}
+
+function distance(a: PointMm, b: PointMm): number {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function routeLength(points: PointMm[]): number {
+  let total = 0;
+  for (let index = 1; index < points.length; index += 1) {
+    const previous = points[index - 1];
+    const current = points[index];
+    if (!previous || !current) continue;
+    total += distance(previous, current);
+  }
+  return total;
+}
+
+function segmentIntersectsRect(a: PointMm, b: PointMm, rect: RectMm): boolean {
+  if (pointInsideRect(a, rect) || pointInsideRect(b, rect)) return true;
+  const steps = Math.max(2, Math.ceil(distance(a, b) / 0.5));
+  for (let i = 1; i < steps; i += 1) {
+    const t = i / steps;
+    const point = { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
+    if (pointInsideRect(point, rect)) return true;
+  }
+  return false;
+}
+
+function invalidBoard(board: BoardBox): boolean {
+  return board.widthMm <= 0 || board.heightMm <= 0;
+}
+
+/** Create a preview/apply plan for placing a group of components on a grid. */
+export function planComponentGroupPlacement(
+  input: ComponentGroupPlacementInput,
+): ComponentGroupPlacementPlan {
+  const mode = input.mode ?? 'preview';
+  const layer = input.layer ?? 1;
+  const columns = Math.max(1, input.columns ?? input.components.length);
+  const spacing = input.spacingMm ?? 1.5;
+  const minSpacing = input.minSpacingMm ?? 0.25;
+  const issues: LayoutIssue[] = [];
+  const placements: PlannedComponentPlacement[] = [];
+
+  if (invalidBoard(input.board)) {
+    issues.push(
+      issue(
+        'LAYOUT_INVALID_BOARD',
+        'error',
+        'Board dimensions must be positive',
+        'Provide valid board width and height before planning placement.',
+        { board: input.board },
+      ),
+    );
+  }
+
+  input.components.forEach((component, index) => {
+    if (!component.ref || component.widthMm <= 0 || component.heightMm <= 0) {
+      issues.push(
+        issue(
+          'LAYOUT_INVALID_COMPONENT',
+          'error',
+          `Component ${component.ref || index} has invalid dimensions or reference`,
+          'Provide component ref, width, and height in millimeters.',
+          { component },
+        ),
+      );
+      return;
+    }
+
+    const col = index % columns;
+    const row = Math.floor(index / columns);
+    const x = input.anchor.x + col * (component.widthMm + spacing);
+    const y = input.anchor.y + row * (component.heightMm + spacing);
+    const bbox = {
+      x: x - component.widthMm / 2,
+      y: y - component.heightMm / 2,
+      widthMm: component.widthMm,
+      heightMm: component.heightMm,
+      name: component.ref,
+    };
+    const placement = {
+      ref: component.ref,
+      primitiveId: component.primitiveId,
+      footprint: component.footprint,
+      x,
+      y,
+      rotation: component.rotation ?? 0,
+      layer,
+      widthMm: component.widthMm,
+      heightMm: component.heightMm,
+      bbox,
+    };
+
+    if (!rectInsideBoard(bbox, input.board)) {
+      issues.push(
+        issue(
+          'LAYOUT_COMPONENT_OUTSIDE_BOARD',
+          'error',
+          `Component ${component.ref} would be outside the board`,
+          'Move the anchor, reduce spacing, increase board size, or reduce the component group size.',
+          { ref: component.ref, bbox, board: input.board },
+        ),
+      );
+    }
+
+    for (const keepout of input.keepouts ?? []) {
+      if (rectsOverlap(bbox, keepout)) {
+        issues.push(
+          issue(
+            'LAYOUT_COMPONENT_IN_KEEPOUT',
+            'error',
+            `Component ${component.ref} overlaps keepout ${keepout.name ?? ''}`.trim(),
+            'Move the component group away from keepout regions.',
+            { ref: component.ref, keepout, bbox },
+          ),
+        );
+      }
+    }
+
+    for (const previous of placements) {
+      if (rectsOverlap(inflate(previous.bbox, minSpacing), inflate(bbox, minSpacing))) {
+        issues.push(
+          issue(
+            'LAYOUT_COMPONENT_COLLISION',
+            'error',
+            `Component ${component.ref} collides with ${previous.ref}`,
+            'Increase placement spacing or change grid columns/anchor.',
+            { ref: component.ref, otherRef: previous.ref, minSpacingMm: minSpacing },
+          ),
+        );
+      }
+    }
+
+    placements.push(placement);
+  });
+
+  const operations = placements.map((placement) => ({
+    method: placement.primitiveId ? 'pcb.modifyComponent' : 'pcb.placeComponent',
+    params: placement.primitiveId
+      ? {
+          primitiveId: placement.primitiveId,
+          property: {
+            x: placement.x,
+            y: placement.y,
+            rotation: placement.rotation,
+            layer: placement.layer,
+          },
+        }
+      : {
+          footprint: placement.footprint ?? placement.ref,
+          x: placement.x,
+          y: placement.y,
+          rotation: placement.rotation,
+          layer: placement.layer,
+        },
+  }));
+  const blocked = issues.some((i) => i.severity === 'error');
+
+  return {
+    transactionId: txId('layout_place', { input, placements }),
+    projectId: input.projectId ?? '',
+    mode,
+    applied: false,
+    blocked,
+    placements,
+    operations,
+    issues,
+    summary: blocked
+      ? `Placement plan blocked by ${issues.filter((i) => i.severity === 'error').length} error(s).`
+      : `Placement plan ready for ${placements.length} component(s).`,
+  };
+}
+
+/** Create a preview/apply plan for a constrained routed path. */
+export function planRoutePath(input: RoutePathInput): RoutePathPlan {
+  const mode = input.mode ?? 'preview';
+  const issues: LayoutIssue[] = [];
+  const length = routeLength(input.waypoints);
+
+  if (input.waypoints.length < 2) {
+    issues.push(
+      issue(
+        'LAYOUT_PATH_TOO_SHORT',
+        'error',
+        'Route path requires at least two waypoints',
+        'Provide start and end waypoints for the route path.',
+        { waypointCount: input.waypoints.length },
+      ),
+    );
+  }
+
+  if (input.widthMm <= 0) {
+    issues.push(
+      issue(
+        'LAYOUT_TRACE_WIDTH_TOO_SMALL',
+        'error',
+        'Trace width must be positive',
+        'Provide a positive trace width in millimeters.',
+        { widthMm: input.widthMm },
+      ),
+    );
+  } else if (input.minWidthMm !== undefined && input.widthMm < input.minWidthMm) {
+    issues.push(
+      issue(
+        'LAYOUT_TRACE_WIDTH_TOO_SMALL',
+        'error',
+        `Trace width ${input.widthMm}mm is below required ${input.minWidthMm}mm`,
+        'Increase trace width or lower the constraint only after electrical/thermal review.',
+        { widthMm: input.widthMm, minWidthMm: input.minWidthMm },
+      ),
+    );
+  }
+
+  if (input.maxLengthMm !== undefined && length > input.maxLengthMm) {
+    issues.push(
+      issue(
+        'LAYOUT_PATH_TOO_LONG',
+        'warning',
+        `Route length ${Number(length.toFixed(3))}mm exceeds maximum ${input.maxLengthMm}mm`,
+        'Shorten the route or relax the maximum length constraint if acceptable.',
+        { pathLengthMm: length, maxLengthMm: input.maxLengthMm },
+      ),
+    );
+  }
+
+  if (input.board) {
+    for (const point of input.waypoints) {
+      if (!pointInsideBoard(point, input.board)) {
+        issues.push(
+          issue(
+            'LAYOUT_PATH_OUTSIDE_BOARD',
+            'error',
+            'Route waypoint is outside the board',
+            'Move all route waypoints inside the board outline.',
+            { point, board: input.board },
+          ),
+        );
+      }
+    }
+  }
+
+  for (let i = 1; i < input.waypoints.length; i += 1) {
+    const a = input.waypoints[i - 1];
+    const b = input.waypoints[i];
+    if (!a || !b) continue;
+    for (const keepout of input.keepouts ?? []) {
+      if (segmentIntersectsRect(a, b, keepout)) {
+        issues.push(
+          issue(
+            'LAYOUT_PATH_IN_KEEPOUT',
+            'error',
+            `Route crosses keepout ${keepout.name ?? ''}`.trim(),
+            'Add waypoints around keepout regions or change the routing layer.',
+            { keepout, segment: [a, b] },
+          ),
+        );
+      }
+    }
+  }
+
+  const flatPoints = input.waypoints.flatMap((point) => [point.x, point.y]);
+  const operations = [
+    {
+      method: 'pcb.addTrack',
+      params: {
+        points: flatPoints,
+        layer: input.layer,
+        width: input.widthMm,
+        netName: input.netName,
+      },
+    },
+  ];
+  const blocked = issues.some((i) => i.severity === 'error');
+
+  return {
+    transactionId: txId('layout_route', { input, length }),
+    projectId: input.projectId ?? '',
+    mode,
+    applied: false,
+    blocked,
+    netName: input.netName,
+    layer: input.layer,
+    widthMm: input.widthMm,
+    pathLengthMm: Number(length.toFixed(4)),
+    operations,
+    issues,
+    summary: blocked
+      ? `Route plan blocked by ${issues.filter((i) => i.severity === 'error').length} error(s).`
+      : `Route plan ready for net ${input.netName}; length ${Number(length.toFixed(3))}mm.`,
+  };
+}

--- a/src/pcb-layout/types.ts
+++ b/src/pcb-layout/types.ts
@@ -1,0 +1,119 @@
+/** High-level PCB layout planning types. */
+
+export type LayoutExecutionMode = 'preview' | 'apply';
+export type LayoutSeverity = 'error' | 'warning' | 'info';
+export type LayoutIssueCode =
+  | 'LAYOUT_COMPONENT_OUTSIDE_BOARD'
+  | 'LAYOUT_COMPONENT_IN_KEEPOUT'
+  | 'LAYOUT_COMPONENT_COLLISION'
+  | 'LAYOUT_INVALID_COMPONENT'
+  | 'LAYOUT_INVALID_BOARD'
+  | 'LAYOUT_PATH_TOO_SHORT'
+  | 'LAYOUT_PATH_OUTSIDE_BOARD'
+  | 'LAYOUT_PATH_IN_KEEPOUT'
+  | 'LAYOUT_PATH_TOO_LONG'
+  | 'LAYOUT_TRACE_WIDTH_TOO_SMALL';
+
+export interface PointMm {
+  x: number;
+  y: number;
+}
+
+export interface BoardBox {
+  widthMm: number;
+  heightMm: number;
+}
+
+export interface RectMm {
+  x: number;
+  y: number;
+  widthMm: number;
+  heightMm: number;
+  name?: string;
+}
+
+export interface LayoutIssue {
+  code: LayoutIssueCode;
+  severity: LayoutSeverity;
+  message: string;
+  remediationHint: string;
+  details?: Record<string, unknown>;
+}
+
+export interface ComponentPlacementInput {
+  ref: string;
+  primitiveId?: string;
+  footprint?: string;
+  widthMm: number;
+  heightMm: number;
+  rotation?: number;
+  fixed?: boolean;
+}
+
+export interface ComponentGroupPlacementInput {
+  projectId?: string;
+  mode?: LayoutExecutionMode;
+  board: BoardBox;
+  anchor: PointMm;
+  columns?: number;
+  spacingMm?: number;
+  layer?: number;
+  minSpacingMm?: number;
+  components: ComponentPlacementInput[];
+  keepouts?: RectMm[];
+  confirmWrite?: boolean;
+}
+
+export interface PlannedComponentPlacement {
+  ref: string;
+  primitiveId?: string;
+  footprint?: string;
+  x: number;
+  y: number;
+  rotation: number;
+  layer: number;
+  widthMm: number;
+  heightMm: number;
+  bbox: RectMm;
+}
+
+export interface ComponentGroupPlacementPlan {
+  transactionId: string;
+  projectId: string;
+  mode: LayoutExecutionMode;
+  applied: boolean;
+  blocked: boolean;
+  placements: PlannedComponentPlacement[];
+  operations: Array<{ method: string; params: Record<string, unknown> }>;
+  issues: LayoutIssue[];
+  summary: string;
+}
+
+export interface RoutePathInput {
+  projectId?: string;
+  mode?: LayoutExecutionMode;
+  board?: BoardBox;
+  netName: string;
+  layer: number;
+  widthMm: number;
+  waypoints: PointMm[];
+  keepouts?: RectMm[];
+  maxLengthMm?: number;
+  minWidthMm?: number;
+  confirmWrite?: boolean;
+}
+
+export interface RoutePathPlan {
+  transactionId: string;
+  projectId: string;
+  mode: LayoutExecutionMode;
+  applied: boolean;
+  blocked: boolean;
+  netName: string;
+  layer: number;
+  widthMm: number;
+  pathLengthMm: number;
+  operations: Array<{ method: string; params: Record<string, unknown> }>;
+  issues: LayoutIssue[];
+  summary: string;
+}

--- a/src/tools/L1_pcb_write.ts
+++ b/src/tools/L1_pcb_write.ts
@@ -1,11 +1,304 @@
 import { z } from 'zod';
 import { type ToolDefinition, type ToolContext } from './types.js';
 import { type EnvConfig } from '../config/env.js';
+import { planComponentGroupPlacement, planRoutePath } from '../pcb-layout/index.js';
+
+const layoutPointSchema = z.object({ x: z.number(), y: z.number() });
+const layoutBoardSchema = z.object({
+  widthMm: z.number().positive(),
+  heightMm: z.number().positive(),
+});
+const layoutRectSchema = z.object({
+  x: z.number(),
+  y: z.number(),
+  widthMm: z.number().positive(),
+  heightMm: z.number().positive(),
+  name: z.string().optional(),
+});
+const layoutIssueSchema = z.object({
+  code: z.string(),
+  severity: z.enum(['error', 'warning', 'info']),
+  message: z.string(),
+  remediationHint: z.string(),
+  details: z.record(z.string(), z.unknown()).optional(),
+});
+const layoutOperationSchema = z.object({
+  method: z.string(),
+  params: z.record(z.string(), z.unknown()),
+});
+const layoutApplyResultSchema = z.object({
+  method: z.string(),
+  success: z.boolean(),
+  primitiveId: z.string().optional(),
+  error: z.string().optional(),
+});
+
+async function applyLayoutOperations(
+  ctx: ToolContext,
+  operations: Array<{ method: string; params: Record<string, unknown> }>,
+) {
+  const results: Array<{ method: string; success: boolean; primitiveId?: string; error?: string }> =
+    [];
+  for (const operation of operations) {
+    try {
+      const result = await ctx.bridge.call<
+        Record<string, unknown>,
+        { primitiveId?: string; result?: string }
+      >(operation.method, operation.params);
+      const data = result as { primitiveId?: string; result?: string } | string;
+      results.push({
+        method: operation.method,
+        success: true,
+        primitiveId:
+          typeof data === 'string' ? data : (data?.primitiveId ?? data?.result ?? undefined),
+      });
+    } catch (error) {
+      results.push({
+        method: operation.method,
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      break;
+    }
+  }
+  return results;
+}
 
 function registerPcbWriteTools(
   registry: { register: (def: ToolDefinition) => void },
   _config: EnvConfig,
 ) {
+  registry.register({
+    name: 'easyeda_pcb_place_component_group',
+    title: 'Plan or apply grouped PCB component placement',
+    description:
+      'Create a high-level, constraint-checked placement plan for a group of components and optionally apply it after explicit confirmation.',
+    profile: 'full',
+    evidence: ['inferred'],
+    risk: 'high',
+    confirmWrite: true,
+    group: 'pcb-write',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
+    inputSchema: z.object({
+      projectId: z.string().optional(),
+      mode: z.enum(['preview', 'apply']).default('preview'),
+      board: layoutBoardSchema,
+      anchor: layoutPointSchema,
+      columns: z.number().int().positive().optional(),
+      spacingMm: z.number().nonnegative().optional(),
+      layer: z.number().int().default(1),
+      minSpacingMm: z.number().nonnegative().optional(),
+      components: z.array(
+        z.object({
+          ref: z.string(),
+          primitiveId: z.string().optional(),
+          footprint: z.string().optional(),
+          widthMm: z.number().positive(),
+          heightMm: z.number().positive(),
+          rotation: z.number().optional(),
+          fixed: z.boolean().optional(),
+        }),
+      ),
+      keepouts: z.array(layoutRectSchema).optional(),
+      confirmWrite: z.boolean().optional(),
+    }),
+    outputSchema: z.object({
+      success: z.boolean(),
+      project_id: z.string(),
+      transaction_id: z.string(),
+      mode: z.string(),
+      applied: z.boolean(),
+      blocked: z.boolean(),
+      placements: z.array(
+        z.object({
+          ref: z.string(),
+          primitiveId: z.string().optional(),
+          footprint: z.string().optional(),
+          x: z.number(),
+          y: z.number(),
+          rotation: z.number(),
+          layer: z.number(),
+          widthMm: z.number(),
+          heightMm: z.number(),
+          bbox: layoutRectSchema,
+        }),
+      ),
+      operations: z.array(layoutOperationSchema),
+      apply_results: z.array(layoutApplyResultSchema).optional(),
+      issues: z.array(layoutIssueSchema),
+      summary: z.string(),
+      error: z.string().optional(),
+    }),
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const p = params as Parameters<typeof planComponentGroupPlacement>[0];
+      const plan = planComponentGroupPlacement(p);
+      if (p.mode !== 'apply') {
+        return {
+          success: !plan.blocked,
+          project_id: plan.projectId,
+          transaction_id: plan.transactionId,
+          mode: plan.mode,
+          applied: false,
+          blocked: plan.blocked,
+          placements: plan.placements,
+          operations: plan.operations,
+          issues: plan.issues,
+          summary: plan.summary,
+        };
+      }
+      if (plan.blocked) {
+        return {
+          success: false,
+          project_id: plan.projectId,
+          transaction_id: plan.transactionId,
+          mode: plan.mode,
+          applied: false,
+          blocked: true,
+          placements: plan.placements,
+          operations: plan.operations,
+          issues: plan.issues,
+          summary: plan.summary,
+          error: 'Placement plan contains blocking constraint errors.',
+        };
+      }
+      if (p.confirmWrite !== true) {
+        return {
+          success: false,
+          project_id: plan.projectId,
+          transaction_id: plan.transactionId,
+          mode: plan.mode,
+          applied: false,
+          blocked: true,
+          placements: plan.placements,
+          operations: plan.operations,
+          issues: plan.issues,
+          summary: 'Apply blocked because confirmWrite=true was not provided.',
+          error: 'confirmWrite=true is required to apply grouped component placement.',
+        };
+      }
+      const applyResults = await applyLayoutOperations(ctx, plan.operations);
+      const failed = applyResults.some((result) => !result.success);
+      return {
+        success: !failed,
+        project_id: plan.projectId,
+        transaction_id: plan.transactionId,
+        mode: plan.mode,
+        applied: !failed,
+        blocked: false,
+        placements: plan.placements,
+        operations: plan.operations,
+        apply_results: applyResults,
+        issues: plan.issues,
+        summary: failed
+          ? 'Placement apply failed before all operations completed.'
+          : `Applied ${applyResults.length} placement operation(s).`,
+        error: applyResults.find((result) => !result.success)?.error,
+      };
+    },
+  });
+
+  registry.register({
+    name: 'easyeda_pcb_route_path_plan',
+    title: 'Plan or apply constrained PCB route path',
+    description:
+      'Create a high-level, constraint-checked route path plan for one net and optionally apply it after explicit confirmation.',
+    profile: 'full',
+    evidence: ['inferred'],
+    risk: 'high',
+    confirmWrite: true,
+    group: 'pcb-write',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
+    inputSchema: z.object({
+      projectId: z.string().optional(),
+      mode: z.enum(['preview', 'apply']).default('preview'),
+      board: layoutBoardSchema.optional(),
+      netName: z.string(),
+      layer: z.number().int(),
+      widthMm: z.number().positive(),
+      waypoints: z.array(layoutPointSchema),
+      keepouts: z.array(layoutRectSchema).optional(),
+      maxLengthMm: z.number().positive().optional(),
+      minWidthMm: z.number().positive().optional(),
+      confirmWrite: z.boolean().optional(),
+    }),
+    outputSchema: z.object({
+      success: z.boolean(),
+      project_id: z.string(),
+      transaction_id: z.string(),
+      mode: z.string(),
+      applied: z.boolean(),
+      blocked: z.boolean(),
+      net_name: z.string(),
+      layer: z.number(),
+      width_mm: z.number(),
+      path_length_mm: z.number(),
+      operations: z.array(layoutOperationSchema),
+      apply_results: z.array(layoutApplyResultSchema).optional(),
+      issues: z.array(layoutIssueSchema),
+      summary: z.string(),
+      error: z.string().optional(),
+    }),
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const p = params as Parameters<typeof planRoutePath>[0];
+      const plan = planRoutePath(p);
+      const base = {
+        project_id: plan.projectId,
+        transaction_id: plan.transactionId,
+        mode: plan.mode,
+        applied: false,
+        blocked: plan.blocked,
+        net_name: plan.netName,
+        layer: plan.layer,
+        width_mm: plan.widthMm,
+        path_length_mm: plan.pathLengthMm,
+        operations: plan.operations,
+        issues: plan.issues,
+      };
+      if (p.mode !== 'apply') return { success: !plan.blocked, ...base, summary: plan.summary };
+      if (plan.blocked) {
+        return {
+          success: false,
+          ...base,
+          blocked: true,
+          summary: plan.summary,
+          error: 'Route plan contains blocking constraint errors.',
+        };
+      }
+      if (p.confirmWrite !== true) {
+        return {
+          success: false,
+          ...base,
+          blocked: true,
+          summary: 'Apply blocked because confirmWrite=true was not provided.',
+          error: 'confirmWrite=true is required to apply route path plan.',
+        };
+      }
+      const applyResults = await applyLayoutOperations(ctx, plan.operations);
+      const failed = applyResults.some((result) => !result.success);
+      return {
+        success: !failed,
+        ...base,
+        applied: !failed,
+        blocked: false,
+        apply_results: applyResults,
+        summary: failed
+          ? 'Route apply failed before all operations completed.'
+          : `Applied ${applyResults.length} route operation(s).`,
+        error: applyResults.find((result) => !result.success)?.error,
+      };
+    },
+  });
+
   registry.register({
     name: 'easyeda_pcb_place_component',
     title: 'Place component on PCB',

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -47,6 +47,6 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('51');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('53');
   });
 });

--- a/tests/unit/pcb-layout/planner.test.ts
+++ b/tests/unit/pcb-layout/planner.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import { planComponentGroupPlacement, planRoutePath } from '../../../src/pcb-layout/index.js';
+
+describe('pcb layout planner', () => {
+  it('creates a previewable component group plan without errors', () => {
+    const plan = planComponentGroupPlacement({
+      board: { widthMm: 60, heightMm: 40 },
+      anchor: { x: 10, y: 10 },
+      columns: 2,
+      spacingMm: 4,
+      components: [
+        { ref: 'U1', primitiveId: 'p-u1', widthMm: 6, heightMm: 6 },
+        { ref: 'C1', primitiveId: 'p-c1', widthMm: 2, heightMm: 1.2 },
+      ],
+    });
+
+    expect(plan.blocked).toBe(false);
+    expect(plan.applied).toBe(false);
+    expect(plan.placements).toHaveLength(2);
+    expect(plan.operations[0]).toMatchObject({ method: 'pcb.modifyComponent' });
+    expect(plan.summary).toContain('ready');
+  });
+
+  it('blocks component placements outside board or inside keepouts', () => {
+    const plan = planComponentGroupPlacement({
+      board: { widthMm: 20, heightMm: 20 },
+      anchor: { x: 19, y: 19 },
+      keepouts: [{ x: 0, y: 0, widthMm: 20, heightMm: 20, name: 'all' }],
+      components: [{ ref: 'U1', primitiveId: 'p-u1', widthMm: 6, heightMm: 6 }],
+    });
+
+    expect(plan.blocked).toBe(true);
+    expect(plan.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining(['LAYOUT_COMPONENT_OUTSIDE_BOARD', 'LAYOUT_COMPONENT_IN_KEEPOUT']),
+    );
+  });
+
+  it('detects placement collision when spacing is insufficient', () => {
+    const plan = planComponentGroupPlacement({
+      board: { widthMm: 50, heightMm: 50 },
+      anchor: { x: 10, y: 10 },
+      columns: 2,
+      spacingMm: 0,
+      minSpacingMm: 2,
+      components: [
+        { ref: 'U1', primitiveId: 'p-u1', widthMm: 10, heightMm: 10 },
+        { ref: 'U2', primitiveId: 'p-u2', widthMm: 10, heightMm: 10 },
+      ],
+    });
+
+    expect(plan.blocked).toBe(true);
+    expect(plan.issues.some((issue) => issue.code === 'LAYOUT_COMPONENT_COLLISION')).toBe(true);
+  });
+
+  it('creates a constrained path plan with length metadata', () => {
+    const plan = planRoutePath({
+      netName: 'GND',
+      layer: 1,
+      widthMm: 0.4,
+      board: { widthMm: 60, heightMm: 40 },
+      waypoints: [
+        { x: 5, y: 5 },
+        { x: 15, y: 5 },
+        { x: 15, y: 15 },
+      ],
+    });
+
+    expect(plan.blocked).toBe(false);
+    expect(plan.pathLengthMm).toBe(20);
+    expect(plan.operations[0]).toMatchObject({ method: 'pcb.addTrack' });
+  });
+
+  it('blocks route path that crosses keepout or leaves board', () => {
+    const plan = planRoutePath({
+      netName: '3V3',
+      layer: 1,
+      widthMm: 0.2,
+      minWidthMm: 0.3,
+      board: { widthMm: 20, heightMm: 20 },
+      keepouts: [{ x: 8, y: 8, widthMm: 4, heightMm: 4, name: 'center' }],
+      waypoints: [
+        { x: 0, y: 10 },
+        { x: 25, y: 10 },
+      ],
+    });
+
+    expect(plan.blocked).toBe(true);
+    expect(plan.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        'LAYOUT_TRACE_WIDTH_TOO_SMALL',
+        'LAYOUT_PATH_OUTSIDE_BOARD',
+        'LAYOUT_PATH_IN_KEEPOUT',
+      ]),
+    );
+  });
+});

--- a/tests/unit/tools/pcb-write.test.ts
+++ b/tests/unit/tools/pcb-write.test.ts
@@ -35,13 +35,134 @@ describe('PCB Write Tools', () => {
     };
   });
 
-  it('should register all 6 PCB write tools', () => {
+  it('should register all 8 PCB write tools', () => {
     expect(registry.get('easyeda_pcb_place_component')).toBeDefined();
     expect(registry.get('easyeda_pcb_add_track')).toBeDefined();
     expect(registry.get('easyeda_pcb_add_via')).toBeDefined();
     expect(registry.get('easyeda_pcb_add_zone')).toBeDefined();
     expect(registry.get('easyeda_pcb_delete_component')).toBeDefined();
     expect(registry.get('easyeda_pcb_modify_component')).toBeDefined();
+    expect(registry.get('easyeda_pcb_place_component_group')).toBeDefined();
+    expect(registry.get('easyeda_pcb_route_path_plan')).toBeDefined();
+  });
+
+  it('easyeda_pcb_place_component_group should preview without bridge calls', async () => {
+    const tool = registry.get('easyeda_pcb_place_component_group');
+
+    const result = await tool?.handler(context, {
+      mode: 'preview',
+      board: { widthMm: 60, heightMm: 40 },
+      anchor: { x: 10, y: 10 },
+      components: [{ ref: 'U1', primitiveId: 'p-u1', widthMm: 6, heightMm: 6 }],
+    });
+
+    expect(bridgeCall).not.toHaveBeenCalled();
+    expect(result?.success).toBe(true);
+    expect(result?.applied).toBe(false);
+    expect(result?.operations[0].method).toBe('pcb.modifyComponent');
+  });
+
+  it('easyeda_pcb_place_component_group should block apply without confirmation', async () => {
+    const tool = registry.get('easyeda_pcb_place_component_group');
+
+    const result = await tool?.handler(context, {
+      mode: 'apply',
+      board: { widthMm: 60, heightMm: 40 },
+      anchor: { x: 10, y: 10 },
+      components: [{ ref: 'U1', primitiveId: 'p-u1', widthMm: 6, heightMm: 6 }],
+    });
+
+    expect(bridgeCall).not.toHaveBeenCalled();
+    expect(result?.success).toBe(false);
+    expect(result?.blocked).toBe(true);
+    expect(result?.error).toContain('confirmWrite');
+  });
+
+  it('easyeda_pcb_place_component_group should apply valid placement with confirmation', async () => {
+    const tool = registry.get('easyeda_pcb_place_component_group');
+    bridgeCall.mockResolvedValue({ result: 'ok' });
+
+    const result = await tool?.handler(context, {
+      mode: 'apply',
+      confirmWrite: true,
+      board: { widthMm: 60, heightMm: 40 },
+      anchor: { x: 10, y: 10 },
+      components: [{ ref: 'U1', primitiveId: 'p-u1', widthMm: 6, heightMm: 6 }],
+    });
+
+    expect(bridgeCall).toHaveBeenCalledWith('pcb.modifyComponent', {
+      primitiveId: 'p-u1',
+      property: { x: 10, y: 10, rotation: 0, layer: 1 },
+    });
+    expect(result?.success).toBe(true);
+    expect(result?.applied).toBe(true);
+  });
+
+  it('easyeda_pcb_route_path_plan should preview without bridge calls', async () => {
+    const tool = registry.get('easyeda_pcb_route_path_plan');
+
+    const result = await tool?.handler(context, {
+      mode: 'preview',
+      netName: 'GND',
+      layer: 1,
+      widthMm: 0.4,
+      waypoints: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+    });
+
+    expect(bridgeCall).not.toHaveBeenCalled();
+    expect(result?.success).toBe(true);
+    expect(result?.path_length_mm).toBe(10);
+  });
+
+  it('easyeda_pcb_route_path_plan should block unsafe apply before bridge call', async () => {
+    const tool = registry.get('easyeda_pcb_route_path_plan');
+
+    const result = await tool?.handler(context, {
+      mode: 'apply',
+      confirmWrite: true,
+      netName: '3V3',
+      layer: 1,
+      widthMm: 0.2,
+      minWidthMm: 0.4,
+      waypoints: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+    });
+
+    expect(bridgeCall).not.toHaveBeenCalled();
+    expect(result?.success).toBe(false);
+    expect(result?.blocked).toBe(true);
+    expect(result?.issues[0].code).toBe('LAYOUT_TRACE_WIDTH_TOO_SMALL');
+  });
+
+  it('easyeda_pcb_route_path_plan should apply valid path with confirmation', async () => {
+    const tool = registry.get('easyeda_pcb_route_path_plan');
+    bridgeCall.mockResolvedValue({ result: 'track-1' });
+
+    const result = await tool?.handler(context, {
+      mode: 'apply',
+      confirmWrite: true,
+      netName: 'GND',
+      layer: 1,
+      widthMm: 0.4,
+      waypoints: [
+        { x: 0, y: 0 },
+        { x: 10, y: 0 },
+      ],
+    });
+
+    expect(bridgeCall).toHaveBeenCalledWith('pcb.addTrack', {
+      points: [0, 0, 10, 0],
+      layer: 1,
+      width: 0.4,
+      netName: 'GND',
+    });
+    expect(result?.success).toBe(true);
+    expect(result?.applied).toBe(true);
   });
 
   it('easyeda_pcb_place_component should call bridge and return success', async () => {


### PR DESCRIPTION
Implements #32. Adds high-level component group placement and route path planning/apply tools with preview-first output, constraint checks, confirmation-gated apply, docs, tests, and generated tool reference. Local verification passed: 46 test files / 620 tests.