### PR TITLE
feat: add production qa artifacts

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -31,6 +31,8 @@ export default defineConfig({
           { text: 'Manufacturing Review', link: '/examples/manufacturing-review' },
           { text: 'Power Tree Analyzer', link: '/power-tree' },
           { text: 'High-Level PCB Layout', link: '/high-level-pcb-layout' },
+          { text: 'Production QA Artifacts', link: '/production-qa' },
+          { text: 'Production QA Artifacts', link: '/production-qa' },
           { text: 'High-Level PCB Layout', link: '/high-level-pcb-layout' },
           { text: 'Claude Prompts', link: '/examples/claude-prompts' },
         ],

--- a/docs/export-manifest.md
+++ b/docs/export-manifest.md
@@ -318,3 +318,17 @@ expectations. The `golden-smoke.test.ts` suite verifies:
   artifact entries, each is validated independently. Deduplication is caller responsibility.
 - **Bridge-dependent fields**: `bridgeMetadata` is recorded if available but not
   validated — the module assumes the bridge provides accurate metadata.
+
+## Production QA roles
+
+Production QA handoff artifacts can be modeled as documentation artifacts in the manifest:
+
+| Role                      | Artifact type   | Purpose                                         |
+| ------------------------- | --------------- | ----------------------------------------------- |
+| `testpoint-checklist`     | `documentation` | Critical-net test access checklist              |
+| `assembly-notes`          | `documentation` | Polarity, DNP, side, and special handling notes |
+| `bringup-plan`            | `documentation` | Bench bring-up and rail verification plan       |
+| `production-qa-checklist` | `documentation` | Operator-facing production QA checklist         |
+| `qa-manifest`             | `documentation` | Machine-readable QA package                     |
+
+Add these roles to `manufacturingPolicy.requiredRoles` when production test and assembly notes must be part of the export package.

--- a/docs/production-qa.md
+++ b/docs/production-qa.md
@@ -1,0 +1,86 @@
+# Production QA Artifacts
+
+Production QA artifacts extend a manufacturing handoff package with test, assembly, and bring-up documentation.
+
+## Tool
+
+```text
+easyeda_production_qa_artifacts
+```
+
+The tool is read-only. It generates Markdown and JSON artifacts from board metadata and does not call the EasyEDA bridge.
+
+## Generated artifacts
+
+| Role                      | Filename pattern               | Purpose                                         |
+| ------------------------- | ------------------------------ | ----------------------------------------------- |
+| `testpoint-checklist`     | `*-testpoint-checklist.md`     | Critical-net test access checklist              |
+| `assembly-notes`          | `*-assembly-notes.md`          | Polarity, DNP, side, and special handling notes |
+| `bringup-plan`            | `*-bringup-plan.md`            | Bench bring-up and rail verification plan       |
+| `production-qa-checklist` | `*-production-qa-checklist.md` | Operator-facing QA checklist                    |
+| `qa-manifest`             | `*-production-qa.json`         | Machine-readable QA package                     |
+
+## Input example
+
+```json
+{
+  "projectId": "proj-qa",
+  "projectName": "Sensor Board",
+  "revision": "A1",
+  "criticalNets": [
+    { "name": "GND", "category": "ground", "hasTestPoint": true, "testPointRef": "TP1" },
+    { "name": "3V3", "category": "power", "hasTestPoint": true, "testPointRef": "TP2" },
+    { "name": "RESET", "category": "reset", "hasTestPoint": true, "testPointRef": "TP3" },
+    { "name": "SWDIO", "category": "programming", "hasTestPoint": true, "testPointRef": "TP4" }
+  ],
+  "components": [
+    { "ref": "D1", "value": "LED", "footprint": "0603", "polarized": true, "orientationMark": true }
+  ],
+  "requiresProgramming": true,
+  "programmingInterfaces": ["SWD"],
+  "hasProgrammingAccess": true,
+  "requiresFunctionalTest": true
+}
+```
+
+## Findings
+
+The generator emits structured issues for release blocking or review-required conditions:
+
+| Code                                 | Severity | Meaning                                                  |
+| ------------------------------------ | -------- | -------------------------------------------------------- |
+| `QA_CRITICAL_NET_MISSING_TESTPOINT`  | error    | Required critical net lacks declared test access         |
+| `QA_PROGRAMMING_ACCESS_REQUIRED`     | error    | Programming/debug access is required but missing         |
+| `QA_POLARITY_NOTE_MISSING`           | warning  | Polarized component lacks orientation note/mark metadata |
+| `QA_ASSEMBLY_HANDLING_NOTE_REQUIRED` | warning  | Board requires special handling notes                    |
+| `QA_BRINGUP_POWER_STEP_REQUIRED`     | info     | Power-rail verification should be part of bring-up       |
+
+## Export manifest integration
+
+Production QA artifacts can be required in a manufacturing export manifest using these roles:
+
+```typescript
+ExportArtifactRole.TestpointChecklist;
+ExportArtifactRole.AssemblyNotes;
+ExportArtifactRole.BringupPlan;
+ExportArtifactRole.ProductionQaChecklist;
+ExportArtifactRole.QaManifest;
+```
+
+Example policy:
+
+```json
+{
+  "manufacturingPolicy": {
+    "requiredRoles": [
+      "testpoint-checklist",
+      "assembly-notes",
+      "bringup-plan",
+      "production-qa-checklist",
+      "qa-manifest"
+    ]
+  }
+}
+```
+
+If a required QA role is missing, export manifest validation fails before the package is considered complete.

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -45,6 +45,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_pcb_production_review`         | `core`  | `medium` | Run fabrication, assembly, and testability production review rules for PCB handoff. Reports severity-ranked DFM/DFA/DFT findings with actionable remediation before Gerber export or manufacturing submission.                                                                                                |
 | `easyeda_pcb_route_path_plan`           | `full`  | `high`   | Create a high-level, constraint-checked route path plan for one net and optionally apply it after explicit confirmation.                                                                                                                                                                                      |
 | `easyeda_power_tree_analyze`            | `core`  | `medium` | Analyze supply sources, regulators, loads, protection, bulk capacitance, current budget, dropout, and regulator thermal risk. Returns machine-readable issues and a human-readable summary.                                                                                                                   |
+| `easyeda_production_qa_artifacts`       | `pro`   | `low`    | Generate testpoint checklist, assembly notes, bring-up plan, production QA checklist, and machine-readable QA manifest for board handoff.                                                                                                                                                                     |
 | `easyeda_project_save`                  | `core`  | `medium` | Explicitly save the current EasyEDA Pro project. This ensures all netlist changes, net flags, pin connections, and other mutations are persisted to the project file. Save is never implicit — the caller must explicitly request it. Requires confirmWrite.                                                  |
 | `easyeda_rule_check_summary`            | `core`  | `low`    | Get a summary of all design and electrical rule check results for the project.                                                                                                                                                                                                                                |
 | `easyeda_run_self_test`                 | `core`  | `low`    | Run internal self-test to verify server integrity, config, and bridge connectivity.                                                                                                                                                                                                                           |
@@ -1220,6 +1221,46 @@ Returns a JSON object matching the schema:
   rails: any;
   regulators: any;
   issues: any;
+  summary: any;
+}
+```
+
+---
+
+## `easyeda_production_qa_artifacts`
+
+**Profile:** `pro` | **Risk Level:** `low`
+
+> Generate testpoint checklist, assembly notes, bring-up plan, production QA checklist, and machine-readable QA manifest for board handoff.
+
+### Input Parameters
+
+| Parameter                | Type  | Required | Description |
+| ------------------------ | ----- | -------- | ----------- |
+| `projectId`              | `any` | No       |             |
+| `projectName`            | `any` | No       |             |
+| `revision`               | `any` | No       |             |
+| `criticalNets`           | `any` | No       |             |
+| `components`             | `any` | No       |             |
+| `requiresProgramming`    | `any` | No       |             |
+| `programmingInterfaces`  | `any` | No       |             |
+| `hasProgrammingAccess`   | `any` | No       |             |
+| `hasBattery`             | `any` | No       |             |
+| `requiresFunctionalTest` | `any` | No       |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  project_id: any;
+  project_name: any;
+  revision: any;
+  passed: any;
+  issues: any;
+  checklist: any;
+  artifacts: any;
   summary: any;
 }
 ```

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -21,7 +21,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     name: 'pro',
     label: 'Pro',
     description: 'Adds pick-and-place, PDF, netlist export for manufacturing workflows',
-    approxToolCount: '44',
+    approxToolCount: '45',
     isDefault: false,
   },
   full: {
@@ -29,7 +29,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls for full runtime control without raw JavaScript execution',
-    approxToolCount: '53',
+    approxToolCount: '54',
     isDefault: false,
   },
   dev: {
@@ -37,14 +37,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '57',
+    approxToolCount: '58',
     isDefault: false,
   },
   experimental: {
     name: 'experimental',
     label: 'Experimental',
     description: 'MCP Apps, Tasks, simulation, autorouter, AI action plans',
-    approxToolCount: '55',
+    approxToolCount: '56',
     isDefault: false,
   },
 };

--- a/src/export-manifest/types.ts
+++ b/src/export-manifest/types.ts
@@ -33,6 +33,8 @@ export enum ArtifactType {
   ErcReport = 'erc-report',
   /** Design rules check report. */
   DrcReport = 'drc-report',
+  /** Markdown or JSON documentation artifact. */
+  Documentation = 'documentation',
 }
 
 /**
@@ -60,6 +62,11 @@ export enum ExportArtifactRole {
   Netlist = 'netlist',
   DrcReport = 'drc-report',
   ErcReport = 'erc-report',
+  TestpointChecklist = 'testpoint-checklist',
+  AssemblyNotes = 'assembly-notes',
+  BringupPlan = 'bringup-plan',
+  ProductionQaChecklist = 'production-qa-checklist',
+  QaManifest = 'qa-manifest',
 }
 
 // ── Manifest entry ─────────────────────────────────────────────────────────

--- a/src/production-qa/generator.ts
+++ b/src/production-qa/generator.ts
@@ -1,0 +1,372 @@
+import type {
+  ProductionQaReport,
+  QaArtifact,
+  QaAssemblyComponentInput,
+  QaBoardInput,
+  QaChecklistItem,
+  QaCriticalNetInput,
+  QaIssue,
+} from './types.js';
+
+function issue(
+  code: QaIssue['code'],
+  severity: QaIssue['severity'],
+  message: string,
+  remediationHint: string,
+  details?: Record<string, unknown>,
+): QaIssue {
+  return { code, severity, message, remediationHint, details };
+}
+
+function slug(value: string): string {
+  return (
+    value
+      .trim()
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-|-$/g, '') || 'project'
+  );
+}
+
+function checklistId(prefix: string, value: string): string {
+  return `${prefix}-${slug(value)}`;
+}
+
+function requiredCriticalNets(input: QaBoardInput): QaCriticalNetInput[] {
+  return (input.criticalNets ?? []).filter((net) => net.required !== false);
+}
+
+function componentsWithNotes(input: QaBoardInput): QaAssemblyComponentInput[] {
+  return (input.components ?? []).filter(
+    (component) =>
+      component.polarized ||
+      component.specialHandling ||
+      component.doNotPopulate ||
+      component.side === 'bottom',
+  );
+}
+
+function generateIssues(input: QaBoardInput): QaIssue[] {
+  const issues: QaIssue[] = [];
+
+  for (const net of requiredCriticalNets(input)) {
+    if (!net.hasTestPoint) {
+      issues.push(
+        issue(
+          'QA_CRITICAL_NET_MISSING_TESTPOINT',
+          'error',
+          `Critical net ${net.name} is missing test access`,
+          'Add a labeled test pad/probe for this critical net or explicitly mark it as not required for production test.',
+          { netName: net.name, category: net.category },
+        ),
+      );
+    }
+  }
+
+  for (const component of input.components ?? []) {
+    if (component.polarized && !component.orientationMark) {
+      issues.push(
+        issue(
+          'QA_POLARITY_NOTE_MISSING',
+          'warning',
+          `Polarized component ${component.ref} lacks an orientation mark or note`,
+          'Add clear silkscreen or assembly-note orientation guidance before handoff.',
+          { ref: component.ref, value: component.value, footprint: component.footprint },
+        ),
+      );
+    }
+  }
+
+  if (input.requiresProgramming && !input.hasProgrammingAccess) {
+    issues.push(
+      issue(
+        'QA_PROGRAMMING_ACCESS_REQUIRED',
+        'error',
+        'Programming or debug access is required but not declared',
+        'Add a programming connector or documented test-pad access for the programming/debug interface.',
+        { programmingInterfaces: input.programmingInterfaces ?? [] },
+      ),
+    );
+  }
+
+  if (input.hasBattery) {
+    issues.push(
+      issue(
+        'QA_ASSEMBLY_HANDLING_NOTE_REQUIRED',
+        'warning',
+        'Board requires battery handling notes',
+        'Add assembly and QA handling notes covering battery polarity, isolation, and first-power inspection.',
+        { hasBattery: input.hasBattery },
+      ),
+    );
+  }
+
+  if ((input.criticalNets ?? []).some((net) => net.category === 'power')) {
+    issues.push(
+      issue(
+        'QA_BRINGUP_POWER_STEP_REQUIRED',
+        'info',
+        'Power-rail bring-up steps should be included in the QA package',
+        'Measure each power rail under current limit before programming or connecting external loads.',
+      ),
+    );
+  }
+
+  return issues;
+}
+
+function generateChecklist(input: QaBoardInput, issues: QaIssue[]): QaChecklistItem[] {
+  const checklist: QaChecklistItem[] = [];
+  const missingTp = new Set(
+    issues
+      .filter((entry) => entry.code === 'QA_CRITICAL_NET_MISSING_TESTPOINT')
+      .map((entry) => String(entry.details?.netName ?? '')),
+  );
+
+  for (const net of requiredCriticalNets(input)) {
+    checklist.push({
+      id: checklistId('tp', net.name),
+      title: `Verify test access for ${net.name}`,
+      category: 'testpoint',
+      required: true,
+      status: missingTp.has(net.name) ? 'fail' : 'pass',
+      details: net.hasTestPoint
+        ? `Test point: ${net.testPointRef ?? 'declared'}`
+        : 'No test point declared',
+      refs: net.testPointRef ? [net.testPointRef] : undefined,
+    });
+  }
+
+  for (const component of componentsWithNotes(input)) {
+    checklist.push({
+      id: checklistId('asm', component.ref),
+      title: `Assembly note for ${component.ref}`,
+      category: 'assembly',
+      required: Boolean(component.polarized || component.specialHandling),
+      status: component.polarized && !component.orientationMark ? 'review' : 'pass',
+      details: [
+        component.value ? `Value: ${component.value}` : undefined,
+        component.footprint ? `Footprint: ${component.footprint}` : undefined,
+        component.polarized ? 'Orientation-sensitive' : undefined,
+        component.doNotPopulate ? 'DNP' : undefined,
+        component.side ? `Side: ${component.side}` : undefined,
+        component.specialHandling,
+      ]
+        .filter(Boolean)
+        .join('; '),
+      refs: [component.ref],
+    });
+  }
+
+  checklist.push({
+    id: 'bringup-visual-inspection',
+    title: 'Visual inspection before bench test',
+    category: 'bringup',
+    required: true,
+    status: 'review',
+    details:
+      'Inspect solder bridges, orientation, connector polarity, DNP placements, and mechanical interference.',
+  });
+
+  checklist.push({
+    id: 'bringup-rail-check',
+    title: 'Bench supply rail check',
+    category: 'bringup',
+    required: true,
+    status: 'review',
+    details: 'Verify all declared power rails before programming or external load connection.',
+  });
+
+  if (input.requiresProgramming) {
+    checklist.push({
+      id: 'programming-access',
+      title: 'Verify programming/debug access',
+      category: 'programming',
+      required: true,
+      status: input.hasProgrammingAccess ? 'pass' : 'fail',
+      details: `Interfaces: ${(input.programmingInterfaces ?? ['unspecified']).join(', ')}`,
+    });
+  }
+
+  if (input.requiresFunctionalTest) {
+    checklist.push({
+      id: 'functional-test',
+      title: 'Run production functional test',
+      category: 'qa',
+      required: true,
+      status: 'review',
+      details:
+        'Run firmware, communication, sensor/actuator, and acceptance-threshold tests defined for this board.',
+    });
+  }
+
+  return checklist;
+}
+
+function mdTable(rows: string[][]): string {
+  if (rows.length === 0) return '';
+  const header = rows[0] ?? [];
+  const sep = header.map(() => '---');
+  return [header, sep, ...rows.slice(1)].map((row) => `| ${row.join(' | ')} |`).join('\n');
+}
+
+function testpointChecklistMarkdown(input: QaBoardInput, checklist: QaChecklistItem[]): string {
+  const rows = [
+    ['Net', 'Category', 'Required', 'Status', 'Test point'],
+    ...requiredCriticalNets(input).map((net) => {
+      const item = checklist.find((entry) => entry.id === checklistId('tp', net.name));
+      return [
+        net.name,
+        net.category ?? 'custom',
+        net.required === false ? 'no' : 'yes',
+        item?.status ?? 'review',
+        net.testPointRef ?? (net.hasTestPoint ? 'declared' : 'missing'),
+      ];
+    }),
+  ];
+  return `# Testpoint Checklist\n\n${mdTable(rows)}\n`;
+}
+
+function assemblyNotesMarkdown(input: QaBoardInput): string {
+  const rows = [
+    ['Ref', 'Value', 'Footprint', 'Side', 'Note'],
+    ...componentsWithNotes(input).map((component) => [
+      component.ref,
+      component.value ?? '',
+      component.footprint ?? '',
+      component.side ?? 'top',
+      [
+        component.polarized
+          ? `Orientation mark: ${component.orientationMark ? 'yes' : 'missing'}`
+          : undefined,
+        component.doNotPopulate ? 'DNP' : undefined,
+        component.specialHandling,
+      ]
+        .filter(Boolean)
+        .join('; '),
+    ]),
+  ];
+  return `# Assembly Notes\n\n${mdTable(rows)}\n`;
+}
+
+function bringupPlanMarkdown(input: QaBoardInput): string {
+  const rails = requiredCriticalNets(input).filter(
+    (net) => net.category === 'power' || net.category === 'ground',
+  );
+  const railLines = rails.length
+    ? rails
+        .map(
+          (net, index) =>
+            `${index + 1}. Measure ${net.name} at ${net.testPointRef ?? 'declared test point'}.`,
+        )
+        .join('\n')
+    : '1. Measure all declared power rails and ground references.';
+
+  return `# Bring-up Plan\n\n1. Visual inspection.\n2. Bench supply rail check.\n${railLines}\n${input.requiresProgramming ? '4. Program/debug the board after rails are verified.\n' : '4. Continue to functional QA after rails are verified.\n'}`;
+}
+
+function qaChecklistMarkdown(checklist: QaChecklistItem[]): string {
+  const rows = [
+    ['ID', 'Category', 'Required', 'Status', 'Title'],
+    ...checklist.map((item) => [
+      item.id,
+      item.category,
+      item.required ? 'yes' : 'no',
+      item.status,
+      item.title,
+    ]),
+  ];
+  return `# Production QA Checklist\n\n${mdTable(rows)}\n`;
+}
+
+function generateArtifacts(
+  input: QaBoardInput,
+  checklist: QaChecklistItem[],
+  reportJson: unknown,
+): QaArtifact[] {
+  const base = slug(input.projectName ?? input.projectId ?? 'project');
+  return [
+    {
+      filename: `${base}-testpoint-checklist.md`,
+      fileType: 'markdown',
+      role: 'testpoint-checklist',
+      content: testpointChecklistMarkdown(input, checklist),
+      required: true,
+    },
+    {
+      filename: `${base}-assembly-notes.md`,
+      fileType: 'markdown',
+      role: 'assembly-notes',
+      content: assemblyNotesMarkdown(input),
+      required: true,
+    },
+    {
+      filename: `${base}-bringup-plan.md`,
+      fileType: 'markdown',
+      role: 'bringup-plan',
+      content: bringupPlanMarkdown(input),
+      required: true,
+    },
+    {
+      filename: `${base}-production-qa-checklist.md`,
+      fileType: 'markdown',
+      role: 'production-qa-checklist',
+      content: qaChecklistMarkdown(checklist),
+      required: true,
+    },
+    {
+      filename: `${base}-production-qa.json`,
+      fileType: 'json',
+      role: 'qa-manifest',
+      content: JSON.stringify(reportJson, null, 2),
+      required: true,
+    },
+  ];
+}
+
+export function generateProductionQaArtifacts(input: QaBoardInput): ProductionQaReport {
+  const issues = generateIssues(input);
+  const checklist = generateChecklist(input, issues);
+  const errorCount = issues.filter((entry) => entry.severity === 'error').length;
+  const warningCount = issues.filter((entry) => entry.severity === 'warning').length;
+  const missingTestpointCount = issues.filter(
+    (entry) => entry.code === 'QA_CRITICAL_NET_MISSING_TESTPOINT',
+  ).length;
+  const assemblyNoteCount = componentsWithNotes(input).length;
+  const partial = {
+    projectId: input.projectId ?? '',
+    projectName: input.projectName,
+    revision: input.revision,
+    passed: errorCount === 0,
+    issues,
+    checklist,
+    artifacts: [] as QaArtifact[],
+    summary: {
+      criticalNetCount: requiredCriticalNets(input).length,
+      missingTestpointCount,
+      assemblyNoteCount,
+      checklistItemCount: checklist.length,
+      errorCount,
+      warningCount,
+      humanSummary:
+        errorCount > 0
+          ? `Production QA package blocked by ${errorCount} error(s) and ${warningCount} warning(s).`
+          : warningCount > 0
+            ? `Production QA package generated with ${warningCount} warning(s) for review.`
+            : 'Production QA package generated with no blocking issues.',
+    },
+  } satisfies ProductionQaReport;
+
+  return {
+    ...partial,
+    artifacts: generateArtifacts(input, checklist, {
+      projectId: partial.projectId,
+      projectName: partial.projectName,
+      revision: partial.revision,
+      passed: partial.passed,
+      issues: partial.issues,
+      checklist: partial.checklist,
+      summary: partial.summary,
+    }),
+  };
+}

--- a/src/production-qa/index.ts
+++ b/src/production-qa/index.ts
@@ -1,0 +1,2 @@
+export { generateProductionQaArtifacts } from './generator.js';
+export type * from './types.js';

--- a/src/production-qa/types.ts
+++ b/src/production-qa/types.ts
@@ -1,0 +1,93 @@
+/** Production QA artifact generator types. */
+
+export type QaSeverity = 'error' | 'warning' | 'info';
+
+export type QaIssueCode =
+  | 'QA_CRITICAL_NET_MISSING_TESTPOINT'
+  | 'QA_POLARITY_NOTE_MISSING'
+  | 'QA_BRINGUP_POWER_STEP_REQUIRED'
+  | 'QA_PROGRAMMING_ACCESS_REQUIRED'
+  | 'QA_ASSEMBLY_HANDLING_NOTE_REQUIRED';
+
+export interface QaIssue {
+  code: QaIssueCode;
+  severity: QaSeverity;
+  message: string;
+  remediationHint: string;
+  details?: Record<string, unknown>;
+}
+
+export interface QaCriticalNetInput {
+  name: string;
+  category?:
+    'power' | 'ground' | 'reset' | 'programming' | 'clock' | 'interface' | 'analog' | 'custom';
+  required?: boolean;
+  hasTestPoint?: boolean;
+  testPointRef?: string;
+}
+
+export interface QaAssemblyComponentInput {
+  ref: string;
+  value?: string;
+  footprint?: string;
+  polarized?: boolean;
+  orientationMark?: boolean;
+  specialHandling?: string;
+  doNotPopulate?: boolean;
+  side?: 'top' | 'bottom';
+}
+
+export interface QaBoardInput {
+  projectId?: string;
+  projectName?: string;
+  revision?: string;
+  criticalNets?: QaCriticalNetInput[];
+  components?: QaAssemblyComponentInput[];
+  requiresProgramming?: boolean;
+  programmingInterfaces?: string[];
+  hasProgrammingAccess?: boolean;
+  hasBattery?: boolean;
+  requiresFunctionalTest?: boolean;
+}
+
+export interface QaChecklistItem {
+  id: string;
+  title: string;
+  category: 'testpoint' | 'assembly' | 'bringup' | 'qa' | 'programming';
+  required: boolean;
+  status: 'pass' | 'fail' | 'review';
+  details?: string;
+  refs?: string[];
+}
+
+export interface QaArtifact {
+  filename: string;
+  fileType: 'markdown' | 'json';
+  role:
+    | 'testpoint-checklist'
+    | 'assembly-notes'
+    | 'bringup-plan'
+    | 'production-qa-checklist'
+    | 'qa-manifest';
+  content: string;
+  required: boolean;
+}
+
+export interface ProductionQaReport {
+  projectId: string;
+  projectName?: string;
+  revision?: string;
+  passed: boolean;
+  issues: QaIssue[];
+  checklist: QaChecklistItem[];
+  artifacts: QaArtifact[];
+  summary: {
+    criticalNetCount: number;
+    missingTestpointCount: number;
+    assemblyNoteCount: number;
+    checklistItemCount: number;
+    errorCount: number;
+    warningCount: number;
+    humanSummary: string;
+  };
+}

--- a/src/tools/L1_export.ts
+++ b/src/tools/L1_export.ts
@@ -3,6 +3,7 @@ import { type ToolDefinition, type ToolContext } from './types.js';
 import { type EnvConfig } from '../config/env.js';
 import { validatePcbConstraints } from '../pcb-constraints/index.js';
 import type { PcbConstraintInput } from '../pcb-constraints/types.js';
+import { generateProductionQaArtifacts } from '../production-qa/index.js';
 
 const productionReviewBoardDataSchema = z.object({}).passthrough();
 
@@ -42,10 +43,126 @@ function runProductionReview(
   };
 }
 
+const qaCriticalNetSchema = z.object({
+  name: z.string(),
+  category: z
+    .enum(['power', 'ground', 'reset', 'programming', 'clock', 'interface', 'analog', 'custom'])
+    .optional(),
+  required: z.boolean().optional(),
+  hasTestPoint: z.boolean().optional(),
+  testPointRef: z.string().optional(),
+});
+
+const qaComponentSchema = z.object({
+  ref: z.string(),
+  value: z.string().optional(),
+  footprint: z.string().optional(),
+  polarized: z.boolean().optional(),
+  orientationMark: z.boolean().optional(),
+  specialHandling: z.string().optional(),
+  doNotPopulate: z.boolean().optional(),
+  side: z.enum(['top', 'bottom']).optional(),
+});
+
+const qaIssueSchema = z.object({
+  code: z.string(),
+  severity: z.enum(['error', 'warning', 'info']),
+  message: z.string(),
+  remediationHint: z.string(),
+  details: z.record(z.string(), z.unknown()).optional(),
+});
+
+const qaChecklistItemSchema = z.object({
+  id: z.string(),
+  title: z.string(),
+  category: z.enum(['testpoint', 'assembly', 'bringup', 'qa', 'programming']),
+  required: z.boolean(),
+  status: z.enum(['pass', 'fail', 'review']),
+  details: z.string().optional(),
+  refs: z.array(z.string()).optional(),
+});
+
+const qaArtifactSchema = z.object({
+  filename: z.string(),
+  fileType: z.enum(['markdown', 'json']),
+  role: z.enum([
+    'testpoint-checklist',
+    'assembly-notes',
+    'bringup-plan',
+    'production-qa-checklist',
+    'qa-manifest',
+  ]),
+  content: z.string(),
+  required: z.boolean(),
+});
+
 function registerExportTools(
   registry: { register: (def: ToolDefinition) => void },
   _config: EnvConfig,
 ) {
+  registry.register({
+    name: 'easyeda_production_qa_artifacts',
+    title: 'Generate production QA artifacts',
+    description:
+      'Generate testpoint checklist, assembly notes, bring-up plan, production QA checklist, and machine-readable QA manifest for board handoff.',
+    profile: 'pro',
+    evidence: ['inferred'],
+    risk: 'low',
+    confirmWrite: false,
+    group: 'export',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    inputSchema: z.object({
+      projectId: z.string().optional(),
+      projectName: z.string().optional(),
+      revision: z.string().optional(),
+      criticalNets: z.array(qaCriticalNetSchema).optional(),
+      components: z.array(qaComponentSchema).optional(),
+      requiresProgramming: z.boolean().optional(),
+      programmingInterfaces: z.array(z.string()).optional(),
+      hasProgrammingAccess: z.boolean().optional(),
+      hasBattery: z.boolean().optional(),
+      requiresFunctionalTest: z.boolean().optional(),
+    }),
+    outputSchema: z.object({
+      project_id: z.string(),
+      project_name: z.string().optional(),
+      revision: z.string().optional(),
+      passed: z.boolean(),
+      issues: z.array(qaIssueSchema),
+      checklist: z.array(qaChecklistItemSchema),
+      artifacts: z.array(qaArtifactSchema),
+      summary: z.object({
+        criticalNetCount: z.number().int().nonnegative(),
+        missingTestpointCount: z.number().int().nonnegative(),
+        assemblyNoteCount: z.number().int().nonnegative(),
+        checklistItemCount: z.number().int().nonnegative(),
+        errorCount: z.number().int().nonnegative(),
+        warningCount: z.number().int().nonnegative(),
+        humanSummary: z.string(),
+      }),
+    }),
+    handler: async (_ctx: ToolContext, params: unknown) => {
+      const report = generateProductionQaArtifacts(
+        params as Parameters<typeof generateProductionQaArtifacts>[0],
+      );
+      return {
+        project_id: report.projectId,
+        project_name: report.projectName,
+        revision: report.revision,
+        passed: report.passed,
+        issues: report.issues,
+        checklist: report.checklist,
+        artifacts: report.artifacts,
+        summary: report.summary,
+      };
+    },
+  });
+
   registry.register({
     name: 'easyeda_export_gerbers',
     title: 'Export Gerber files',

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -43,10 +43,10 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('44');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('45');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('53');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('54');
   });
 });

--- a/tests/unit/export-manifest/production-qa-roles.test.ts
+++ b/tests/unit/export-manifest/production-qa-roles.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { validateExportManifest } from '../../../src/export-manifest/validation.js';
+import { ExportManifestCode } from '../../../src/export-manifest/errors.js';
+import { ArtifactType, ExportArtifactRole } from '../../../src/export-manifest/types.js';
+import type { ExportManifestInput } from '../../../src/export-manifest/types.js';
+
+function manifest(roles: ExportArtifactRole[]): ExportManifestInput {
+  return {
+    version: '1.0.0',
+    sourceProjectId: 'proj-qa',
+    generatedAt: '2026-07-01T00:00:00.000Z',
+    artifacts: roles.map((role) => ({
+      filename: `${role}.md`,
+      fileType: ArtifactType.Documentation,
+      role,
+      purpose: role,
+      sourceProject: 'proj-qa',
+      generatedByTool: 'easyeda_production_qa_artifacts',
+      timestamp: '2026-07-01T00:00:00.000Z',
+      checksum: 'a'.repeat(64),
+      checksumAlgorithm: 'sha256',
+      fileSize: 100,
+      required: true,
+      stale: false,
+    })),
+    manufacturingPolicy: { requiredRoles: roles },
+  };
+}
+
+describe('production QA manifest roles', () => {
+  it('accepts all production QA artifact roles', () => {
+    const roles = [
+      ExportArtifactRole.TestpointChecklist,
+      ExportArtifactRole.AssemblyNotes,
+      ExportArtifactRole.BringupPlan,
+      ExportArtifactRole.ProductionQaChecklist,
+      ExportArtifactRole.QaManifest,
+    ];
+    const result = validateExportManifest(manifest(roles));
+
+    expect(result.valid).toBe(true);
+    expect(result.summary.missingRequiredRoles).toBe(0);
+  });
+
+  it('fails when a required QA role is absent', () => {
+    const input = manifest([]);
+    input.manufacturingPolicy = { requiredRoles: [ExportArtifactRole.TestpointChecklist] };
+    const result = validateExportManifest(input);
+
+    expect(result.valid).toBe(false);
+    expect(
+      result.issues.some((issue) => issue.code === ExportManifestCode.MISSING_REQUIRED_ROLE),
+    ).toBe(true);
+  });
+});

--- a/tests/unit/production-qa/production-qa.test.ts
+++ b/tests/unit/production-qa/production-qa.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { generateProductionQaArtifacts } from '../../../src/production-qa/index.js';
+
+describe('generateProductionQaArtifacts', () => {
+  it('generates QA artifacts for a complete production-ready board', () => {
+    const report = generateProductionQaArtifacts({
+      projectId: 'proj-qa',
+      projectName: 'Sensor Board',
+      revision: 'A1',
+      criticalNets: [
+        { name: 'GND', category: 'ground', hasTestPoint: true, testPointRef: 'TP1' },
+        { name: '3V3', category: 'power', hasTestPoint: true, testPointRef: 'TP2' },
+        { name: 'RESET', category: 'reset', hasTestPoint: true, testPointRef: 'TP3' },
+        { name: 'SWDIO', category: 'programming', hasTestPoint: true, testPointRef: 'TP4' },
+      ],
+      components: [
+        {
+          ref: 'D1',
+          value: 'LED',
+          footprint: '0603',
+          polarized: true,
+          orientationMark: true,
+          side: 'top',
+        },
+      ],
+      requiresProgramming: true,
+      programmingInterfaces: ['SWD'],
+      hasProgrammingAccess: true,
+      requiresFunctionalTest: true,
+    });
+
+    expect(report.passed).toBe(true);
+    expect(report.summary.missingTestpointCount).toBe(0);
+    expect(report.summary.criticalNetCount).toBe(4);
+    expect(report.artifacts.map((artifact) => artifact.role)).toEqual([
+      'testpoint-checklist',
+      'assembly-notes',
+      'bringup-plan',
+      'production-qa-checklist',
+      'qa-manifest',
+    ]);
+    expect(report.artifacts[0].content).toContain('TP1');
+    expect(report.artifacts[1].content).toContain('D1');
+  });
+
+  it('flags missing test access on required critical nets', () => {
+    const report = generateProductionQaArtifacts({
+      projectId: 'proj-qa',
+      criticalNets: [
+        { name: 'GND', category: 'ground', hasTestPoint: true, testPointRef: 'TP1' },
+        { name: '3V3', category: 'power', hasTestPoint: false },
+        { name: 'RESET', category: 'reset' },
+      ],
+    });
+
+    expect(report.passed).toBe(false);
+    expect(report.summary.missingTestpointCount).toBe(2);
+    expect(
+      report.issues.filter((issue) => issue.code === 'QA_CRITICAL_NET_MISSING_TESTPOINT'),
+    ).toHaveLength(2);
+    expect(report.checklist.find((item) => item.id === 'tp-3v3')?.status).toBe('fail');
+  });
+
+  it('flags missing programming access and missing component orientation notes', () => {
+    const report = generateProductionQaArtifacts({
+      projectId: 'proj-qa',
+      requiresProgramming: true,
+      programmingInterfaces: ['SWD', 'UART'],
+      hasProgrammingAccess: false,
+      components: [
+        { ref: 'U1', value: 'MCU', footprint: 'QFN', polarized: true, orientationMark: false },
+      ],
+    });
+
+    expect(report.passed).toBe(false);
+    expect(report.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining(['QA_PROGRAMMING_ACCESS_REQUIRED', 'QA_POLARITY_NOTE_MISSING']),
+    );
+    expect(report.checklist.find((item) => item.id === 'programming-access')?.status).toBe('fail');
+  });
+
+  it('includes DNP and special handling notes in assembly artifact', () => {
+    const report = generateProductionQaArtifacts({
+      projectName: 'Factory Demo',
+      components: [
+        {
+          ref: 'R99',
+          value: '0R',
+          doNotPopulate: true,
+          specialHandling: 'Install only for debug builds',
+          side: 'bottom',
+        },
+      ],
+    });
+
+    const assembly = report.artifacts.find((artifact) => artifact.role === 'assembly-notes');
+    expect(assembly?.filename).toBe('factory-demo-assembly-notes.md');
+    expect(assembly?.content).toContain('R99');
+    expect(assembly?.content).toContain('DNP');
+    expect(assembly?.content).toContain('Install only for debug builds');
+  });
+});

--- a/tests/unit/tools/production-qa.test.ts
+++ b/tests/unit/tools/production-qa.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ToolRegistry } from '../../../src/tools/registry.js';
+import { type ToolContext } from '../../../src/tools/types.js';
+import { registerExportTools } from '../../../src/tools/L1_export.js';
+import { EnvSchema } from '../../../src/config/env.js';
+
+describe('Production QA tool', () => {
+  let registry: ToolRegistry;
+  let context: ToolContext;
+  let bridgeCall: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    registry = new ToolRegistry();
+    registerExportTools(registry, EnvSchema.parse({ NODE_ENV: 'test' }));
+    bridgeCall = vi.fn();
+    context = {
+      profile: 'pro',
+      bridge: { connected: true, call: bridgeCall },
+      config: { bridgeTimeoutMs: 1000, artifactDir: '.easyeda-mcp-pro/artifacts' },
+      vendors: { lcsc: null, jlcpcb: null, mouser: null, digikey: null },
+    };
+  });
+
+  it('returns handoff artifacts without bridge calls', async () => {
+    const tool = registry.get('easyeda_production_qa_artifacts');
+    expect(tool).toBeDefined();
+
+    const result = await tool?.handler(context, {
+      projectId: 'proj-qa',
+      projectName: 'Sensor Board',
+      criticalNets: [
+        { name: 'GND', category: 'ground', hasTestPoint: true, testPointRef: 'TP1' },
+        { name: '3V3', category: 'power', hasTestPoint: false },
+      ],
+      components: [{ ref: 'D1', value: 'LED', polarized: true, orientationMark: false }],
+      requiresProgramming: true,
+      programmingInterfaces: ['SWD'],
+      hasProgrammingAccess: false,
+    });
+
+    expect(bridgeCall).not.toHaveBeenCalled();
+    expect(result?.project_id).toBe('proj-qa');
+    expect(result?.passed).toBe(false);
+    expect(result?.summary.missingTestpointCount).toBe(1);
+    expect(result?.artifacts).toHaveLength(5);
+  });
+});


### PR DESCRIPTION
Implements #37. Adds production QA artifact generator, read-only MCP tool, export manifest QA roles, docs, and tests. Local verification passed: 49 test files / 627 tests.