### PR TITLE
feat: add remote MCP routing core

### DIFF
--- a/src/remote/approval-policy.ts
+++ b/src/remote/approval-policy.ts
@@ -1,0 +1,76 @@
+import type { ActiveProject, RemoteRiskLevel } from './protocol.js';
+
+export interface ApprovalRequestInput {
+  approvalId: string;
+  userId: string;
+  sessionId: string;
+  toolName: string;
+  riskLevel: RemoteRiskLevel;
+  inputHash: string;
+  actionSummary: string;
+  activeProject?: ActiveProject;
+  expiresAt: Date;
+}
+
+export type ApprovalDecision = 'approved' | 'rejected' | 'timeout';
+
+export interface ApprovalRecord extends ApprovalRequestInput {
+  decision?: ApprovalDecision;
+  decidedAt?: Date;
+}
+
+export function requiresApproval(riskLevel: RemoteRiskLevel): boolean {
+  return riskLevel !== 'read';
+}
+
+export function isDestructiveRisk(riskLevel: RemoteRiskLevel): boolean {
+  return riskLevel === 'destructive';
+}
+
+export class ApprovalStore {
+  private readonly approvals = new Map<string, ApprovalRecord>();
+
+  request(input: ApprovalRequestInput): ApprovalRecord {
+    const record: ApprovalRecord = { ...input };
+    this.approvals.set(input.approvalId, record);
+    return record;
+  }
+
+  resolve(
+    approvalId: string,
+    decision: ApprovalDecision,
+    now = new Date(),
+  ): ApprovalRecord | undefined {
+    const record = this.approvals.get(approvalId);
+    if (!record) return undefined;
+    record.decision = now.getTime() > record.expiresAt.getTime() ? 'timeout' : decision;
+    record.decidedAt = now;
+    return record;
+  }
+
+  consumeApproved(input: {
+    approvalId: string;
+    userId: string;
+    sessionId: string;
+    toolName: string;
+    inputHash: string;
+    now?: Date;
+  }): boolean {
+    const record = this.approvals.get(input.approvalId);
+    if (!record) return false;
+    const now = input.now ?? new Date();
+    const matches =
+      record.userId === input.userId &&
+      record.sessionId === input.sessionId &&
+      record.toolName === input.toolName &&
+      record.inputHash === input.inputHash &&
+      record.decision === 'approved' &&
+      record.expiresAt.getTime() > now.getTime();
+    if (matches) this.approvals.delete(input.approvalId);
+    return matches;
+  }
+
+  get(approvalId: string): ApprovalRecord | undefined {
+    return this.approvals.get(approvalId);
+  }
+}

--- a/src/remote/index.ts
+++ b/src/remote/index.ts
@@ -1,0 +1,5 @@
+export * from './approval-policy.js';
+export * from './observability.js';
+export * from './protocol.js';
+export * from './scope.js';
+export * from './session-router.js';

--- a/src/remote/observability.ts
+++ b/src/remote/observability.ts
@@ -1,0 +1,65 @@
+import type { RemoteDeploymentMode, RemoteRiskLevel } from './protocol.js';
+
+export type RemoteAuditEventName =
+  | 'remote.session.registered'
+  | 'remote.session.paired'
+  | 'remote.session.disconnected'
+  | 'remote.tool.requested'
+  | 'remote.tool.dispatched'
+  | 'remote.tool.completed'
+  | 'remote.tool.failed'
+  | 'remote.approval.requested'
+  | 'remote.approval.resolved'
+  | 'remote.identity.rejected';
+
+export interface RemoteAuditEvent {
+  event: RemoteAuditEventName;
+  observedAt: string;
+  mode: RemoteDeploymentMode;
+  userId?: string;
+  sessionId?: string;
+  connectionId?: string;
+  toolName?: string;
+  riskLevel?: RemoteRiskLevel;
+  inputHash?: string;
+  status?: 'ok' | 'error' | 'rejected' | 'timeout';
+  durationMs?: number;
+  errorCode?: string;
+}
+
+const REDACTED = '[redacted]';
+const SECRET_KEY_PATTERN = /(token|secret|password|credential|apiKey|api_key|pairingCode)/i;
+
+export function redactRemotePayload(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => redactRemotePayload(item));
+  if (!value || typeof value !== 'object') return value;
+  const out: Record<string, unknown> = {};
+  for (const [key, child] of Object.entries(value)) {
+    out[key] = SECRET_KEY_PATTERN.test(key) ? REDACTED : redactRemotePayload(child);
+  }
+  return out;
+}
+
+export class RemoteAuditLog {
+  private events: RemoteAuditEvent[] = [];
+
+  constructor(private readonly maxEvents = 200) {}
+
+  record(event: Omit<RemoteAuditEvent, 'observedAt'> & { observedAt?: string }): RemoteAuditEvent {
+    const stored: RemoteAuditEvent = {
+      ...event,
+      observedAt: event.observedAt ?? new Date().toISOString(),
+    };
+    this.events.push(stored);
+    if (this.events.length > this.maxEvents) this.events = this.events.slice(-this.maxEvents);
+    return stored;
+  }
+
+  recent(limit = 25): RemoteAuditEvent[] {
+    return this.events.slice(-limit);
+  }
+
+  clear(): void {
+    this.events = [];
+  }
+}

--- a/src/remote/protocol.ts
+++ b/src/remote/protocol.ts
@@ -1,0 +1,127 @@
+import { z } from 'zod';
+
+export const REMOTE_RELAY_PROTOCOL_VERSION = '2026-07-remote-relay-v1' as const;
+export const RemoteDeploymentModeSchema = z.enum(['local', 'hosted', 'self_hosted']);
+export const RemoteRiskLevelSchema = z.enum(['read', 'write', 'export', 'destructive']);
+export const RemoteScopeSchema = z.enum([
+  'easyeda.read',
+  'easyeda.write',
+  'easyeda.export',
+  'easyeda.project_admin',
+]);
+
+export type RemoteDeploymentMode = z.infer<typeof RemoteDeploymentModeSchema>;
+export type RemoteRiskLevel = z.infer<typeof RemoteRiskLevelSchema>;
+export type RemoteScope = z.infer<typeof RemoteScopeSchema>;
+
+export const ActiveProjectSchema = z.object({
+  projectId: z.string().min(1).optional(),
+  projectName: z.string().min(1).optional(),
+  documentType: z.enum(['schematic', 'pcb', 'unknown']).default('unknown'),
+  url: z.string().url().optional(),
+});
+
+export type ActiveProject = z.infer<typeof ActiveProjectSchema>;
+
+const BaseRelayMessageSchema = z.object({
+  protocolVersion: z.literal(REMOTE_RELAY_PROTOCOL_VERSION),
+  messageId: z.string().min(1),
+  sessionId: z.string().min(1).optional(),
+  timestamp: z.string().datetime(),
+});
+
+export const RegisterSessionMessageSchema = BaseRelayMessageSchema.extend({
+  type: z.literal('register_session'),
+  extensionVersion: z.string().min(1),
+  mode: RemoteDeploymentModeSchema.exclude(['local']),
+  activeProject: ActiveProjectSchema.optional(),
+  capabilities: z.array(z.string().min(1)).default([]),
+});
+
+export const SessionRegisteredMessageSchema = BaseRelayMessageSchema.extend({
+  type: z.literal('session_registered'),
+  sessionId: z.string().min(1),
+  paired: z.boolean(),
+  expiresAt: z.string().datetime(),
+});
+
+export const HeartbeatMessageSchema = BaseRelayMessageSchema.extend({
+  type: z.literal('heartbeat'),
+});
+
+export const ToolRequestMessageSchema = BaseRelayMessageSchema.extend({
+  type: z.literal('tool_request'),
+  sessionId: z.string().min(1),
+  toolName: z.string().min(1),
+  riskLevel: RemoteRiskLevelSchema,
+  requiresApproval: z.boolean(),
+  input: z.unknown().optional(),
+  inputHash: z.string().min(1),
+  activeProjectHint: ActiveProjectSchema.optional(),
+  deadlineMs: z.number().int().positive().optional(),
+});
+
+export const ToolResponseMessageSchema = BaseRelayMessageSchema.extend({
+  type: z.literal('tool_response'),
+  sessionId: z.string().min(1),
+  requestMessageId: z.string().min(1),
+  ok: z.boolean(),
+  result: z.unknown().optional(),
+  error: z
+    .object({
+      code: z.string().min(1),
+      message: z.string().min(1),
+      suggestion: z.string().min(1).optional(),
+    })
+    .optional(),
+  durationMs: z.number().nonnegative(),
+});
+
+export const ApprovalRequestMessageSchema = BaseRelayMessageSchema.extend({
+  type: z.literal('approval_request'),
+  sessionId: z.string().min(1),
+  approvalId: z.string().min(1),
+  toolName: z.string().min(1),
+  riskLevel: RemoteRiskLevelSchema,
+  actionSummary: z.string().min(1),
+  inputHash: z.string().min(1),
+  activeProject: ActiveProjectSchema.optional(),
+  expiresAt: z.string().datetime(),
+});
+
+export const ApprovalResultMessageSchema = BaseRelayMessageSchema.extend({
+  type: z.literal('approval_result'),
+  sessionId: z.string().min(1),
+  approvalId: z.string().min(1),
+  result: z.enum(['approved', 'rejected', 'timeout']),
+});
+
+export const SessionClosedMessageSchema = BaseRelayMessageSchema.extend({
+  type: z.literal('session_closed'),
+  sessionId: z.string().min(1),
+  reason: z.enum(['user_disabled', 'expired', 'disconnected', 'replaced']),
+});
+
+export const RelayErrorMessageSchema = BaseRelayMessageSchema.extend({
+  type: z.literal('error'),
+  sessionId: z.string().min(1).optional(),
+  code: z.string().min(1),
+  message: z.string().min(1),
+});
+
+export const RelayMessageSchema = z.discriminatedUnion('type', [
+  RegisterSessionMessageSchema,
+  SessionRegisteredMessageSchema,
+  HeartbeatMessageSchema,
+  ToolRequestMessageSchema,
+  ToolResponseMessageSchema,
+  ApprovalRequestMessageSchema,
+  ApprovalResultMessageSchema,
+  SessionClosedMessageSchema,
+  RelayErrorMessageSchema,
+]);
+
+export type RelayMessage = z.infer<typeof RelayMessageSchema>;
+export type RegisterSessionMessage = z.infer<typeof RegisterSessionMessageSchema>;
+export type ToolRequestMessage = z.infer<typeof ToolRequestMessageSchema>;
+export type ApprovalRequestMessage = z.infer<typeof ApprovalRequestMessageSchema>;

--- a/src/remote/scope.ts
+++ b/src/remote/scope.ts
@@ -1,0 +1,39 @@
+import type { RemoteRiskLevel, RemoteScope } from './protocol.js';
+
+export interface RemoteIdentity {
+  userId: string;
+  scopes: readonly RemoteScope[];
+  expiresAt?: Date;
+}
+
+export type ScopeCheckResult =
+  | { ok: true }
+  | { ok: false; code: 'IDENTITY_MISSING' | 'IDENTITY_EXPIRED' | 'SCOPE_MISSING'; message: string };
+
+export function requiredScopeForRisk(riskLevel: RemoteRiskLevel): RemoteScope {
+  if (riskLevel === 'read') return 'easyeda.read';
+  if (riskLevel === 'write') return 'easyeda.write';
+  if (riskLevel === 'export') return 'easyeda.export';
+  return 'easyeda.project_admin';
+}
+
+export function hasRemoteScope(identity: RemoteIdentity, scope: RemoteScope): boolean {
+  return identity.scopes.includes(scope) || identity.scopes.includes('easyeda.project_admin');
+}
+
+export function checkRemoteScope(
+  identity: RemoteIdentity | undefined,
+  riskLevel: RemoteRiskLevel,
+  now = new Date(),
+): ScopeCheckResult {
+  if (!identity)
+    return { ok: false, code: 'IDENTITY_MISSING', message: 'Remote identity is required.' };
+  if (identity.expiresAt && identity.expiresAt.getTime() <= now.getTime()) {
+    return { ok: false, code: 'IDENTITY_EXPIRED', message: 'Remote identity has expired.' };
+  }
+  const required = requiredScopeForRisk(riskLevel);
+  if (!hasRemoteScope(identity, required)) {
+    return { ok: false, code: 'SCOPE_MISSING', message: `Remote tool requires ${required}.` };
+  }
+  return { ok: true };
+}

--- a/src/remote/session-router.ts
+++ b/src/remote/session-router.ts
@@ -1,0 +1,185 @@
+import { randomUUID } from 'node:crypto';
+import type { ActiveProject, RemoteDeploymentMode, RemoteRiskLevel } from './protocol.js';
+
+export interface ExtensionSession {
+  sessionId: string;
+  connectionId: string;
+  mode: Exclude<RemoteDeploymentMode, 'local'>;
+  extensionVersion: string;
+  userId?: string;
+  activeProject?: ActiveProject;
+  connected: boolean;
+  createdAt: Date;
+  lastSeenAt: Date;
+  expiresAt: Date;
+}
+
+interface PairingCode {
+  code: string;
+  userId: string;
+  sessionId?: string;
+  createdAt: Date;
+  expiresAt: Date;
+  usedAt?: Date;
+}
+
+export type SessionRouteResult =
+  | { ok: true; session: ExtensionSession }
+  | {
+      ok: false;
+      code:
+        | 'SESSION_UNPAIRED'
+        | 'SESSION_DISCONNECTED'
+        | 'SESSION_EXPIRED'
+        | 'SESSION_AMBIGUOUS'
+        | 'PROJECT_INACTIVE';
+      message: string;
+    };
+
+export class RemoteSessionRouter {
+  private readonly sessions = new Map<string, ExtensionSession>();
+  private readonly pairings = new Map<string, PairingCode>();
+
+  constructor(
+    private readonly now: () => Date = () => new Date(),
+    private readonly makeId: () => string = () => randomUUID(),
+  ) {}
+
+  registerSession(input: {
+    connectionId: string;
+    mode: Exclude<RemoteDeploymentMode, 'local'>;
+    extensionVersion: string;
+    activeProject?: ActiveProject;
+    ttlMs?: number;
+  }): ExtensionSession {
+    const now = this.now();
+    const session: ExtensionSession = {
+      sessionId: `sess_${this.makeId()}`,
+      connectionId: input.connectionId,
+      mode: input.mode,
+      extensionVersion: input.extensionVersion,
+      activeProject: input.activeProject,
+      connected: true,
+      createdAt: now,
+      lastSeenAt: now,
+      expiresAt: new Date(now.getTime() + (input.ttlMs ?? 2 * 60 * 60 * 1000)),
+    };
+    this.sessions.set(session.sessionId, session);
+    return session;
+  }
+
+  createPairingCode(input: { userId: string; sessionId?: string; ttlMs?: number }): string {
+    const now = this.now();
+    const code = `EDA-${this.makeId().replace(/-/g, '').slice(0, 8).toUpperCase()}`;
+    this.pairings.set(code, {
+      code,
+      userId: input.userId,
+      sessionId: input.sessionId,
+      createdAt: now,
+      expiresAt: new Date(now.getTime() + (input.ttlMs ?? 10 * 60 * 1000)),
+    });
+    return code;
+  }
+
+  completePairing(input: { code: string; userId: string; sessionId: string }): boolean {
+    const pairing = this.pairings.get(input.code);
+    const session = this.sessions.get(input.sessionId);
+    const now = this.now();
+    if (!pairing || !session) return false;
+    if (pairing.usedAt) return false;
+    if (pairing.userId !== input.userId) return false;
+    if (pairing.sessionId && pairing.sessionId !== input.sessionId) return false;
+    if (pairing.expiresAt.getTime() <= now.getTime()) return false;
+    if (!session.connected || session.expiresAt.getTime() <= now.getTime()) return false;
+    pairing.usedAt = now;
+    session.userId = input.userId;
+    session.lastSeenAt = now;
+    return true;
+  }
+
+  heartbeat(sessionId: string): boolean {
+    const session = this.sessions.get(sessionId);
+    if (!session || !session.connected) return false;
+    session.lastSeenAt = this.now();
+    return true;
+  }
+
+  updateActiveProject(sessionId: string, activeProject?: ActiveProject): boolean {
+    const session = this.sessions.get(sessionId);
+    if (!session) return false;
+    session.activeProject = activeProject;
+    session.lastSeenAt = this.now();
+    return true;
+  }
+
+  disconnect(sessionId: string): boolean {
+    const session = this.sessions.get(sessionId);
+    if (!session) return false;
+    session.connected = false;
+    session.lastSeenAt = this.now();
+    return true;
+  }
+
+  resolve(input: {
+    userId: string;
+    riskLevel: RemoteRiskLevel;
+    sessionId?: string;
+  }): SessionRouteResult {
+    const now = this.now();
+    const candidates = [...this.sessions.values()].filter(
+      (session) =>
+        session.userId === input.userId &&
+        (!input.sessionId || session.sessionId === input.sessionId),
+    );
+    if (candidates.length === 0) {
+      return {
+        ok: false,
+        code: 'SESSION_UNPAIRED',
+        message: 'No paired EasyEDA extension session.',
+      };
+    }
+    const active = candidates.filter((session) => session.connected);
+    if (active.length === 0) {
+      return {
+        ok: false,
+        code: 'SESSION_DISCONNECTED',
+        message: 'Paired EasyEDA extension is disconnected.',
+      };
+    }
+    const unexpired = active.filter((session) => session.expiresAt.getTime() > now.getTime());
+    if (unexpired.length === 0) {
+      return {
+        ok: false,
+        code: 'SESSION_EXPIRED',
+        message: 'Paired EasyEDA extension session expired.',
+      };
+    }
+    if (!input.sessionId && unexpired.length > 1) {
+      return {
+        ok: false,
+        code: 'SESSION_AMBIGUOUS',
+        message: 'Multiple active EasyEDA sessions require explicit selection.',
+      };
+    }
+    const session = unexpired[0];
+    if (!session) {
+      return {
+        ok: false,
+        code: 'SESSION_UNPAIRED',
+        message: 'No paired EasyEDA extension session.',
+      };
+    }
+    if (input.riskLevel !== 'read' && !session.activeProject) {
+      return {
+        ok: false,
+        code: 'PROJECT_INACTIVE',
+        message: 'No active EasyEDA project is visible.',
+      };
+    }
+    return { ok: true, session };
+  }
+
+  getSession(sessionId: string): ExtensionSession | undefined {
+    return this.sessions.get(sessionId);
+  }
+}

--- a/tests/unit/remote/policy-observability.test.ts
+++ b/tests/unit/remote/policy-observability.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { ApprovalStore, requiresApproval } from '../../../src/remote/approval-policy.js';
+import { RemoteAuditLog, redactRemotePayload } from '../../../src/remote/observability.js';
+import { checkRemoteScope, requiredScopeForRisk } from '../../../src/remote/scope.js';
+
+describe('remote approval policy', () => {
+  it('requires approval for non-read actions', () => {
+    expect(requiresApproval('read')).toBe(false);
+    expect(requiresApproval('write')).toBe(true);
+    expect(requiresApproval('export')).toBe(true);
+    expect(requiresApproval('destructive')).toBe(true);
+  });
+
+  it('binds approval to user, session, tool, and input hash', () => {
+    const store = new ApprovalStore();
+    store.request({
+      approvalId: 'approval_1',
+      userId: 'user_1',
+      sessionId: 'sess_1',
+      toolName: 'schematic.addWire',
+      riskLevel: 'write',
+      inputHash: 'hash_1',
+      actionSummary: 'Add a wire',
+      expiresAt: new Date('2026-07-03T00:01:00.000Z'),
+    });
+    store.resolve('approval_1', 'approved', new Date('2026-07-03T00:00:10.000Z'));
+
+    expect(
+      store.consumeApproved({
+        approvalId: 'approval_1',
+        userId: 'user_1',
+        sessionId: 'sess_1',
+        toolName: 'schematic.addWire',
+        inputHash: 'hash_2',
+        now: new Date('2026-07-03T00:00:11.000Z'),
+      }),
+    ).toBe(false);
+    expect(
+      store.consumeApproved({
+        approvalId: 'approval_1',
+        userId: 'user_1',
+        sessionId: 'sess_1',
+        toolName: 'schematic.addWire',
+        inputHash: 'hash_1',
+        now: new Date('2026-07-03T00:00:11.000Z'),
+      }),
+    ).toBe(true);
+  });
+});
+
+describe('remote scope checks', () => {
+  it('maps risk levels to scopes', () => {
+    expect(requiredScopeForRisk('read')).toBe('easyeda.read');
+    expect(requiredScopeForRisk('write')).toBe('easyeda.write');
+    expect(requiredScopeForRisk('export')).toBe('easyeda.export');
+    expect(requiredScopeForRisk('destructive')).toBe('easyeda.project_admin');
+  });
+
+  it('rejects missing and insufficient scopes', () => {
+    expect(checkRemoteScope(undefined, 'read')).toMatchObject({
+      ok: false,
+      code: 'IDENTITY_MISSING',
+    });
+    expect(checkRemoteScope({ userId: 'u1', scopes: ['easyeda.read'] }, 'write')).toMatchObject({
+      ok: false,
+      code: 'SCOPE_MISSING',
+    });
+    expect(
+      checkRemoteScope({ userId: 'u1', scopes: ['easyeda.project_admin'] }, 'destructive'),
+    ).toEqual({ ok: true });
+  });
+});
+
+describe('remote observability', () => {
+  it('redacts secret-like payload keys', () => {
+    expect(redactRemotePayload({ token: 'abc', nested: { apiKey: 'def', visible: 'ok' } })).toEqual(
+      { token: '[redacted]', nested: { apiKey: '[redacted]', visible: 'ok' } },
+    );
+  });
+
+  it('stores bounded audit events', () => {
+    const log = new RemoteAuditLog(1);
+    log.record({ event: 'remote.session.registered', mode: 'hosted', sessionId: 'sess_1' });
+    log.record({
+      event: 'remote.tool.completed',
+      mode: 'hosted',
+      sessionId: 'sess_1',
+      status: 'ok',
+    });
+
+    expect(log.recent()).toHaveLength(1);
+    expect(log.recent()[0]?.event).toBe('remote.tool.completed');
+  });
+});

--- a/tests/unit/remote/protocol.test.ts
+++ b/tests/unit/remote/protocol.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import {
+  RegisterSessionMessageSchema,
+  RelayMessageSchema,
+  REMOTE_RELAY_PROTOCOL_VERSION,
+  ToolRequestMessageSchema,
+} from '../../../src/remote/protocol.js';
+
+describe('remote relay protocol', () => {
+  it('validates extension session registration', () => {
+    const parsed = RegisterSessionMessageSchema.parse({
+      protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+      messageId: 'msg_1',
+      timestamp: '2026-07-03T00:00:00.000Z',
+      type: 'register_session',
+      extensionVersion: '0.17.1',
+      mode: 'hosted',
+      activeProject: { projectName: 'Power Board', documentType: 'schematic' },
+      capabilities: ['schematic.read'],
+    });
+
+    expect(parsed.type).toBe('register_session');
+    expect(parsed.activeProject?.projectName).toBe('Power Board');
+  });
+
+  it('rejects local mode for remote registration', () => {
+    expect(() =>
+      RegisterSessionMessageSchema.parse({
+        protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+        messageId: 'msg_1',
+        timestamp: '2026-07-03T00:00:00.000Z',
+        type: 'register_session',
+        extensionVersion: '0.17.1',
+        mode: 'local',
+      }),
+    ).toThrow();
+  });
+
+  it('validates tool request envelope', () => {
+    const parsed = ToolRequestMessageSchema.parse({
+      protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+      messageId: 'msg_2',
+      sessionId: 'sess_1',
+      timestamp: '2026-07-03T00:00:01.000Z',
+      type: 'tool_request',
+      toolName: 'schematic.listComponents',
+      riskLevel: 'read',
+      requiresApproval: false,
+      inputHash: 'sha256:abc',
+    });
+
+    expect(parsed.riskLevel).toBe('read');
+  });
+
+  it('parses discriminated relay messages', () => {
+    const parsed = RelayMessageSchema.parse({
+      protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+      messageId: 'msg_3',
+      timestamp: '2026-07-03T00:00:02.000Z',
+      type: 'heartbeat',
+    });
+
+    expect(parsed.type).toBe('heartbeat');
+  });
+});

--- a/tests/unit/remote/session-router.test.ts
+++ b/tests/unit/remote/session-router.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { RemoteSessionRouter } from '../../../src/remote/session-router.js';
+
+function makeRouter(start = new Date('2026-07-03T00:00:00.000Z')) {
+  let now = start;
+  let counter = 0;
+  return {
+    router: new RemoteSessionRouter(
+      () => now,
+      () => `id-${++counter}`,
+    ),
+    advance(ms: number) {
+      now = new Date(now.getTime() + ms);
+    },
+  };
+}
+
+describe('RemoteSessionRouter', () => {
+  it('pairs a user to an extension session once', () => {
+    const { router } = makeRouter();
+    const session = router.registerSession({
+      connectionId: 'conn_1',
+      mode: 'hosted',
+      extensionVersion: '0.17.1',
+      activeProject: { projectName: 'Demo', documentType: 'schematic' },
+    });
+    const code = router.createPairingCode({ userId: 'user_1', sessionId: session.sessionId });
+
+    expect(router.completePairing({ code, userId: 'user_1', sessionId: session.sessionId })).toBe(
+      true,
+    );
+    expect(router.completePairing({ code, userId: 'user_1', sessionId: session.sessionId })).toBe(
+      false,
+    );
+  });
+
+  it('rejects cross-user pairing attempts', () => {
+    const { router } = makeRouter();
+    const session = router.registerSession({
+      connectionId: 'conn_1',
+      mode: 'hosted',
+      extensionVersion: '0.17.1',
+    });
+    const code = router.createPairingCode({ userId: 'user_1', sessionId: session.sessionId });
+
+    expect(router.completePairing({ code, userId: 'user_2', sessionId: session.sessionId })).toBe(
+      false,
+    );
+  });
+
+  it('resolves a paired read session without active project', () => {
+    const { router } = makeRouter();
+    const session = router.registerSession({
+      connectionId: 'conn_1',
+      mode: 'hosted',
+      extensionVersion: '0.17.1',
+    });
+    const code = router.createPairingCode({ userId: 'user_1', sessionId: session.sessionId });
+    router.completePairing({ code, userId: 'user_1', sessionId: session.sessionId });
+
+    const result = router.resolve({ userId: 'user_1', riskLevel: 'read' });
+    expect(result.ok).toBe(true);
+  });
+
+  it('requires active project for write routing', () => {
+    const { router } = makeRouter();
+    const session = router.registerSession({
+      connectionId: 'conn_1',
+      mode: 'hosted',
+      extensionVersion: '0.17.1',
+    });
+    const code = router.createPairingCode({ userId: 'user_1', sessionId: session.sessionId });
+    router.completePairing({ code, userId: 'user_1', sessionId: session.sessionId });
+
+    const result = router.resolve({ userId: 'user_1', riskLevel: 'write' });
+    expect(result).toMatchObject({ ok: false, code: 'PROJECT_INACTIVE' });
+  });
+
+  it('fails closed after disconnect', () => {
+    const { router } = makeRouter();
+    const session = router.registerSession({
+      connectionId: 'conn_1',
+      mode: 'hosted',
+      extensionVersion: '0.17.1',
+      activeProject: { projectName: 'Demo', documentType: 'pcb' },
+    });
+    const code = router.createPairingCode({ userId: 'user_1', sessionId: session.sessionId });
+    router.completePairing({ code, userId: 'user_1', sessionId: session.sessionId });
+    router.disconnect(session.sessionId);
+
+    const result = router.resolve({ userId: 'user_1', riskLevel: 'write' });
+    expect(result).toMatchObject({ ok: false, code: 'SESSION_DISCONNECTED' });
+  });
+
+  it('rejects expired pairing codes', () => {
+    const { router, advance } = makeRouter();
+    const session = router.registerSession({
+      connectionId: 'conn_1',
+      mode: 'hosted',
+      extensionVersion: '0.17.1',
+    });
+    const code = router.createPairingCode({
+      userId: 'user_1',
+      sessionId: session.sessionId,
+      ttlMs: 10,
+    });
+    advance(11);
+
+    expect(router.completePairing({ code, userId: 'user_1', sessionId: session.sessionId })).toBe(
+      false,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Add typed Remote MCP relay protocol schemas.
- Add remote scope checks for read/write/export/destructive risk classes.
- Add pairing/session routing core for hosted and self-hosted extension sessions.
- Add approval policy store tied to user, session, tool, and input hash.
- Add remote observability/audit event model with redaction helpers.
- Add unit tests for protocol, routing, scope, approval, and observability boundaries.

## Validation

- `pnpm typecheck`
- `pnpm exec vitest run tests/unit/remote`
- `pnpm lint`
- `pnpm format:check`
- `pnpm build`
- `git diff --check`

Note: a previous broad `pnpm test -- tests/unit/remote` invocation was not scoped by Vitest and ran the full suite, where the existing eval benchmark timed out. The correctly scoped remote test command passed.

Closes #105
Closes #113
Closes #114

Refs #102
Refs #106
