### PR TITLE
feat: add extension remote relay mode

### DIFF
--- a/easyeda-bridge-extension/src/index.ts
+++ b/easyeda-bridge-extension/src/index.ts
@@ -1,3 +1,5 @@
+import { RemoteRelayClient, type RemoteRelayMode } from './remote-client.js';
+
 declare const eda: EasyedaGlobal | undefined;
 declare const EDA: unknown | undefined;
 declare const api: unknown | undefined;
@@ -43,6 +45,13 @@ interface EasyedaGlobal {
   connect?: (mode?: ConnectMode) => Promise<void>;
   disconnect?: () => void;
   showStatus?: () => void;
+  connectRemoteRelay?: (
+    mode?: Exclude<RemoteRelayMode, 'disabled'>,
+    relayUrl?: string,
+    pairingCode?: string,
+  ) => void;
+  disconnectRemoteRelay?: () => void;
+  showRemoteRelayStatus?: () => void;
 }
 
 interface EasyedaWebSocketApi {
@@ -115,7 +124,6 @@ const RECONNECT_MAX_MS = 30000;
 const STORAGE_KEY = 'easyeda-mcp-pro:autoConnect';
 const HEARTBEAT_MS = 15000;
 const SOCKET_ID = 'easyeda-mcp-pro-bridge';
-const PORT_SCAN_LABEL = 'configured local port range';
 const API_CLASS_PREFIXES = ['DMT_', 'SCH_', 'PCB_', 'LIB_'] as const;
 const DENIED_API_METHODS = new Set([
   'constructor',
@@ -134,6 +142,53 @@ let manualDisconnectRequested = false;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 let externalInteractionWarningShown = false;
+
+let remoteRelayClient: RemoteRelayClient | null = null;
+
+function getRemoteRelayClient(): RemoteRelayClient {
+  remoteRelayClient ??= new RemoteRelayClient({
+    extensionVersion: '0.17.1', // x-release-please-version
+    log,
+    showToast,
+    readActiveProject: readRemoteActiveProject,
+  });
+  return remoteRelayClient;
+}
+
+function readRemoteActiveProject():
+  | { projectName?: string; documentType: 'schematic' | 'pcb' | 'unknown'; url?: string }
+  | undefined {
+  const href = typeof location !== 'undefined' ? location.href : undefined;
+  const title = typeof document !== 'undefined' ? document.title : undefined;
+  const projectName = title && title.trim() ? title.trim() : undefined;
+  if (!href && !projectName) return undefined;
+  const lower = `${href ?? ''} ${projectName ?? ''}`.toLowerCase();
+  const documentType = lower.includes('pcb')
+    ? 'pcb'
+    : lower.includes('sch')
+      ? 'schematic'
+      : 'unknown';
+  return { projectName, documentType, url: href };
+}
+
+function connectRemoteRelay(
+  mode: Exclude<RemoteRelayMode, 'disabled'> = 'hosted',
+  relayUrl?: string,
+  pairingCode?: string,
+): void {
+  getRemoteRelayClient().connect({ mode, relayUrl, pairingCode });
+}
+
+function disconnectRemoteRelay(): void {
+  getRemoteRelayClient().disconnect('user_disabled');
+  showToast('Remote Relay disabled');
+}
+
+function showRemoteRelayStatus(): void {
+  const status = getRemoteRelayClient().getStatus();
+  const project = status.activeProject?.projectName ?? 'no active project detected';
+  showToast(`Remote Relay: ${status.mode}/${status.state} | project: ${project}`);
+}
 
 function getGlobal(): EasyedaGlobal | null {
   if (typeof eda !== 'undefined' && eda) return eda;
@@ -2409,6 +2464,9 @@ function expose(): void {
     api.connect = connect;
     api.disconnect = disconnect;
     api.showStatus = showStatus;
+    api.connectRemoteRelay = connectRemoteRelay;
+    api.disconnectRemoteRelay = disconnectRemoteRelay;
+    api.showRemoteRelayStatus = showRemoteRelayStatus;
     (api as any).toggleAutoConnect = toggleAutoConnect;
     api.activate = handleActivate;
     api.deactivate = disconnect;
@@ -2418,6 +2476,9 @@ function expose(): void {
   globalScope.connect = connect;
   globalScope.disconnect = disconnect;
   globalScope.showStatus = showStatus;
+  globalScope.connectRemoteRelay = connectRemoteRelay;
+  globalScope.disconnectRemoteRelay = disconnectRemoteRelay;
+  globalScope.showRemoteRelayStatus = showRemoteRelayStatus;
   globalScope.toggleAutoConnect = toggleAutoConnect;
 }
 

--- a/easyeda-bridge-extension/src/remote-client.ts
+++ b/easyeda-bridge-extension/src/remote-client.ts
@@ -1,0 +1,191 @@
+export type RemoteRelayMode = 'disabled' | 'hosted' | 'self_hosted';
+export type RemoteRelayState = 'disconnected' | 'connecting' | 'connected' | 'paired';
+
+export interface RemoteActiveProject {
+  projectId?: string;
+  projectName?: string;
+  documentType: 'schematic' | 'pcb' | 'unknown';
+  url?: string;
+}
+
+export interface RemoteRelayStatus {
+  mode: RemoteRelayMode;
+  state: RemoteRelayState;
+  relayUrl?: string;
+  sessionId?: string;
+  pairingCode?: string;
+  activeProject?: RemoteActiveProject;
+  lastError?: string;
+}
+
+interface RemoteRelayClientOptions {
+  extensionVersion: string;
+  log: (message: string, data?: unknown) => void;
+  showToast: (message: string) => void;
+  readActiveProject: () => RemoteActiveProject | undefined;
+}
+
+interface RemoteEnvelope {
+  protocolVersion: '2026-07-remote-relay-v1';
+  messageId: string;
+  type: string;
+  sessionId?: string;
+  timestamp: string;
+  [key: string]: unknown;
+}
+
+const PROTOCOL_VERSION = '2026-07-remote-relay-v1';
+const DEFAULT_HOSTED_RELAY_URL = 'wss://relay.easyeda-mcp-pro.local/session';
+
+function makeMessageId(): string {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID();
+  return `msg_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
+
+export class RemoteRelayClient {
+  private socket: WebSocket | null = null;
+  private status: RemoteRelayStatus = { mode: 'disabled', state: 'disconnected' };
+
+  constructor(private readonly options: RemoteRelayClientOptions) {}
+
+  connect(input: {
+    mode: Exclude<RemoteRelayMode, 'disabled'>;
+    relayUrl?: string;
+    pairingCode?: string;
+  }): void {
+    this.disconnect('replaced');
+    const relayUrl = input.relayUrl ?? DEFAULT_HOSTED_RELAY_URL;
+    this.status = {
+      mode: input.mode,
+      state: 'connecting',
+      relayUrl,
+      pairingCode: input.pairingCode,
+      activeProject: this.options.readActiveProject(),
+    };
+    this.options.showToast(`Remote Relay connecting: ${input.mode}`);
+
+    try {
+      const socket = new WebSocket(relayUrl);
+      this.socket = socket;
+      socket.onopen = () => this.handleOpen(input.pairingCode);
+      socket.onmessage = (event) => this.handleMessage(event.data);
+      socket.onerror = () => this.handleError('Remote Relay socket error');
+      socket.onclose = () => this.handleClose();
+    } catch (error) {
+      this.handleError(`Remote Relay failed to start: ${String(error)}`);
+    }
+  }
+
+  disconnect(reason: 'user_disabled' | 'replaced' | 'disconnected' = 'user_disabled'): void {
+    if (this.socket) {
+      try {
+        this.send({ type: 'session_closed', reason });
+        this.socket.close();
+      } catch (error) {
+        this.options.log('Remote Relay close failed', error);
+      }
+    }
+    this.socket = null;
+    this.status = { ...this.status, state: 'disconnected', sessionId: undefined };
+  }
+
+  getStatus(): RemoteRelayStatus {
+    return {
+      ...this.status,
+      activeProject: this.options.readActiveProject() ?? this.status.activeProject,
+    };
+  }
+
+  private handleOpen(pairingCode?: string): void {
+    this.status = { ...this.status, state: pairingCode ? 'paired' : 'connected' };
+    this.send({
+      type: 'register_session',
+      extensionVersion: this.options.extensionVersion,
+      mode: this.status.mode,
+      pairingCode,
+      activeProject: this.options.readActiveProject(),
+      capabilities: ['local_bridge_proxy'],
+    });
+    this.options.showToast(
+      pairingCode ? 'Remote Relay connected and pairing code sent' : 'Remote Relay connected',
+    );
+  }
+
+  private handleMessage(data: unknown): void {
+    const text = typeof data === 'string' ? data : '';
+    let message: RemoteEnvelope | undefined;
+    try {
+      message = JSON.parse(text) as RemoteEnvelope;
+    } catch {
+      this.options.log('Remote Relay ignored non-JSON message');
+      return;
+    }
+    if (message.protocolVersion !== PROTOCOL_VERSION) {
+      this.send({
+        type: 'error',
+        code: 'RELAY_VERSION_UNSUPPORTED',
+        message: 'Unsupported relay protocol version',
+      });
+      return;
+    }
+    if (message.type === 'session_registered') {
+      this.status = {
+        ...this.status,
+        state: message.paired ? 'paired' : 'connected',
+        sessionId:
+          typeof message.sessionId === 'string' ? message.sessionId : this.status.sessionId,
+      };
+      return;
+    }
+    if (message.type === 'heartbeat') {
+      this.send({ type: 'heartbeat' });
+      return;
+    }
+    if (message.type === 'approval_request') {
+      this.options.showToast(
+        `Remote approval requested: ${String(message.toolName ?? 'tool action')}`,
+      );
+      return;
+    }
+    if (message.type === 'tool_request') {
+      this.send({
+        type: 'tool_response',
+        requestMessageId: message.messageId,
+        ok: false,
+        error: {
+          code: 'REMOTE_EXECUTION_NOT_ENABLED',
+          message: 'Remote command dispatch is not enabled in this extension build yet.',
+          suggestion:
+            'Use local bridge mode or wait for the next Remote Relay implementation phase.',
+        },
+        durationMs: 0,
+      });
+    }
+  }
+
+  private handleError(message: string): void {
+    this.status = { ...this.status, state: 'disconnected', lastError: message };
+    this.options.log(message);
+    this.options.showToast(message);
+  }
+
+  private handleClose(): void {
+    this.socket = null;
+    if (this.status.state !== 'disconnected') {
+      this.status = { ...this.status, state: 'disconnected' };
+      this.options.showToast('Remote Relay disconnected');
+    }
+  }
+
+  private send(payload: Record<string, unknown>): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+    const envelope = {
+      protocolVersion: PROTOCOL_VERSION,
+      messageId: makeMessageId(),
+      sessionId: this.status.sessionId,
+      timestamp: new Date().toISOString(),
+      ...payload,
+    } as RemoteEnvelope;
+    this.socket.send(JSON.stringify(envelope));
+  }
+}


### PR DESCRIPTION
## Summary

- Add extension-side Remote Relay Mode state machine.
- Add outbound WebSocket relay client for hosted and self-hosted remote sessions.
- Expose extension methods for connecting, disconnecting, and inspecting remote relay status.
- Register remote sessions with active project metadata and relay protocol version.
- Fail tool dispatch safely until the next remote command execution phase is enabled.

## Validation

- `pnpm --filter @easyeda-mcp-pro/bridge-extension typecheck`
- `pnpm build:extension`
- `pnpm verify:extension`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm format:check`
- `git diff --check`

Closes #106
Refs #102
