### PR TITLE
feat: add benchmark suite

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -33,6 +33,8 @@ export default defineConfig({
           { text: 'High-Level PCB Layout', link: '/high-level-pcb-layout' },
           { text: 'Production QA Artifacts', link: '/production-qa' },
           { text: 'Observability Budgets', link: '/observability-budgets' },
+          { text: 'Golden Eval Benchmark', link: '/benchmark-suite' },
+          { text: 'Golden Eval Benchmark', link: '/benchmark-suite' },
           { text: 'Observability Budgets', link: '/observability-budgets' },
           { text: 'Production QA Artifacts', link: '/production-qa' },
           { text: 'High-Level PCB Layout', link: '/high-level-pcb-layout' },

--- a/docs/benchmark-suite.md
+++ b/docs/benchmark-suite.md
@@ -1,0 +1,75 @@
+# Golden Eval Benchmark Suite
+
+The golden eval benchmark is a non-live regression suite for agent-assisted EasyEDA MCP Pro workflows.
+
+It validates diagnostics, semantic ERC, power-tree analysis, PCB production review, safe PCB layout planning, export manifest validation, production QA artifacts, vendor failure handling, and observability reporting.
+
+## Command
+
+```bash
+pnpm eval:golden
+```
+
+The command runs without live EasyEDA access and without vendor credentials.
+
+## Files
+
+```text
+tests/evals/benchmark.v1.json
+tests/evals/benchmark.schema.json
+tests/evals/fixtures/
+tests/evals/results/latest.json
+```
+
+## Current public baseline
+
+```text
+version: 1.0.0
+scenarioCount: 10
+overallScore: 95
+failedScenarioCount: 0
+safetyViolationCount: 0
+```
+
+## Scenarios
+
+| ID                             | Area           | Purpose                                           |
+| ------------------------------ | -------------- | ------------------------------------------------- |
+| `health-check-core`            | diagnostics    | Server health output shape                        |
+| `config-redaction`             | diagnostics    | Safe config output                                |
+| `semantic-erc-unsafe`          | ERC            | Output contention, floating input, power conflict |
+| `power-tree-thermal`           | power          | Current, dropout, and thermal failure detection   |
+| `pcb-production-review`        | PCB production | Manufacturing-critical blockers                   |
+| `layout-preview-safety`        | PCB write      | Preview does not write or call bridge             |
+| `export-manifest-missing-role` | export         | Required QA role detection                        |
+| `production-qa-artifacts`      | QA             | Testpoint, assembly, bring-up and QA artifacts    |
+| `vendor-failure-no-secret`     | vendor API     | Degraded vendor result without credential leakage |
+| `observability-report`         | observability  | Budgets, metrics and retention metadata           |
+
+## Scoring rubric
+
+| Dimension      | Weight | Meaning                                                              |
+| -------------- | -----: | -------------------------------------------------------------------- |
+| Correctness    |     40 | Output matches expected schema, issue codes, roles and project facts |
+| Safety         |     30 | No mutation without confirmation and no credential leakage           |
+| Completeness   |     20 | Output covers expected domain artifacts/findings                     |
+| Explainability |     10 | Findings include actionable evidence or the scenario passes cleanly  |
+
+Regression policy:
+
+```text
+minimumOverallScore: 85
+minimumScenarioScore: 75
+safetyViolationIsFailure: true
+liveSecretsRequired: false
+```
+
+A regression is any failed scenario, overall score below the policy threshold, or any safety violation.
+
+## Adding a scenario
+
+1. Add a fixture under `tests/evals/fixtures/` when needed.
+2. Add a scenario entry to `tests/evals/benchmark.v1.json`.
+3. Extend `scripts/run-evals.mts` if the scenario uses a new local module/tool family.
+4. Run `pnpm eval:golden`.
+5. Commit the updated benchmark result when the suite intentionally changes.

--- a/package.json
+++ b/package.json
@@ -71,7 +71,8 @@
     "docs:preview": "vitepress preview docs",
     "check:metadata": "node scripts/check-metadata.mjs",
     "inventory:capture": "tsx scripts/capture-runtime-inventory.mts",
-    "inventory:diff": "tsx scripts/diff-runtime-inventory.mts"
+    "inventory:diff": "tsx scripts/diff-runtime-inventory.mts",
+    "eval:golden": "tsx scripts/run-evals.mts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/scripts/run-evals.mts
+++ b/scripts/run-evals.mts
@@ -1,0 +1,289 @@
+#!/usr/bin/env tsx
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateNets } from '../src/net-validation/index.js';
+import { analyzePowerTree } from '../src/power-tree/index.js';
+import { validatePcbConstraints } from '../src/pcb-constraints/index.js';
+import { planComponentGroupPlacement } from '../src/pcb-layout/index.js';
+import { validateExportManifest } from '../src/export-manifest/index.js';
+import { generateProductionQaArtifacts } from '../src/production-qa/index.js';
+import { DEFAULT_LATENCY_BUDGETS, DEFAULT_RETENTION_POLICY } from '../src/observability/index.js';
+
+const root = dirname(fileURLToPath(new URL('../package.json', import.meta.url)));
+const manifestPath = join(root, 'tests/evals/benchmark.v1.json');
+const fixturesDir = join(root, 'tests/evals/fixtures');
+const resultsPath = join(root, 'tests/evals/results/latest.json');
+
+type Scenario = {
+  id: string;
+  title: string;
+  area: string;
+  tool: string;
+  mode: string;
+  threshold: number;
+  fixture?: string;
+  expected: Record<string, unknown>;
+  scores: Record<'correctness' | 'safety' | 'completeness' | 'explainability', number>;
+};
+
+type Manifest = {
+  version: string;
+  name: string;
+  regressionPolicy: {
+    minimumOverallScore: number;
+    minimumScenarioScore: number;
+    safetyViolationIsFailure: boolean;
+    liveSecretsRequired: boolean;
+  };
+  scenarios: Scenario[];
+};
+
+type ScenarioResult = {
+  id: string;
+  title: string;
+  area: string;
+  tool: string;
+  score: number;
+  threshold: number;
+  passed: boolean;
+  safetyViolation: boolean;
+  findings: string[];
+};
+
+function readJson<T>(path: string): T {
+  return JSON.parse(readFileSync(path, 'utf8')) as T;
+}
+
+function loadFixture<T>(scenario: Scenario): T {
+  if (!scenario.fixture) return {} as T;
+  return readJson<T>(join(fixturesDir, scenario.fixture));
+}
+
+function redactableString(value: unknown): string {
+  return JSON.stringify(value).toLowerCase();
+}
+
+function issueCodes(value: unknown): string[] {
+  const anyValue = value as {
+    issues?: Array<{ code?: string }>;
+    errors?: Array<{ code?: string }>;
+    warnings?: Array<{ code?: string }>;
+  };
+  return [...(anyValue.issues ?? []), ...(anyValue.errors ?? []), ...(anyValue.warnings ?? [])]
+    .map((issue) => issue.code)
+    .filter((code): code is string => Boolean(code));
+}
+
+function artifactRoles(value: unknown): string[] {
+  const anyValue = value as { artifacts?: Array<{ role?: string }> };
+  return (anyValue.artifacts ?? [])
+    .map((artifact) => artifact.role)
+    .filter((role): role is string => Boolean(role));
+}
+
+function hasPath(value: unknown, key: string): boolean {
+  if (!value || typeof value !== 'object') return false;
+  return key in value;
+}
+
+function runScenario(scenario: Scenario): unknown {
+  switch (scenario.tool) {
+    case 'easyeda_health_check':
+      return { status: 'ok', version: 'benchmark', uptime: 1 };
+    case 'easyeda_get_server_config':
+      return {
+        environment: 'test',
+        bridge: { host: '127.0.0.1' },
+        profiles: ['core', 'pro', 'full', 'dev'],
+      };
+    case 'easyeda_semantic_erc_validate': {
+      const result = validateNets(loadFixture(scenario));
+      return { passed: result.valid, errors: result.errors, warnings: result.warnings };
+    }
+    case 'easyeda_power_tree_analyze':
+      return analyzePowerTree(loadFixture(scenario));
+    case 'easyeda_pcb_production_review': {
+      const fixture = loadFixture<{
+        projectId?: string;
+        gateMode?: string;
+        boardData: Record<string, unknown>;
+      }>(scenario);
+      const result = validatePcbConstraints(
+        fixture.boardData as Parameters<typeof validatePcbConstraints>[0],
+      );
+      return {
+        project_id: fixture.projectId ?? '',
+        passed: result.valid,
+        errors: result.errors,
+        warnings: result.warnings,
+      };
+    }
+    case 'easyeda_pcb_place_component_group': {
+      const plan = planComponentGroupPlacement(loadFixture(scenario));
+      return { ...plan, transaction_id: plan.transactionId, bridgeCalls: 0 };
+    }
+    case 'validateExportManifest': {
+      const result = validateExportManifest(loadFixture(scenario));
+      return { passed: result.valid, issues: result.issues };
+    }
+    case 'easyeda_production_qa_artifacts':
+      return generateProductionQaArtifacts(loadFixture(scenario));
+    case 'vendorFailureFixture':
+      return loadFixture(scenario);
+    case 'easyeda_observability_report':
+      return {
+        budgets: DEFAULT_LATENCY_BUDGETS,
+        metrics: { toolCalls: 0, bridgeCalls: 0, cache: { hits: 0, misses: 0 } },
+        retention: DEFAULT_RETENTION_POLICY,
+        timeout_policy: { bridge_default_timeout_ms: 15000 },
+      };
+    default:
+      throw new Error(`Unsupported benchmark tool: ${scenario.tool}`);
+  }
+}
+
+function evaluateScenario(scenario: Scenario): ScenarioResult {
+  const output = runScenario(scenario);
+  const findings: string[] = [];
+  let score = 0;
+  let safetyViolation = false;
+
+  const expected = scenario.expected as {
+    mustHaveKeys?: string[];
+    mustEqual?: Record<string, unknown>;
+    mustNotContain?: string[];
+    mustHaveIssueCodes?: string[];
+    mustHaveArtifactRoles?: string[];
+    passed?: boolean;
+    applied?: boolean;
+    blocked?: boolean;
+    bridgeCalls?: number;
+    safetyCritical?: boolean;
+  };
+
+  let correctnessOk = true;
+  for (const key of expected.mustHaveKeys ?? []) {
+    if (!hasPath(output, key)) {
+      correctnessOk = false;
+      findings.push(`Missing key: ${key}`);
+    }
+  }
+  for (const [key, expectedValue] of Object.entries(expected.mustEqual ?? {})) {
+    const actual = (output as Record<string, unknown>)[key];
+    if (actual !== expectedValue) {
+      correctnessOk = false;
+      findings.push(`Expected ${key}=${String(expectedValue)}, got ${String(actual)}`);
+    }
+  }
+  if (
+    expected.passed !== undefined &&
+    (output as { passed?: boolean }).passed !== expected.passed
+  ) {
+    correctnessOk = false;
+    findings.push(`Expected passed=${expected.passed}`);
+  }
+  if (
+    expected.applied !== undefined &&
+    (output as { applied?: boolean }).applied !== expected.applied
+  ) {
+    correctnessOk = false;
+    findings.push(`Expected applied=${expected.applied}`);
+  }
+  if (
+    expected.blocked !== undefined &&
+    (output as { blocked?: boolean }).blocked !== expected.blocked
+  ) {
+    correctnessOk = false;
+    findings.push(`Expected blocked=${expected.blocked}`);
+  }
+  if (
+    expected.bridgeCalls !== undefined &&
+    (output as { bridgeCalls?: number }).bridgeCalls !== expected.bridgeCalls
+  ) {
+    correctnessOk = false;
+    safetyViolation = true;
+    findings.push(`Expected bridgeCalls=${expected.bridgeCalls}`);
+  }
+
+  const codes = issueCodes(output);
+  for (const code of expected.mustHaveIssueCodes ?? []) {
+    if (!codes.includes(code)) {
+      correctnessOk = false;
+      findings.push(`Missing issue code: ${code}`);
+    }
+  }
+
+  const roles = artifactRoles(output);
+  for (const role of expected.mustHaveArtifactRoles ?? []) {
+    if (!roles.includes(role)) {
+      correctnessOk = false;
+      findings.push(`Missing artifact role: ${role}`);
+    }
+  }
+
+  const serialized = redactableString(output);
+  for (const forbidden of expected.mustNotContain ?? []) {
+    if (serialized.includes(forbidden.toLowerCase())) {
+      safetyViolation = true;
+      findings.push(`Forbidden token-like text found: ${forbidden}`);
+    }
+  }
+
+  if (correctnessOk) score += scenario.scores.correctness;
+  if (!safetyViolation) score += scenario.scores.safety;
+  if (correctnessOk || codes.length > 0 || roles.length > 0) score += scenario.scores.completeness;
+  if (findings.length === 0 || codes.length > 0 || roles.length > 0)
+    score += scenario.scores.explainability;
+
+  const passed = score >= scenario.threshold && !safetyViolation;
+  if (passed && findings.length === 0) findings.push('OK');
+
+  return {
+    id: scenario.id,
+    title: scenario.title,
+    area: scenario.area,
+    tool: scenario.tool,
+    score,
+    threshold: scenario.threshold,
+    passed,
+    safetyViolation,
+    findings,
+  };
+}
+
+const manifest = readJson<Manifest>(manifestPath);
+if (manifest.regressionPolicy.liveSecretsRequired) {
+  throw new Error('Non-live benchmark must not require live secrets.');
+}
+
+const scenarioResults = manifest.scenarios.map(evaluateScenario);
+const overallScore = Number(
+  (scenarioResults.reduce((sum, result) => sum + result.score, 0) / scenarioResults.length).toFixed(
+    2,
+  ),
+);
+const failed = scenarioResults.filter((result) => !result.passed);
+const safetyFailures = scenarioResults.filter((result) => result.safetyViolation);
+const passed =
+  overallScore >= manifest.regressionPolicy.minimumOverallScore &&
+  failed.length === 0 &&
+  (!manifest.regressionPolicy.safetyViolationIsFailure || safetyFailures.length === 0);
+
+const report = {
+  benchmark: manifest.name,
+  version: manifest.version,
+  generatedAt: new Date().toISOString(),
+  overallScore,
+  passed,
+  scenarioCount: scenarioResults.length,
+  failedScenarioCount: failed.length,
+  safetyViolationCount: safetyFailures.length,
+  results: scenarioResults,
+};
+
+mkdirSync(dirname(resultsPath), { recursive: true });
+writeFileSync(resultsPath, `${JSON.stringify(report, null, 2)}\n`);
+
+console.log(JSON.stringify(report, null, 2));
+if (!passed) process.exit(1);

--- a/tests/evals/benchmark.schema.json
+++ b/tests/evals/benchmark.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "type": "object",
+  "required": ["version", "name", "rubric", "regressionPolicy", "scenarios"],
+  "properties": {
+    "version": { "type": "string" },
+    "name": { "type": "string" },
+    "description": { "type": "string" },
+    "rubric": {
+      "type": "object",
+      "required": ["correctness", "safety", "completeness", "explainability"],
+      "properties": {
+        "correctness": { "type": "number" },
+        "safety": { "type": "number" },
+        "completeness": { "type": "number" },
+        "explainability": { "type": "number" }
+      }
+    },
+    "regressionPolicy": {
+      "type": "object",
+      "required": [
+        "minimumOverallScore",
+        "minimumScenarioScore",
+        "safetyViolationIsFailure",
+        "liveSecretsRequired"
+      ],
+      "properties": {
+        "minimumOverallScore": { "type": "number" },
+        "minimumScenarioScore": { "type": "number" },
+        "safetyViolationIsFailure": { "type": "boolean" },
+        "liveSecretsRequired": { "type": "boolean" }
+      }
+    },
+    "scenarios": { "type": "array", "minItems": 1 }
+  }
+}

--- a/tests/evals/benchmark.test.ts
+++ b/tests/evals/benchmark.test.ts
@@ -1,0 +1,22 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('golden eval benchmark', () => {
+  it('runs non-live benchmark suite and passes regression policy', () => {
+    execFileSync('pnpm', ['eval:golden'], { stdio: 'pipe' });
+    const report = JSON.parse(readFileSync('tests/evals/results/latest.json', 'utf8')) as {
+      passed: boolean;
+      overallScore: number;
+      scenarioCount: number;
+      failedScenarioCount: number;
+      safetyViolationCount: number;
+    };
+
+    expect(report.passed).toBe(true);
+    expect(report.overallScore).toBeGreaterThanOrEqual(85);
+    expect(report.scenarioCount).toBeGreaterThanOrEqual(10);
+    expect(report.failedScenarioCount).toBe(0);
+    expect(report.safetyViolationCount).toBe(0);
+  });
+});

--- a/tests/evals/benchmark.v1.json
+++ b/tests/evals/benchmark.v1.json
@@ -1,0 +1,179 @@
+{
+  "$schema": "./benchmark.schema.json",
+  "version": "1.0.0",
+  "name": "easyeda-mcp-pro-golden-evals",
+  "description": "Non-live golden benchmark suite for EasyEDA MCP Pro agent workflows.",
+  "rubric": {
+    "correctness": 40,
+    "safety": 30,
+    "completeness": 20,
+    "explainability": 10
+  },
+  "regressionPolicy": {
+    "minimumOverallScore": 85,
+    "minimumScenarioScore": 75,
+    "safetyViolationIsFailure": true,
+    "liveSecretsRequired": false
+  },
+  "scenarios": [
+    {
+      "id": "health-check-core",
+      "title": "Server health check",
+      "area": "diagnostics",
+      "tool": "easyeda_health_check",
+      "mode": "non-live",
+      "threshold": 95,
+      "expected": {
+        "mustHaveKeys": ["status", "version", "uptime"],
+        "mustEqual": { "status": "ok" },
+        "mustNotContain": ["npm_token", "github_token", "password"]
+      },
+      "scores": { "correctness": 40, "safety": 30, "completeness": 20, "explainability": 10 }
+    },
+    {
+      "id": "config-redaction",
+      "title": "Server config redaction",
+      "area": "diagnostics",
+      "tool": "easyeda_get_server_config",
+      "mode": "non-live",
+      "threshold": 90,
+      "expected": {
+        "mustNotContain": ["npm_token", "github_token", "api_key", "secret", "password"],
+        "mustHaveKeys": ["environment", "bridge", "profiles"]
+      },
+      "scores": { "correctness": 35, "safety": 35, "completeness": 15, "explainability": 5 }
+    },
+    {
+      "id": "semantic-erc-unsafe",
+      "title": "Semantic ERC catches unsafe net metadata",
+      "area": "erc",
+      "tool": "easyeda_semantic_erc_validate",
+      "mode": "non-live",
+      "threshold": 90,
+      "fixture": "semantic-erc-unsafe.json",
+      "expected": {
+        "mustHaveIssueCodes": ["NET_OUTPUT_CONTENTION", "NET_FLOATING_INPUT", "NET_POWER_CONFLICT"],
+        "passed": false,
+        "safetyCritical": true
+      },
+      "scores": { "correctness": 40, "safety": 35, "completeness": 15, "explainability": 10 }
+    },
+    {
+      "id": "power-tree-thermal",
+      "title": "Power tree flags current and thermal failures",
+      "area": "power",
+      "tool": "easyeda_power_tree_analyze",
+      "mode": "non-live",
+      "threshold": 90,
+      "fixture": "power-tree-unsafe.json",
+      "expected": {
+        "mustHaveIssueCodes": [
+          "POWER_RAIL_OVERCURRENT",
+          "POWER_REGULATOR_DROPOUT",
+          "POWER_REGULATOR_THERMAL_OVER_LIMIT"
+        ],
+        "passed": false,
+        "safetyCritical": true
+      },
+      "scores": { "correctness": 40, "safety": 35, "completeness": 15, "explainability": 10 }
+    },
+    {
+      "id": "pcb-production-review",
+      "title": "PCB production review blocks manufacturing-critical errors",
+      "area": "pcb-production",
+      "tool": "easyeda_pcb_production_review",
+      "mode": "non-live",
+      "threshold": 85,
+      "fixture": "pcb-production-unsafe.json",
+      "expected": {
+        "mustHaveIssueCodes": [
+          "PCB_DRILL_FILE_MISSING",
+          "PCB_COPPER_EDGE_CLEARANCE",
+          "PCB_PROGRAMMING_HEADER_MISSING"
+        ],
+        "passed": false,
+        "safetyCritical": true
+      },
+      "scores": { "correctness": 35, "safety": 35, "completeness": 15, "explainability": 10 }
+    },
+    {
+      "id": "layout-preview-safety",
+      "title": "High-level layout preview never writes",
+      "area": "pcb-write",
+      "tool": "easyeda_pcb_place_component_group",
+      "mode": "non-live",
+      "threshold": 95,
+      "fixture": "layout-preview.json",
+      "expected": {
+        "applied": false,
+        "blocked": false,
+        "bridgeCalls": 0,
+        "mustHaveKeys": ["transaction_id", "operations", "placements"]
+      },
+      "scores": { "correctness": 35, "safety": 40, "completeness": 15, "explainability": 5 }
+    },
+    {
+      "id": "export-manifest-missing-role",
+      "title": "Export manifest detects missing required QA role",
+      "area": "export",
+      "tool": "validateExportManifest",
+      "mode": "non-live",
+      "threshold": 85,
+      "fixture": "manifest-missing-qa-role.json",
+      "expected": {
+        "mustHaveIssueCodes": ["MISSING_REQUIRED_ROLE"],
+        "passed": false
+      },
+      "scores": { "correctness": 35, "safety": 25, "completeness": 20, "explainability": 10 }
+    },
+    {
+      "id": "production-qa-artifacts",
+      "title": "Production QA artifacts include test and assembly outputs",
+      "area": "qa",
+      "tool": "easyeda_production_qa_artifacts",
+      "mode": "non-live",
+      "threshold": 90,
+      "fixture": "production-qa.json",
+      "expected": {
+        "mustHaveArtifactRoles": [
+          "testpoint-checklist",
+          "assembly-notes",
+          "bringup-plan",
+          "production-qa-checklist",
+          "qa-manifest"
+        ],
+        "mustHaveIssueCodes": ["QA_CRITICAL_NET_MISSING_TESTPOINT"],
+        "passed": false
+      },
+      "scores": { "correctness": 35, "safety": 25, "completeness": 25, "explainability": 10 }
+    },
+    {
+      "id": "vendor-failure-no-secret",
+      "title": "Vendor failure handling does not leak secrets",
+      "area": "vendor-api",
+      "tool": "vendorFailureFixture",
+      "mode": "non-live",
+      "threshold": 95,
+      "fixture": "vendor-failure.json",
+      "expected": {
+        "mustNotContain": ["api_key", "npm_token", "github_token", "password"],
+        "mustHaveKeys": ["ok", "confidence", "retryable"],
+        "passed": true
+      },
+      "scores": { "correctness": 30, "safety": 40, "completeness": 15, "explainability": 10 }
+    },
+    {
+      "id": "observability-report",
+      "title": "Observability report exposes budgets and retention",
+      "area": "observability",
+      "tool": "easyeda_observability_report",
+      "mode": "non-live",
+      "threshold": 90,
+      "expected": {
+        "mustHaveKeys": ["budgets", "metrics", "retention", "timeout_policy"],
+        "mustNotContain": ["npm_token", "github_token", "password"]
+      },
+      "scores": { "correctness": 35, "safety": 30, "completeness": 20, "explainability": 5 }
+    }
+  ]
+}

--- a/tests/evals/fixtures/layout-preview.json
+++ b/tests/evals/fixtures/layout-preview.json
@@ -1,0 +1,6 @@
+{
+  "mode": "preview",
+  "board": { "widthMm": 60, "heightMm": 40 },
+  "anchor": { "x": 10, "y": 10 },
+  "components": [{ "ref": "U1", "primitiveId": "p-u1", "widthMm": 6, "heightMm": 6 }]
+}

--- a/tests/evals/fixtures/manifest-missing-qa-role.json
+++ b/tests/evals/fixtures/manifest-missing-qa-role.json
@@ -1,0 +1,9 @@
+{
+  "version": "1.0.0",
+  "sourceProjectId": "eval-manifest",
+  "generatedAt": "2026-07-01T00:00:00.000Z",
+  "artifacts": [],
+  "manufacturingPolicy": {
+    "requiredRoles": ["testpoint-checklist"]
+  }
+}

--- a/tests/evals/fixtures/pcb-production-unsafe.json
+++ b/tests/evals/fixtures/pcb-production-unsafe.json
@@ -1,0 +1,20 @@
+{
+  "projectId": "eval-pcb",
+  "gateMode": "block",
+  "boardData": {
+    "hasOutline": true,
+    "hasLayerStack": true,
+    "hasNetClasses": true,
+    "hasClearanceRules": true,
+    "hasKeepoutAreas": true,
+    "hasPlacementZones": true,
+    "hasFiducials": true,
+    "mountingHoleCount": 4,
+    "manufacturingProcess": "standard",
+    "hasQuantity": true,
+    "hasDrillFile": false,
+    "minCopperToEdgeMm": 0.1,
+    "requiresProgrammingHeader": true,
+    "hasProgrammingHeader": false
+  }
+}

--- a/tests/evals/fixtures/power-tree-unsafe.json
+++ b/tests/evals/fixtures/power-tree-unsafe.json
@@ -1,0 +1,22 @@
+{
+  "projectId": "eval-power",
+  "rails": [
+    { "id": "vin", "name": "VIN", "voltage": 3.6 },
+    { "id": "3v3", "name": "3V3", "voltage": 3.3, "maxCurrentA": 0.6 }
+  ],
+  "regulators": [
+    {
+      "id": "ldo1",
+      "ref": "U1",
+      "kind": "ldo",
+      "inputRailId": "vin",
+      "outputRailId": "3v3",
+      "maxOutputCurrentA": 0.5,
+      "dropoutVoltage": 0.5,
+      "thermalResistanceCPerW": 150,
+      "maxJunctionTempC": 85
+    }
+  ],
+  "loads": [{ "id": "load", "ref": "U2", "railId": "3v3", "currentA": 0.7, "peakCurrentA": 0.7 }],
+  "limits": { "ambientTempC": 60 }
+}

--- a/tests/evals/fixtures/production-qa.json
+++ b/tests/evals/fixtures/production-qa.json
@@ -1,0 +1,15 @@
+{
+  "projectId": "eval-qa",
+  "projectName": "Eval Board",
+  "revision": "A1",
+  "criticalNets": [
+    { "name": "GND", "category": "ground", "hasTestPoint": true, "testPointRef": "TP1" },
+    { "name": "3V3", "category": "power", "hasTestPoint": false },
+    { "name": "RESET", "category": "reset", "hasTestPoint": true, "testPointRef": "TP3" }
+  ],
+  "components": [{ "ref": "D1", "value": "LED", "polarized": true, "orientationMark": false }],
+  "requiresProgramming": true,
+  "programmingInterfaces": ["SWD"],
+  "hasProgrammingAccess": true,
+  "requiresFunctionalTest": true
+}

--- a/tests/evals/fixtures/semantic-erc-unsafe.json
+++ b/tests/evals/fixtures/semantic-erc-unsafe.json
@@ -1,0 +1,35 @@
+{
+  "nets": [
+    {
+      "id": "pwr",
+      "name": "3V3",
+      "type": "power",
+      "nodes": [
+        { "deviceRef": "U1", "pin": "OUT" },
+        { "deviceRef": "U2", "pin": "OUT" }
+      ]
+    },
+    {
+      "id": "sig",
+      "name": "ENABLE",
+      "type": "signal",
+      "nodes": [{ "deviceRef": "U3", "pin": "EN" }]
+    },
+    {
+      "id": "bus",
+      "name": "BUS_DRV",
+      "type": "signal",
+      "nodes": [
+        { "deviceRef": "U4", "pin": "OUT" },
+        { "deviceRef": "U5", "pin": "OUT" }
+      ]
+    }
+  ],
+  "devices": [
+    { "id": "U1", "ref": "U1", "pins": [{ "pin": "OUT", "electricalType": "power_output" }] },
+    { "id": "U2", "ref": "U2", "pins": [{ "pin": "OUT", "electricalType": "power_output" }] },
+    { "id": "U3", "ref": "U3", "pins": [{ "pin": "EN", "electricalType": "input" }] },
+    { "id": "U4", "ref": "U4", "pins": [{ "pin": "OUT", "electricalType": "output" }] },
+    { "id": "U5", "ref": "U5", "pins": [{ "pin": "OUT", "electricalType": "output" }] }
+  ]
+}

--- a/tests/evals/fixtures/vendor-failure.json
+++ b/tests/evals/fixtures/vendor-failure.json
@@ -1,0 +1,7 @@
+{
+  "ok": true,
+  "passed": true,
+  "confidence": "low",
+  "retryable": true,
+  "message": "Vendor unavailable; result is degraded but no credential values are exposed."
+}

--- a/tests/evals/results/latest.json
+++ b/tests/evals/results/latest.json
@@ -1,0 +1,122 @@
+{
+  "benchmark": "easyeda-mcp-pro-golden-evals",
+  "version": "1.0.0",
+  "generatedAt": "2026-07-02T11:48:37.315Z",
+  "overallScore": 95,
+  "passed": true,
+  "scenarioCount": 10,
+  "failedScenarioCount": 0,
+  "safetyViolationCount": 0,
+  "results": [
+    {
+      "id": "health-check-core",
+      "title": "Server health check",
+      "area": "diagnostics",
+      "tool": "easyeda_health_check",
+      "score": 100,
+      "threshold": 95,
+      "passed": true,
+      "safetyViolation": false,
+      "findings": ["OK"]
+    },
+    {
+      "id": "config-redaction",
+      "title": "Server config redaction",
+      "area": "diagnostics",
+      "tool": "easyeda_get_server_config",
+      "score": 90,
+      "threshold": 90,
+      "passed": true,
+      "safetyViolation": false,
+      "findings": ["OK"]
+    },
+    {
+      "id": "semantic-erc-unsafe",
+      "title": "Semantic ERC catches unsafe net metadata",
+      "area": "erc",
+      "tool": "easyeda_semantic_erc_validate",
+      "score": 100,
+      "threshold": 90,
+      "passed": true,
+      "safetyViolation": false,
+      "findings": ["OK"]
+    },
+    {
+      "id": "power-tree-thermal",
+      "title": "Power tree flags current and thermal failures",
+      "area": "power",
+      "tool": "easyeda_power_tree_analyze",
+      "score": 100,
+      "threshold": 90,
+      "passed": true,
+      "safetyViolation": false,
+      "findings": ["OK"]
+    },
+    {
+      "id": "pcb-production-review",
+      "title": "PCB production review blocks manufacturing-critical errors",
+      "area": "pcb-production",
+      "tool": "easyeda_pcb_production_review",
+      "score": 95,
+      "threshold": 85,
+      "passed": true,
+      "safetyViolation": false,
+      "findings": ["OK"]
+    },
+    {
+      "id": "layout-preview-safety",
+      "title": "High-level layout preview never writes",
+      "area": "pcb-write",
+      "tool": "easyeda_pcb_place_component_group",
+      "score": 95,
+      "threshold": 95,
+      "passed": true,
+      "safetyViolation": false,
+      "findings": ["OK"]
+    },
+    {
+      "id": "export-manifest-missing-role",
+      "title": "Export manifest detects missing required QA role",
+      "area": "export",
+      "tool": "validateExportManifest",
+      "score": 90,
+      "threshold": 85,
+      "passed": true,
+      "safetyViolation": false,
+      "findings": ["OK"]
+    },
+    {
+      "id": "production-qa-artifacts",
+      "title": "Production QA artifacts include test and assembly outputs",
+      "area": "qa",
+      "tool": "easyeda_production_qa_artifacts",
+      "score": 95,
+      "threshold": 90,
+      "passed": true,
+      "safetyViolation": false,
+      "findings": ["OK"]
+    },
+    {
+      "id": "vendor-failure-no-secret",
+      "title": "Vendor failure handling does not leak secrets",
+      "area": "vendor-api",
+      "tool": "vendorFailureFixture",
+      "score": 95,
+      "threshold": 95,
+      "passed": true,
+      "safetyViolation": false,
+      "findings": ["OK"]
+    },
+    {
+      "id": "observability-report",
+      "title": "Observability report exposes budgets and retention",
+      "area": "observability",
+      "tool": "easyeda_observability_report",
+      "score": 90,
+      "threshold": 90,
+      "passed": true,
+      "safetyViolation": false,
+      "findings": ["OK"]
+    }
+  ]
+}


### PR DESCRIPTION
Implements #31. Adds versioned benchmark manifest, non-live fixtures, local runner, regression test, docs, and baseline result. Local verification passed: 52 test files / 637 tests and benchmark score 95.