### PR TITLE
docs: define remote MCP foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@
   <a href="docs/vendor-terms.md">Vendor Terms and Unsupported Workflows</a>
   ·
   <a href="docs/OPENSSF_BEST_PRACTICES.md">OpenSSF Best Practices</a>
+  ·
+  <a href="docs/REMOTE_MCP_MODES.md">Remote MCP Modes</a>
 </p>
 
 </div>

--- a/docs/CHATGPT_APP_INTEGRATION.md
+++ b/docs/CHATGPT_APP_INTEGRATION.md
@@ -1,0 +1,56 @@
+# ChatGPT app integration plan
+
+ChatGPT integration should use the hosted Remote MCP architecture as the primary app path. Self-hosted endpoints remain an advanced/developer path for clients that can connect to arbitrary remote MCP URLs.
+
+## Target architecture
+
+```text
+ChatGPT app
+  ↓
+Hosted Remote MCP Gateway
+  ↓
+Session Router
+  ↓
+Extension Relay
+  ↓
+EasyEDA bridge extension
+  ↓
+Open EasyEDA Web project
+```
+
+## Integration requirements
+
+- Hosted MCP endpoint and app metadata.
+- User authentication and account/session linking.
+- Pairing flow between ChatGPT user and extension session.
+- Tool descriptors with clear read/write/export risk classification.
+- UX for active project visibility.
+- Approval prompts for write/export/destructive operations.
+- Test flow for a connected extension session.
+
+## State model
+
+| State            | Description                                               |
+| ---------------- | --------------------------------------------------------- |
+| Unauthenticated  | User has not connected the hosted service.                |
+| Authenticated    | User is known but no EasyEDA extension session is paired. |
+| Paired           | User has one active extension session.                    |
+| Project active   | Extension can identify the open EasyEDA project.          |
+| Approval pending | A risky action is waiting for user approval.              |
+| Disconnected     | The extension or relay session is no longer active.       |
+
+## Hosted mode is primary
+
+The public ChatGPT app should not require each user to provide their own tunnel URL. The hosted gateway provides the stable app entrypoint, while pairing routes requests to the user's browser extension session.
+
+## Advanced self-hosted path
+
+Self-hosted remote endpoints can be documented for developer workflows and MCP clients that support arbitrary remote MCP URLs. This path must keep auth, pairing, approval, and logging responsibilities explicit.
+
+## Open risks
+
+- Final app distribution and review requirements.
+- Exact production auth provider and account-linking model.
+- UI surface for showing active EasyEDA project and approvals.
+- Handling multiple simultaneous EasyEDA tabs or projects.
+- Long-running export/manufacturing operations.

--- a/docs/CLAUDE_WEB_CONNECTOR.md
+++ b/docs/CLAUDE_WEB_CONNECTOR.md
@@ -1,0 +1,68 @@
+# Claude Web Remote MCP connector setup
+
+Claude Web can use EasyEDA MCP Pro through a public Remote MCP endpoint. The endpoint can be the hosted gateway or a user-managed self-hosted endpoint.
+
+## Hosted mode
+
+```text
+Claude Web
+  ↓
+https://mcp.example.com/mcp
+  ↓
+Hosted Remote MCP Gateway
+  ↓
+Paired EasyEDA extension session
+```
+
+User flow:
+
+1. Install and activate the EasyEDA bridge extension.
+2. Open EasyEDA Web and the target project.
+3. Enable Remote Relay Mode in the extension.
+4. Sign in or pair against the hosted gateway.
+5. Add the hosted Remote MCP connector URL in Claude Web.
+6. Confirm the extension shows connected status and the active project.
+7. Use read tools first; approve write/export actions in the extension.
+
+## Self-hosted mode
+
+```text
+Claude Web
+  ↓
+https://mcp.user-domain.example/mcp
+  ↓
+User-managed Remote MCP endpoint
+  ↓
+Paired EasyEDA extension session
+```
+
+User flow:
+
+1. Start the self-hosted EasyEDA MCP server with auth and pairing enabled.
+2. Expose it through a safe domain, tunnel, reverse proxy, or VPS.
+3. Add that public MCP URL in Claude Web.
+4. Pair the extension session.
+5. Confirm active project visibility before approving changes.
+
+## Expected extension status
+
+Before project-changing requests, the extension should show:
+
+- mode: Hosted Remote or Self-hosted Remote,
+- connection: connected,
+- pairing: paired,
+- active project: detected,
+- approval policy: enabled for write/export actions.
+
+## Troubleshooting
+
+| Problem               | Check                                                              |
+| --------------------- | ------------------------------------------------------------------ |
+| Claude cannot connect | Public URL, TLS, auth config, and allowed endpoint path.           |
+| No active project     | EasyEDA tab/project is not open or extension cannot detect it.     |
+| Tool call rejected    | Missing auth, missing pairing, missing scope, or approval timeout. |
+| Wrong project risk    | Stop and re-pair after selecting the intended EasyEDA project.     |
+
+## Safety note
+
+Remote tools can affect the active design. Review approval prompts carefully, especially for write, export, overwrite, or delete operations.

--- a/docs/EXTENSION_RELAY_PROTOCOL.md
+++ b/docs/EXTENSION_RELAY_PROTOCOL.md
@@ -1,0 +1,81 @@
+# Extension relay protocol
+
+The relay protocol carries authenticated gateway requests to an opted-in EasyEDA bridge extension session. The extension uses an outbound connection and does not expose a local listener to the public internet.
+
+## Goals
+
+- Route tool requests to the correct active EasyEDA session.
+- Keep the extension connection user-visible and opt-in.
+- Support protocol versioning and safe rejection of unsupported messages.
+- Carry approval requests and tool responses with consistent envelopes.
+
+## Connection lifecycle
+
+```text
+extension starts Remote Relay Mode
+  ↓
+register_session
+  ↓
+gateway validates pairing/auth state
+  ↓
+heartbeat loop
+  ↓
+tool_request / approval_request / tool_response
+  ↓
+session expires, disconnects, or user disables remote mode
+```
+
+## Envelope shape
+
+Every relay message should include:
+
+```json
+{
+  "protocolVersion": "2026-07-remote-relay-v1",
+  "messageId": "msg_...",
+  "type": "tool_request",
+  "sessionId": "sess_...",
+  "timestamp": "2026-07-03T00:00:00.000Z"
+}
+```
+
+## Message types
+
+| Type                 | Direction                   | Purpose                                                       |
+| -------------------- | --------------------------- | ------------------------------------------------------------- |
+| `register_session`   | Extension → Gateway         | Register extension version, mode, and active EasyEDA context. |
+| `session_registered` | Gateway → Extension         | Confirm registration and pairing state.                       |
+| `heartbeat`          | Both                        | Keep connection alive and measure liveness.                   |
+| `tool_request`       | Gateway → Extension         | Request a tool action after auth, routing, and policy checks. |
+| `tool_response`      | Extension → Gateway         | Return success, structured output, or safe error.             |
+| `approval_request`   | Gateway/Extension → User UI | Present a risky action for explicit approval.                 |
+| `approval_result`    | Extension → Gateway         | Return approve/reject/timeout.                                |
+| `session_closed`     | Both                        | Close a session intentionally.                                |
+| `error`              | Both                        | Return protocol, routing, or execution errors.                |
+
+## Tool request fields
+
+A `tool_request` should include:
+
+- `toolName`
+- `riskLevel`
+- `requiresApproval`
+- `input`
+- `inputHash`
+- `activeProjectHint`
+- `deadlineMs`
+
+## Failure handling
+
+The extension and gateway must reject:
+
+- unsupported protocol versions,
+- messages for unknown sessions,
+- tool requests before pairing,
+- approval-required actions without approval,
+- messages with malformed envelopes,
+- requests after user disables Remote Relay Mode.
+
+## Compatibility
+
+Protocol changes must be versioned. The gateway should keep a small compatibility window when practical, but unsupported versions must fail safely with an actionable error.

--- a/docs/PAIRING_AND_SESSION_ROUTING.md
+++ b/docs/PAIRING_AND_SESSION_ROUTING.md
@@ -1,0 +1,62 @@
+# Pairing and session routing
+
+Pairing binds a remote MCP identity to an active EasyEDA bridge extension session. Session routing ensures every tool call reaches only the intended user's EasyEDA project.
+
+## Pairing lifecycle
+
+```text
+extension enters Remote Relay Mode
+  ↓
+extension registers session
+  ↓
+gateway issues or accepts pairing code
+  ↓
+user completes pairing in hosted app or remote client flow
+  ↓
+gateway binds user id to extension session id
+  ↓
+remote tools can route to that session until expiry/disconnect
+```
+
+## Pairing requirements
+
+- Pairing codes are short-lived.
+- Pairing codes are single-use.
+- Session IDs are not guessable.
+- Pairing binds user, extension session, and deployment mode.
+- Re-pairing is required after explicit disconnect or session expiry.
+
+## Session router contract
+
+Input:
+
+- authenticated user id,
+- requested tool name,
+- requested risk level,
+- optional active project hint.
+
+Output:
+
+- active extension session id,
+- relay connection id,
+- active project metadata,
+- policy/approval requirement,
+- safe error if unresolved.
+
+## Multi-window behavior
+
+The first MVP should avoid ambiguous routing. If multiple EasyEDA sessions are active, the extension or gateway should require the user to select the intended project/session before write or export operations.
+
+## Expiration and disconnects
+
+Sessions should expire automatically and fail closed. A disconnected extension must cause remote tool calls to return a safe disconnected-session error rather than queueing unexpected future mutations.
+
+## Security tests
+
+Tests should prove that:
+
+- user A cannot route to user B's session,
+- expired pairings cannot be reused,
+- duplicate active sessions require explicit selection,
+- disconnected sessions fail safely,
+- approval state is tied to session and input hash.

--- a/docs/REMOTE_GATEWAY_DESIGN.md
+++ b/docs/REMOTE_GATEWAY_DESIGN.md
@@ -1,0 +1,82 @@
+# Hosted Remote MCP Gateway design
+
+The hosted gateway is the public MCP entrypoint for managed remote usage. It receives MCP requests from remote clients and dispatches validated tool calls to the user's paired EasyEDA bridge extension session.
+
+## Endpoint shape
+
+```text
+https://mcp.example.com/mcp
+```
+
+The endpoint should use the project's HTTP transport and remain separate from local-only stdio workflows.
+
+## Request flow
+
+```text
+remote MCP request
+  ↓
+transport parser
+  ↓
+auth validation
+  ↓
+scope validation
+  ↓
+session router
+  ↓
+tool policy / approval gate
+  ↓
+relay dispatch
+  ↓
+extension response
+  ↓
+MCP response
+```
+
+## Required configuration
+
+```env
+REMOTE_MODE=hosted
+TRANSPORT=http
+HTTP_HOST=0.0.0.0
+HTTP_PORT=3000
+PUBLIC_BASE_URL=https://mcp.example.com
+AUTH_REQUIRED=true
+PAIRING_REQUIRED=true
+REQUIRE_APPROVAL_FOR_WRITE=true
+REQUIRE_APPROVAL_FOR_EXPORT=true
+```
+
+The existing safe production guardrails should remain active. Public binding must require auth and explicit origin/base URL configuration.
+
+## Route responsibilities
+
+| Layer          | Responsibility                                         |
+| -------------- | ------------------------------------------------------ |
+| Transport      | Parse MCP request and return protocol-shaped response. |
+| Auth           | Validate identity, token status, and audience.         |
+| Scope          | Confirm tool-specific permission.                      |
+| Session router | Resolve user to exactly one active extension session.  |
+| Policy         | Determine risk level and approval requirement.         |
+| Relay          | Send a versioned request envelope to the extension.    |
+| Audit          | Record structured events with redaction.               |
+
+## Safe response states
+
+The gateway must return safe, actionable errors for:
+
+- unauthenticated request,
+- insufficient scope,
+- no paired session,
+- expired pairing,
+- disconnected extension,
+- missing active project,
+- approval required,
+- approval rejected or timed out,
+- unsupported relay protocol version.
+
+## Non-goals for MVP
+
+- No cloud-hosted Chromium worker is required.
+- No anonymous public tool endpoint.
+- No direct inbound network access to user devices.
+- No automatic destructive project actions.

--- a/docs/REMOTE_MCP_MODES.md
+++ b/docs/REMOTE_MCP_MODES.md
@@ -1,0 +1,100 @@
+# Remote MCP modes
+
+EasyEDA MCP Pro supports three deployment modes. The modes share the same tool semantics, but they have different network and security boundaries.
+
+## Mode matrix
+
+| Mode               | Primary use                         | Public endpoint            | EasyEDA runs in                | Recommended users                             |
+| ------------------ | ----------------------------------- | -------------------------- | ------------------------------ | --------------------------------------------- |
+| Local              | Desktop MCP clients and development | No                         | User browser                   | Local-only users and developers               |
+| Hosted Remote      | Managed connector/app experience    | Maintainer-operated domain | User browser extension session | Claude Web, ChatGPT app, managed teams        |
+| Self-hosted Remote | User-managed remote MCP server      | User domain/tunnel/VPS     | User browser extension session | Power users, enterprises, private deployments |
+
+## Local Mode
+
+Local Mode keeps the current workflow:
+
+```text
+MCP client
+  ↓
+localhost MCP server
+  ↓
+EasyEDA bridge extension
+  ↓
+Open EasyEDA Web project
+```
+
+This mode must keep safe local defaults. It should bind to localhost unless the operator explicitly enables a public remote mode.
+
+## Hosted Remote Mode
+
+Hosted Remote Mode is the product-grade remote path:
+
+```text
+Claude Web / ChatGPT / remote MCP client
+  ↓
+https://mcp.example.com/mcp
+  ↓
+Remote MCP Gateway
+  ↓
+Session Router
+  ↓
+Relay
+  ↓
+EasyEDA bridge extension
+  ↓
+Open EasyEDA Web project
+```
+
+The extension opens an outbound relay connection. The hosted gateway never connects directly to a user's local network.
+
+## Self-hosted Remote Mode
+
+Self-hosted Remote Mode lets the operator expose their own endpoint:
+
+```text
+Remote MCP client
+  ↓
+https://mcp.user-domain.example/mcp
+  ↓
+User-managed tunnel, reverse proxy, or VPS
+  ↓
+EasyEDA MCP server
+  ↓
+EasyEDA bridge extension
+  ↓
+Open EasyEDA Web project
+```
+
+Tunnels provide reachability only. They do not replace authentication, pairing, origin validation, rate limiting, or approval controls.
+
+## Common user journey
+
+1. The user opens EasyEDA Web in a browser window.
+2. The user activates the EasyEDA bridge extension.
+3. The extension is placed in Local, Hosted Remote, or Self-hosted Remote mode.
+4. The user pairs the extension session with the remote MCP client or hosted account.
+5. Remote tool calls route to the paired EasyEDA project.
+6. Read operations can run after auth and pairing.
+7. Write/export/destructive operations follow the approval policy.
+
+## Security responsibilities
+
+| Responsibility              | Local                  | Hosted Remote      | Self-hosted Remote                  |
+| --------------------------- | ---------------------- | ------------------ | ----------------------------------- |
+| Keep local binding safe     | Project                | Project            | Operator                            |
+| Operate public TLS endpoint | N/A                    | Maintainer         | Operator                            |
+| Enforce auth                | Optional local profile | Maintainer gateway | Operator server                     |
+| Enforce pairing             | Optional local profile | Required           | Required                            |
+| Approve risky actions       | User                   | User + gateway     | User + operator server              |
+| Audit remote calls          | Optional               | Required           | Recommended/required for production |
+
+## Related documents
+
+- [Remote security model](./REMOTE_SECURITY_MODEL.md)
+- [Relay protocol](./EXTENSION_RELAY_PROTOCOL.md)
+- [Tool approval policy](./TOOL_APPROVAL_POLICY.md)
+- [Self-hosted setup](./SELF_HOSTED_REMOTE_MCP.md)
+- [Claude Web connector setup](./CLAUDE_WEB_CONNECTOR.md)
+- [ChatGPT app integration plan](./CHATGPT_APP_INTEGRATION.md)
+- [Observability model](./REMOTE_OBSERVABILITY.md)

--- a/docs/REMOTE_MCP_TEST_PLAN.md
+++ b/docs/REMOTE_MCP_TEST_PLAN.md
@@ -1,0 +1,38 @@
+# Remote MCP test plan
+
+Remote MCP tests should validate security boundaries before implementation is considered product-ready.
+
+## Unit test matrix
+
+| Area            | Required coverage                                                                     |
+| --------------- | ------------------------------------------------------------------------------------- |
+| Auth            | missing, invalid, expired, insufficient-scope tokens.                                 |
+| Pairing         | valid code, expired code, reused code, wrong user.                                    |
+| Session router  | paired session, no session, disconnected session, cross-user access.                  |
+| Relay protocol  | supported version, unsupported version, malformed envelope.                           |
+| Approval policy | read allowed, write blocked without approval, export approval, destructive rejection. |
+| Observability   | event shape, redaction, error code mapping.                                           |
+
+## Integration smoke tests
+
+The integration smoke suite should be able to run without live EasyEDA credentials by using a fake extension relay fixture.
+
+Recommended scenarios:
+
+1. User pairs fake extension session.
+2. Remote read tool routes and returns a fixture response.
+3. Remote write tool requests approval and succeeds after approval.
+4. Remote write tool fails after rejection.
+5. Cross-user session request is rejected.
+6. Disconnected extension returns a safe error.
+
+## Manual validation
+
+Before public beta:
+
+- hosted endpoint deployed under a test domain,
+- extension connects in Remote Relay Mode,
+- Claude Web connector can call at least one read tool,
+- write action shows approval prompt,
+- approval result is reflected in the remote MCP response,
+- logs show structured events with redaction.

--- a/docs/REMOTE_OBSERVABILITY.md
+++ b/docs/REMOTE_OBSERVABILITY.md
@@ -1,0 +1,66 @@
+# Remote MCP observability
+
+Remote MCP sessions need enough telemetry to debug routing, safety, and reliability without logging secrets or raw project contents by default.
+
+## Event categories
+
+| Event                         | Purpose                                          |
+| ----------------------------- | ------------------------------------------------ |
+| `remote.session.registered`   | Extension session registered with relay.         |
+| `remote.session.paired`       | User/client was paired to an extension session.  |
+| `remote.session.disconnected` | Extension or gateway closed the session.         |
+| `remote.tool.requested`       | Gateway received a tool call.                    |
+| `remote.tool.dispatched`      | Gateway routed the call to an extension session. |
+| `remote.tool.completed`       | Tool returned successfully.                      |
+| `remote.tool.failed`          | Tool failed with a categorized error.            |
+| `remote.approval.requested`   | A risky action required approval.                |
+| `remote.approval.resolved`    | Approval was approved, rejected, or timed out.   |
+| `remote.auth.rejected`        | Auth, scope, or token validation failed.         |
+
+## Common fields
+
+- timestamp,
+- event name,
+- deployment mode,
+- user id or local operator id,
+- session id,
+- connection id,
+- tool name,
+- risk level,
+- approval requirement,
+- input hash,
+- status,
+- duration,
+- error code.
+
+## Redaction rules
+
+Do not log by default:
+
+- access tokens,
+- pairing codes,
+- project source payloads,
+- full schematics or board documents,
+- vendor credentials,
+- raw BOM lines with private project identifiers.
+
+Prefer hashes, counts, sizes, and structured status codes.
+
+## Error taxonomy
+
+| Code                        | Meaning                                       |
+| --------------------------- | --------------------------------------------- |
+| `AUTH_MISSING`              | No valid remote auth context.                 |
+| `AUTH_INSUFFICIENT_SCOPE`   | Token lacks the required scope.               |
+| `SESSION_UNPAIRED`          | User has no paired extension session.         |
+| `SESSION_DISCONNECTED`      | Extension session is not connected.           |
+| `PROJECT_INACTIVE`          | EasyEDA project cannot be detected.           |
+| `APPROVAL_REQUIRED`         | Action requires approval.                     |
+| `APPROVAL_REJECTED`         | User rejected the action.                     |
+| `APPROVAL_TIMEOUT`          | Approval window expired.                      |
+| `RELAY_VERSION_UNSUPPORTED` | Relay protocol version mismatch.              |
+| `BRIDGE_EXECUTION_FAILED`   | EasyEDA bridge returned an execution failure. |
+
+## Acceptance baseline
+
+The first implementation should make remote routing debuggable without creating a sensitive design-data log sink.

--- a/docs/REMOTE_SECURITY_MODEL.md
+++ b/docs/REMOTE_SECURITY_MODEL.md
@@ -1,0 +1,78 @@
+# Remote MCP security model
+
+Remote MCP must not be treated as a public wrapper around local tool execution. Every remote path must enforce identity, pairing, session isolation, approval policy, and auditable routing.
+
+## Trust boundaries
+
+```text
+Remote MCP client
+  │ untrusted prompts and tool arguments
+  ▼
+Remote MCP Gateway
+  │ authenticated, authorized, policy-checked requests
+  ▼
+Session Router
+  │ paired user/session mapping
+  ▼
+Relay
+  │ versioned request envelopes
+  ▼
+EasyEDA bridge extension
+  │ user-visible active project and approvals
+  ▼
+EasyEDA Web page
+```
+
+## Required controls
+
+| Control           | Requirement                                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------------- |
+| Authentication    | Remote tool calls require a valid token or equivalent authenticated session.                |
+| Pairing           | A remote user must be paired with exactly one active extension session before tool routing. |
+| Session isolation | A user must never access another user's EasyEDA session.                                    |
+| Authorization     | Tool scopes separate read, write, export, and project administration actions.               |
+| Approval          | Write, export, and destructive actions require explicit approval according to policy.       |
+| Origin validation | Public HTTP endpoints validate expected origins where applicable.                           |
+| Safe defaults     | Public binding is not enabled without remote mode, auth, and allowed-origin configuration.  |
+| Audit             | Remote requests record structured events without secrets or raw design payloads by default. |
+
+## Scope model
+
+Recommended initial scopes:
+
+- `easyeda.read`
+- `easyeda.write`
+- `easyeda.export`
+- `easyeda.project_admin`
+
+Read tools require `easyeda.read`. Project-changing tools require the relevant stronger scope and approval.
+
+## Hosted responsibilities
+
+The maintainer-operated hosted gateway is responsible for TLS, token verification, pairing lifecycle, session routing, rate limiting, audit logging, and policy enforcement before relay dispatch.
+
+## Self-hosted responsibilities
+
+A self-hosted operator is responsible for their domain/tunnel/VPS, TLS, authentication, secrets, access control, logs, upgrades, and abuse prevention. Tunneling a local port is not a security control.
+
+## Safe failures
+
+The gateway must fail closed when:
+
+- authentication is missing or invalid,
+- the user is not paired,
+- the extension session is expired or disconnected,
+- the requested tool requires a missing scope,
+- approval is required but not granted,
+- the active EasyEDA project cannot be confirmed.
+
+## Regression coverage
+
+Security tests should cover:
+
+- missing, invalid, expired, and insufficient tokens,
+- unpaired and expired sessions,
+- cross-user session access attempts,
+- unsupported relay protocol versions,
+- approval-required actions without approval,
+- redaction of secrets and large raw design payloads.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -49,3 +49,16 @@ The latest npm and GitHub release is the actively maintained release. Older vers
 - Redistributing proprietary EasyEDA, JLCPCB, LCSC, Mouser, or DigiKey data.
 - Replacing human engineering review for manufacturability or safety-critical design decisions.
 - Enabling remote HTTP exposure without explicit authentication and allowed-origin controls.
+
+## v0.18.0 — Remote MCP Gateway & self-hosted tunnels
+
+Planned milestone for hosted and self-hosted remote MCP usage:
+
+- hosted Remote MCP Gateway endpoint design;
+- extension Remote Relay Mode;
+- pairing and session routing;
+- remote auth, scopes, approval policy, audit, and observability;
+- self-hosted remote setup using user-owned domains, tunnels, reverse proxies, or VPS deployments;
+- Claude Web connector and ChatGPT Apps SDK integration guidance.
+
+See [Remote MCP modes](./REMOTE_MCP_MODES.md), [remote security model](./REMOTE_SECURITY_MODEL.md), and [extension relay protocol](./EXTENSION_RELAY_PROTOCOL.md).

--- a/docs/SELF_HOSTED_REMOTE_MCP.md
+++ b/docs/SELF_HOSTED_REMOTE_MCP.md
@@ -1,0 +1,80 @@
+# Self-hosted Remote MCP setup
+
+Self-hosted Remote MCP lets an operator expose EasyEDA MCP Pro through their own domain, tunnel, VPS, or reverse proxy. This mode is for power users and private deployments that need a public MCP endpoint without using the hosted gateway.
+
+## Architecture
+
+```text
+Remote MCP client
+  ↓
+https://mcp.user-domain.example/mcp
+  ↓
+User-managed tunnel or reverse proxy
+  ↓
+EasyEDA MCP server
+  ↓
+EasyEDA bridge extension
+  ↓
+Open EasyEDA Web project
+```
+
+## Minimum safe configuration
+
+```env
+TRANSPORT=http
+HTTP_HOST=127.0.0.1
+HTTP_PORT=3000
+PUBLIC_BASE_URL=https://mcp.user-domain.example
+AUTH_REQUIRED=true
+PAIRING_REQUIRED=true
+REMOTE_MODE=self_hosted
+REQUIRE_APPROVAL_FOR_WRITE=true
+REQUIRE_APPROVAL_FOR_EXPORT=true
+```
+
+The local server should bind to localhost behind the tunnel or reverse proxy. Do not bind to all interfaces unless the host firewall, TLS, auth, and origin policy are explicitly configured.
+
+## Cloudflare Tunnel example
+
+```yaml
+tunnel: easyeda-mcp
+credentials-file: /home/user/.cloudflared/easyeda-mcp.json
+
+ingress:
+  - hostname: mcp.user-domain.example
+    service: http://localhost:3000
+  - service: http_status:404
+```
+
+Example commands:
+
+```bash
+cloudflared tunnel route dns easyeda-mcp mcp.user-domain.example
+cloudflared tunnel run easyeda-mcp
+```
+
+## Operator checklist
+
+Before exposing a self-hosted endpoint:
+
+- [ ] TLS is enabled at the public endpoint.
+- [ ] Auth is enabled.
+- [ ] Pairing is required.
+- [ ] Write/export approvals are enabled.
+- [ ] The local MCP server is not anonymously exposed.
+- [ ] The extension shows the active project before approving changes.
+- [ ] Logs are redacted and stored safely.
+- [ ] The operator knows how to revoke tokens and stop the tunnel.
+
+## Troubleshooting
+
+| Symptom                      | Likely cause                          | Resolution                                 |
+| ---------------------------- | ------------------------------------- | ------------------------------------------ |
+| Remote client cannot connect | Tunnel DNS or service target is wrong | Verify public hostname and local port.     |
+| Tools return unpaired        | Extension has not completed pairing   | Re-run pairing flow.                       |
+| Tools return disconnected    | Extension relay is not active         | Open EasyEDA and enable Remote Relay Mode. |
+| Write action is rejected     | Approval missing or timed out         | Approve the exact action in the extension. |
+
+## Security warning
+
+A tunnel only makes a local service reachable. It does not provide authorization by itself. Production self-hosted endpoints must use auth, pairing, approval policy, and safe logging.

--- a/docs/TOOL_APPROVAL_POLICY.md
+++ b/docs/TOOL_APPROVAL_POLICY.md
@@ -1,0 +1,57 @@
+# Remote tool approval policy
+
+Remote tool approval protects the user from unintended project changes when a cloud MCP client or self-hosted remote endpoint controls an active EasyEDA session.
+
+## Risk levels
+
+| Risk level  | Examples                                                     | Default behavior                                          |
+| ----------- | ------------------------------------------------------------ | --------------------------------------------------------- |
+| Read        | list project, inspect netlist, read BOM, read DRC/ERC report | Allowed after auth and pairing.                           |
+| Write       | add component, create net, edit wire, update PCB primitive   | Requires explicit approval.                               |
+| Export      | generate Gerber, BOM, pick-and-place, manufacturing package  | Requires explicit approval.                               |
+| Destructive | delete, overwrite, bulk replace, publish/share, place order  | Requires stronger confirmation or is disabled by default. |
+
+## Approval prompt requirements
+
+The extension approval prompt should show:
+
+- requesting client or account,
+- active EasyEDA project name or identifier,
+- tool name and risk level,
+- human-readable action summary,
+- expected change list when available,
+- approve, reject, and timeout outcomes.
+
+## Gateway enforcement
+
+The gateway must enforce approval policy before dispatching the final action to the extension. Approval state must be tied to:
+
+- user identity,
+- extension session,
+- tool name,
+- input hash,
+- expiration time.
+
+A previous approval must not authorize a materially different input payload.
+
+## Default policy
+
+- Read tools: no prompt after auth and pairing.
+- Write tools: prompt required.
+- Export tools: prompt required.
+- Destructive tools: prompt plus stronger confirmation, or disabled until explicitly enabled.
+
+## Audit events
+
+Approval events should record:
+
+- approval request id,
+- user id or local operator id,
+- session id,
+- tool name,
+- risk level,
+- input hash,
+- approve/reject/timeout,
+- duration.
+
+Secrets and raw project payloads must not be logged by default.

--- a/docs/index.md
+++ b/docs/index.md
@@ -29,4 +29,7 @@ features:
   - title: 'Easy Setup Wizard'
     details: 'Automatically configures popular MCP client environments (Claude Desktop, Cursor, VS Code Copilot, etc.) in seconds.'
     icon: ⚡
+  - title: 'Remote MCP Ready'
+    details: 'Architecture docs for hosted gateways, self-hosted tunnels, extension relay, pairing, approvals, and remote security.'
+    icon: 🌐
 ---


### PR DESCRIPTION
## Summary

- Add the Remote MCP foundation documentation set for hosted and self-hosted usage.
- Define hosted gateway design, pairing/session routing, relay protocol, remote security model, approval policy, observability model, and test plan.
- Add Claude Web connector and ChatGPT Apps SDK integration planning docs.
- Link Remote MCP docs from README, docs home, and roadmap.

## Validation

- `pnpm exec prettier --write ...`
- `pnpm format:check`
- `pnpm docs:build`
- `pnpm lint`
- `git diff --check`

## Issue closure

Closes #103
Closes #104
Closes #107
Closes #108
Closes #109
Closes #110
Closes #111
Closes #112
Closes #115

Refs #102
Refs #105
Refs #106
Refs #113
Refs #114
