### PR TITLE
fix: harden release and governance checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,14 @@ jobs:
       - run: pnpm generate:tools-doc
       - run: git diff --exit-code docs/reference/tools.md
       - run: pnpm docs:build
+      - name: Docker default startup smoke
+        run: |
+          docker build -t easyeda-mcp-pro:ci .
+          cid=$(docker run -d easyeda-mcp-pro:ci)
+          trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+          sleep 3
+          docker logs "$cid"
+          docker exec "$cid" node -e "const r = await fetch('http://127.0.0.1:3000/healthz'); if (!r.ok) process.exit(1); console.log(await r.text());"
 
   codeql:
     if: (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && (github.event_name == 'push' || github.event_name == 'pull_request')

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,8 +33,9 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 ENV TRANSPORT=http
-ENV HTTP_HOST=0.0.0.0
+ENV HTTP_HOST=127.0.0.1
 ENV HTTP_PORT=3000
+# For externally reachable HTTP deployments, override HTTP_HOST=0.0.0.0 and provide OAuth + ALLOWED_ORIGINS.
 
 # Copy runtime assets and built package
 COPY --from=builder /app/package.json ./package.json

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13406/badge)](https://www.bestpractices.dev/projects/13406)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/oaslananka/easyeda-mcp-pro)
 
+Compliance docs: [Third-Party Notices](THIRD_PARTY_NOTICES.md) · [Vendor Terms and Unsupported Workflows](docs/vendor-terms.md)
+
 <p align="center">
   <a href="https://www.buymeacoffee.com/oaslananka">
     <img src="https://img.buymeacoffee.com/button-api/?text=Buy%20me%20a%20coffee&emoji=%E2%98%95&slug=oaslananka&button_colour=FFDD00&font_colour=000000&font_family=Arial&outline_colour=000000&coffee_colour=ffffff" alt="Buy me a coffee" />
@@ -46,7 +48,7 @@ For advanced configurations, manual instructions, and specific clients, see [Ins
 
 ## Overview
 
-easyeda-mcp-pro is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that bridges AI assistants with hardware design workflows in EasyEDA Pro. It exposes 52 profile-gated MCP tools for schematic inspection and editing, controlled EasyEDA Pro API calls, BOM management, design rule checks, PCB board analysis, fabrication exports, and supplier integration.
+easyeda-mcp-pro is a [Model Context Protocol (MCP)](https://modelcontextprotocol.io) server that bridges AI assistants with hardware design workflows in EasyEDA Pro. It exposes up to 60 profile-gated MCP tools for schematic inspection and editing, controlled EasyEDA Pro API calls, BOM management, design rule checks, PCB board analysis, fabrication exports, and supplier integration.
 
 The server connects to EasyEDA Pro via a WebSocket bridge extension, enabling real-time access to open project data. It integrates with JLCPCB, LCSC, Mouser, and DigiKey for BOM sourcing and pricing.
 
@@ -456,6 +458,24 @@ When `OAUTH_ENABLED=true`, every request to `/mcp` must include an `Authorizatio
 
 The server enforces startup safety checks: **non-loopback `HTTP_HOST` without OAuth is rejected**, and `HTTP_AUTH_DISABLED=true` is rejected outside non-production loopback deployments.
 
+### Docker defaults
+
+The Docker image starts in HTTP mode with `HTTP_HOST=127.0.0.1` so the default container boot path is safe and passes the same startup safety checks as local HTTP mode. For an externally reachable container, override the bind address and configure OAuth plus an explicit origin allowlist:
+
+```bash
+docker run --rm \
+  -e HTTP_HOST=0.0.0.0 \
+  -e ALLOWED_ORIGINS=https://your-client.example.com \
+  -e OAUTH_ENABLED=true \
+  -e OAUTH_ISSUER=https://issuer.example.com/ \
+  -e OAUTH_JWKS_URI=https://issuer.example.com/.well-known/jwks.json \
+  -e OAUTH_AUDIENCE=easyeda-mcp-pro \
+  -p 127.0.0.1:3000:3000 \
+  ghcr.io/oaslananka/easyeda-mcp-pro:latest
+```
+
+Do not expose non-loopback HTTP without OAuth. Use a reverse proxy or platform gateway for TLS termination and external access.
+
 #### HTTP Security Features
 
 - **Rate limiting**: Per-IP sliding window (configurable via `HTTP_RATE_LIMIT_MAX`), returns `429 Too Many Requests` with retry-after header
@@ -568,7 +588,7 @@ The schematic write APIs use EasyEDA Pro extension APIs that EasyEDA currently m
 │  (via Plugin)    │     Protocol      │  └───────────────┘  │
 └─────────────────┘                    │  ┌───────────────┐  │
                                        │  │  ToolRegistry  │  │
-                                       │  │  (41 tools)   │  │
+                                       │  │ (up to 60)    │  │
                                        │  └───────────────┘  │
                                        │  ┌───────────────┐  │
                                        │  │    Storage     │──┼──► SQLite

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,49 @@
+# Third-Party Notices
+
+This project is distributed under the MIT License. This notice file summarizes third-party materials and external services that maintainers should review before each release. It is not legal advice.
+
+## Runtime and development dependencies
+
+The npm package depends on third-party open source packages declared in `package.json` and resolved in `pnpm-lock.yaml`. Maintain release evidence through:
+
+- `pnpm audit --audit-level low`
+- generated CycloneDX SBOM from the release workflow
+- npm package provenance / GitHub attestations
+- dependency review via Renovate, Dependabot, and CodeQL
+
+Before a v1.0 release, attach the SBOM to the GitHub release and retain the generated artifact with the release notes.
+
+## Bundled extension artifact
+
+The npm package includes `easyeda-bridge-extension.eext`. The source for that artifact lives under `easyeda-bridge-extension/` and is built by `pnpm build:extension`.
+
+The extension interacts with EasyEDA Pro through the user's installed EasyEDA environment. It must not claim endorsement by EasyEDA, JLCPCB, LCSC, Mouser, DigiKey, or any other vendor unless that vendor has granted explicit permission.
+
+## External services and trademarks
+
+`easyeda-mcp-pro` can integrate with or reference external services:
+
+| Service          | Project use                                         | Maintainer note                                                                                                |
+| ---------------- | --------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| EasyEDA Pro      | Local editor/runtime bridge                         | Users must comply with EasyEDA's terms for their own account, projects, and extension use.                     |
+| JLCPCB           | Quote/manufacturing workflow preparation            | Quote and order workflows must remain non-binding unless explicit human review and credentials are configured. |
+| LCSC / jlcsearch | Part search, availability, and BOM context          | Public search data must be treated as advisory and rechecked before ordering.                                  |
+| Mouser           | Optional supplier search/cart/order API integration | Requires user-provided credentials and compliance with Mouser API/account terms.                               |
+| DigiKey          | Optional supplier API integration                   | Requires user-provided credentials and compliance with DigiKey developer/account terms.                        |
+
+All vendor names, logos, product names, and trademarks belong to their respective owners. This repository does not redistribute vendor databases, datasheets, pricing feeds, or proprietary EasyEDA/JLCPCB/LCSC/Mouser/DigiKey content.
+
+## Generated outputs
+
+The server can generate local review, manifest, BOM, export, benchmark, and QA artifacts. Generated outputs are user/project data and are not part of the project license unless explicitly committed by the maintainer.
+
+## Release checklist
+
+Before each public release:
+
+- Run the complete CI gate from `docs/release-ci-runbook.md`.
+- Confirm `npm pack --dry-run` includes only intended files.
+- Verify `easyeda-bridge-extension.eext` is rebuilt and checksummed.
+- Review `docs/vendor-terms.md` for stale vendor links or unsupported workflows.
+- Attach SBOM and extension artifacts to the GitHub release.
+- Do not include credentials, private designs, vendor API responses, or generated customer data in release artifacts.

--- a/docs/benchmark-suite.md
+++ b/docs/benchmark-suite.md
@@ -10,6 +10,8 @@ It validates diagnostics, semantic ERC, power-tree analysis, PCB production revi
 pnpm eval:golden
 ```
 
+The default benchmark output path is ignored by git so routine validation does not dirty the working tree. Use `pnpm eval:golden:update` only when intentionally refreshing `tests/evals/results/latest.json`.
+
 The command runs without live EasyEDA access and without vendor credentials.
 
 ## Files
@@ -18,7 +20,7 @@ The command runs without live EasyEDA access and without vendor credentials.
 tests/evals/benchmark.v1.json
 tests/evals/benchmark.schema.json
 tests/evals/fixtures/
-tests/evals/results/latest.json
+.easyeda-mcp-pro/evals/latest.json
 ```
 
 ## Current public baseline
@@ -71,5 +73,5 @@ A regression is any failed scenario, overall score below the policy threshold, o
 1. Add a fixture under `tests/evals/fixtures/` when needed.
 2. Add a scenario entry to `tests/evals/benchmark.v1.json`.
 3. Extend `scripts/run-evals.mts` if the scenario uses a new local module/tool family.
-4. Run `pnpm eval:golden`.
+4. Run `pnpm eval:golden`. To intentionally refresh the tracked baseline, run `pnpm eval:golden:update`.
 5. Commit the updated benchmark result when the suite intentionally changes.

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -107,10 +107,10 @@ Tools are organized into hierarchical profiles: `core` < `pro` < `full` < `dev` 
 - The `TOOL_PROFILE` environment variable selects which tools are enabled.
 - Each tool definition declares a minimum `profile` level.
 - Only tools at or below the active profile are registered on the MCP server.
-- `core` is the default and exposes ~29 tools.
-- `pro` adds manufacturing export tools (pick-and-place, PDF, netlist).
-- `full` adds the controlled `easyeda_api_call` tool for direct EasyEDA API access.
-- `dev` adds runtime probes for debugging (bridge method probing, component inspection).
+- `core` is the default and exposes 42 tools.
+- `pro` exposes 47 tools and adds manufacturing export tools (pick-and-place, PDF, netlist).
+- `full` exposes 56 tools and adds the controlled `easyeda_api_call` tool for direct EasyEDA API access.
+- `dev` exposes 60 tools and adds runtime probes for debugging (bridge method probing, component inspection).
 - `experimental` enables MCP Apps, Tasks, simulation, autorouter, and AI action plans.
 
 **Security principle:** Privilege escalation is prevented because tool registration happens at startup. Changing the active profile requires a server restart.
@@ -359,7 +359,7 @@ Path traversal protection is enforced in all export tools — artifact paths are
 ### 9.3 Branch Protection
 
 - `main` requires PR approval (minimum 1 reviewer).
-- Status checks must pass: `quality (24)`, `quality (25)`, `codeql`.
+- Status checks must pass: `quality (24)` and CodeQL analysis.
 - Branches must be up to date before merging.
 - Linear history enforced (squash or rebase merge).
 

--- a/docs/vendor-terms.md
+++ b/docs/vendor-terms.md
@@ -1,0 +1,43 @@
+# Vendor Terms and Unsupported Workflows
+
+This page records the compliance posture for integrations used by `easyeda-mcp-pro`. It is an engineering checklist, not legal advice. Maintainers should review the linked vendor pages before v1.0 and before any feature that expands API use, ordering, extension distribution, or redistribution of vendor data.
+
+## Source links reviewed
+
+| Vendor / service      | Source to review                                                | Why it matters                                                                                                                                                         |
+| --------------------- | --------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| EasyEDA               | https://easyeda.com/page/legal                                  | Governs use of EasyEDA services, accounts, user content, third-party services, limitations of liability, and related rights.                                           |
+| JLCPCB                | https://jlcpcb.com/terms                                        | Governs JLCPCB manufacturing/order workflows when users move from review/quote preparation to actual purchase.                                                         |
+| LCSC                  | https://www.lcsc.com                                            | Governs LCSC catalog, account, purchasing, and data use. If using a public/unofficial mirror such as `jlcsearch.tscircuit.com`, also review its terms and attribution. |
+| jlcsearch / tscircuit | https://jlcsearch.tscircuit.com/                                | Used as a public JLCPCB in-stock parts engine; its page states it is unofficial and operated by tscircuit, not JLCPCB.                                                 |
+| Mouser                | https://www.mouser.com/api-hub/ and Mouser Terms and Conditions | Governs Mouser product data, availability, pricing, cart, order, and order-history API use.                                                                            |
+| DigiKey               | https://developer.digikey.com/                                  | Governs DigiKey developer API credentials, data access, and API usage.                                                                                                 |
+
+## Project rules
+
+1. The MCP server may read local EasyEDA project data only through the user's local EasyEDA Pro session and bridge extension.
+2. Supplier data is advisory. Stock, price, lifecycle, and replacement information must be rechecked with the vendor before ordering or manufacturing handoff.
+3. Ordering is disabled by default. Any quote/order workflow must be non-binding unless the user configures approved credentials and explicitly confirms the action.
+4. The project must not redistribute vendor catalogs, pricing databases, datasheet archives, proprietary EasyEDA runtime files, or private user designs.
+5. The project must not imply vendor endorsement or partnership without explicit permission.
+6. Credentials must be supplied by the user through environment variables or the host secret store and must never be committed, logged, included in artifacts, or returned by MCP tools.
+7. Human review remains mandatory before fabrication, assembly, paid quotes, component substitution, or ordering.
+
+## Unsupported or restricted workflows
+
+The following workflows are intentionally unsupported unless a future legal/product review approves them:
+
+- Automatic paid JLCPCB/Mouser/DigiKey ordering without human confirmation.
+- Scraping or bulk redistribution of vendor catalog data.
+- Shipping preloaded vendor credentials or shared API keys.
+- Uploading full private board geometry/netlists to supplier APIs except where the user explicitly triggers a documented export or quote workflow.
+- Using vendor trademarks/logos in marketing in a way that implies endorsement.
+- Circumventing EasyEDA account, extension, or workspace restrictions.
+
+## Acceptance criteria for v1.0
+
+- `THIRD_PARTY_NOTICES.md` exists and is linked from the README.
+- Release artifacts contain no private designs, credentials, vendor API payload caches, or generated customer data.
+- All supplier/order features clearly label stock/price/quote output as advisory until a human verifies it.
+- The quote workflow keeps explicit human-review gates and audit evidence.
+- `pnpm audit`, CodeQL, dependency review, and secret scanning are clean or have documented risk acceptance.

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "check:metadata": "node scripts/check-metadata.mjs",
     "inventory:capture": "tsx scripts/capture-runtime-inventory.mts",
     "inventory:diff": "tsx scripts/diff-runtime-inventory.mts",
-    "eval:golden": "tsx scripts/run-evals.mts"
+    "eval:golden": "tsx scripts/run-evals.mts",
+    "eval:golden:update": "tsx scripts/run-evals.mts --update-baseline"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/scripts/run-evals.mts
+++ b/scripts/run-evals.mts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { validateNets } from '../src/net-validation/index.js';
 import { analyzePowerTree } from '../src/power-tree/index.js';
@@ -13,7 +13,24 @@ import { DEFAULT_LATENCY_BUDGETS, DEFAULT_RETENTION_POLICY } from '../src/observ
 const root = dirname(fileURLToPath(new URL('../package.json', import.meta.url)));
 const manifestPath = join(root, 'tests/evals/benchmark.v1.json');
 const fixturesDir = join(root, 'tests/evals/fixtures');
-const resultsPath = join(root, 'tests/evals/results/latest.json');
+const baselineResultsPath = join(root, 'tests/evals/results/latest.json');
+const defaultResultsPath = join(root, '.easyeda-mcp-pro/evals/latest.json');
+
+function parseArgs(argv: string[]): { outputPath: string; updateBaseline: boolean } {
+  const updateBaseline = argv.includes('--update-baseline') || argv.includes('--update');
+  const outputIndex = argv.indexOf('--output');
+  if (outputIndex >= 0 && !argv[outputIndex + 1]) {
+    throw new Error('--output requires a file path');
+  }
+  const outputPath = updateBaseline
+    ? baselineResultsPath
+    : outputIndex >= 0
+      ? resolve(root, argv[outputIndex + 1])
+      : defaultResultsPath;
+  return { outputPath, updateBaseline };
+}
+
+const { outputPath: resultsPath } = parseArgs(process.argv.slice(2));
 
 type Scenario = {
   id: string;

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -54,7 +54,7 @@ if (fs.existsSync(serverJsonPath)) {
 try {
   const prettierFiles = [extensionJsonPath, serverJsonPath].filter((f) => fs.existsSync(f));
   if (prettierFiles.length > 0) {
-    execSync(`npx prettier --write ${prettierFiles.join(' ')}`, {
+    execFileSync('npx', ['prettier', '--write', ...prettierFiles], {
       cwd: root,
       stdio: 'pipe',
       encoding: 'utf8',

--- a/tests/evals/benchmark.test.ts
+++ b/tests/evals/benchmark.test.ts
@@ -1,11 +1,17 @@
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 describe('golden eval benchmark', () => {
   it('runs non-live benchmark suite and passes regression policy', () => {
-    execFileSync('pnpm', ['eval:golden'], { stdio: 'pipe' });
-    const report = JSON.parse(readFileSync('tests/evals/results/latest.json', 'utf8')) as {
+    const resultPath = '.easyeda-mcp-pro/evals/vitest-latest.json';
+    rmSync(resultPath, { force: true });
+    mkdirSync(dirname(resultPath), { recursive: true });
+    execFileSync('pnpm', ['exec', 'tsx', 'scripts/run-evals.mts', '--output', resultPath], {
+      stdio: 'pipe',
+    });
+    const report = JSON.parse(readFileSync(resultPath, 'utf8')) as {
       passed: boolean;
       overallScore: number;
       scenarioCount: number;


### PR DESCRIPTION
## Summary

This PR closes the audit findings from the 2026-07-02 review:

- Fixes the CodeQL shell-command construction warning in `scripts/sync-versions.mjs` by using `execFileSync` with argument arrays.
- Makes `pnpm eval:golden` non-mutating by default so routine benchmark runs no longer dirty `tests/evals/results/latest.json`.
- Adds `pnpm eval:golden:update` for intentional tracked baseline refreshes.
- Adds Docker default startup smoke to CI and changes Docker default bind address to a safe loopback default.
- Updates README/security docs to match the actual tool profile counts: core 42, pro 47, full 56, dev 60.
- Adds `THIRD_PARTY_NOTICES.md` and `docs/vendor-terms.md` for vendor/API/legal-risk tracking.

Closes #44.

## Verification

- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `pnpm test` — 54 files / 649 tests passed
- `pnpm eval:golden` — passed and did not modify tracked files
- `pnpm check:metadata`
- `pnpm verify:tool-coverage`
- `pnpm typecheck:extension`
- `pnpm build:extension`
- `pnpm verify:extension`
- `pnpm docs:build`
- `pnpm audit --audit-level low`
- `pnpm peers check`
- `pnpm lint:tools`
- `pnpm test:coverage` — All files: 80.79% statements / 81.21% lines
- `npm pack --dry-run`

Docker local smoke could not be run in the WSL environment because Docker is unavailable there; CI now contains the Docker smoke step.

## Repo settings applied outside this PR

Branch protection for `main` has been enabled with:

- required status checks: `quality (24)`, `codeql`, `Socket Security: Project Report`
- strict up-to-date branches
- 1 required approving review
- stale review dismissal
- admin enforcement
- conversation resolution required
- force pushes and deletions disabled

GitHub security feature enablement for Dependabot alerts / secret scanning still needs to be completed in repository settings if the API remains unavailable.
