### PR TITLE
fix(remote): normalize OAuth scope formats

### DIFF
--- a/src/server/transports/http.ts
+++ b/src/server/transports/http.ts
@@ -59,6 +59,27 @@ function createRateLimiter(windowMs: number, maxRequests: number) {
  */
 const SUPPORTED_TOKEN_TYPES = new Set(['JWT', undefined]);
 
+function trimTrailingSlash(value: string): string {
+  return value.endsWith('/') ? value.slice(0, -1) : value;
+}
+
+function inferRequestBaseUrl(req: Request, config: EnvConfig): string {
+  const proto = isLoopback(config.HTTP_HOST) ? 'http' : 'https';
+  const host = req.headers.host || String(config.HTTP_HOST) + ':' + String(config.HTTP_PORT);
+  return trimTrailingSlash(config.PUBLIC_BASE_URL || proto + '://' + host);
+}
+
+export function getMcpResourceUrl(req: Request, config: EnvConfig): string {
+  return inferRequestBaseUrl(req, config) + '/mcp';
+}
+
+export function normalizeOAuthScope(scope: string): string {
+  return scope
+    .trim()
+    .replace(/^easyeda:/, 'easyeda.')
+    .replace('project-admin', 'project_admin');
+}
+
 /** Structured error responses for token validation failures. */
 function tokenError(res: Response, message: string, code = 'invalid_token'): void {
   res.status(401).json({ error: message, code });
@@ -98,6 +119,7 @@ function validateOAuthToken(config: EnvConfig) {
   }
 
   const requiredScopes = parseScopeList(config.OAUTH_REQUIRED_SCOPES);
+  const normalizedRequiredScopes = requiredScopes.map(normalizeOAuthScope);
 
   // The config validator already ensures OAUTH_JWKS_URI is present when OAuth is enabled.
   // We cache the JWKSet for the lifetime of the server.
@@ -133,7 +155,10 @@ function validateOAuthToken(config: EnvConfig) {
 
         if (requiredScopes.length > 0) {
           const tokenScopes = extractTokenScopes(payload as Record<string, unknown>);
-          const missingScopes = requiredScopes.filter((scope) => !tokenScopes.has(scope));
+          const normalizedTokenScopes = new Set([...tokenScopes].map(normalizeOAuthScope));
+          const missingScopes = requiredScopes.filter(
+            (_scope, idx) => !normalizedTokenScopes.has(normalizedRequiredScopes[idx] ?? ''),
+          );
           if (missingScopes.length > 0) {
             res.status(403).json({
               error: 'Token is missing required OAuth scope',

--- a/src/server/transports/http.ts
+++ b/src/server/transports/http.ts
@@ -59,20 +59,6 @@ function createRateLimiter(windowMs: number, maxRequests: number) {
  */
 const SUPPORTED_TOKEN_TYPES = new Set(['JWT', undefined]);
 
-function trimTrailingSlash(value: string): string {
-  return value.endsWith('/') ? value.slice(0, -1) : value;
-}
-
-function inferRequestBaseUrl(req: Request, config: EnvConfig): string {
-  const proto = isLoopback(config.HTTP_HOST) ? 'http' : 'https';
-  const host = req.headers.host || String(config.HTTP_HOST) + ':' + String(config.HTTP_PORT);
-  return trimTrailingSlash(config.PUBLIC_BASE_URL || proto + '://' + host);
-}
-
-export function getMcpResourceUrl(req: Request, config: EnvConfig): string {
-  return inferRequestBaseUrl(req, config) + '/mcp';
-}
-
 export function normalizeOAuthScope(scope: string): string {
   return scope
     .trim()

--- a/tests/unit/server/transports/http-scope-normalization.test.ts
+++ b/tests/unit/server/transports/http-scope-normalization.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeOAuthScope } from '../../../../src/server/transports/http.js';
+
+describe('normalizeOAuthScope', () => {
+  it('normalizes legacy colon scopes to remote dot scopes', () => {
+    expect(normalizeOAuthScope('easyeda:read')).toBe('easyeda.read');
+    expect(normalizeOAuthScope('easyeda:write')).toBe('easyeda.write');
+    expect(normalizeOAuthScope('easyeda:export')).toBe('easyeda.export');
+  });
+
+  it('normalizes project admin spelling while preserving dot scopes', () => {
+    expect(normalizeOAuthScope('easyeda:project-admin')).toBe('easyeda.project_admin');
+    expect(normalizeOAuthScope('easyeda.project_admin')).toBe('easyeda.project_admin');
+  });
+});


### PR DESCRIPTION
## Summary

- Normalizes OAuth scopes so legacy `easyeda:read` style tokens can satisfy remote `easyeda.read` style requirements.
- Adds focused unit coverage for the normalization helper.

## Validation

Validated locally on ops-vps-02 before opening this PR:

- `pnpm exec prettier --check src/config/env.ts src/server/transports/http.ts tests/unit/server/transports/http.test.ts`
- `pnpm lint`
- `pnpm exec tsc --noEmit`
- `pnpm test -- --reporter=dot` — 57 files, 666 tests passed

## Issues

Progresses #122.