### PR TITLE
Harden release governance: Scorecard workflow + dependency-bot ownership

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,0 @@
-version: 2
-# GitHub Actions updates are managed by Renovate (see renovate.json)
-# Only npm updates are handled here for complementary coverage.
-updates: []

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,53 @@
+---
+name: Scorecard
+
+'on':
+  push:
+    branches: [main]
+  schedule:
+    - cron: '30 4 * * 1'
+  workflow_dispatch: {}
+
+permissions: read-all
+
+jobs:
+  analysis:
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      # actions/checkout v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        # ossf/scorecard-action v2.4.3
+        # NOTE: pinned to the version tag, not a commit SHA. This session has
+        # no network access to verify third-party commit SHAs against the
+        # upstream repository; Renovate (matchManagers: github-actions) will
+        # propose the digest pin on its next run per docs/adr/0002.
+        uses: ossf/scorecard-action@v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF results
+        # actions/upload-artifact v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        # github/codeql-action/upload-sarif v4.36.2
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
   <a href="https://www.bestpractices.dev/projects/13406">
     <img src="https://www.bestpractices.dev/projects/13406/badge" alt="OpenSSF Best Practices" />
   </a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/oaslananka/easyeda-mcp-pro">
+    <img src="https://api.scorecard.dev/projects/github.com/oaslananka/easyeda-mcp-pro/badge" alt="OpenSSF Scorecard" />
+  </a>
   <a href="https://github.com/oaslananka/easyeda-mcp-pro/security/policy">
     <img src="https://img.shields.io/badge/security-policy-blue" alt="Security policy" />
   </a>

--- a/docs/OPENSSF_BEST_PRACTICES.md
+++ b/docs/OPENSSF_BEST_PRACTICES.md
@@ -64,7 +64,7 @@ This file is a copy-ready evidence map for OpenSSF Best Practices self-certifica
 | `installation_standard_variables` | N/A                                         | npm-managed package install; no POSIX-style install path variables are used.                                                                                      |
 | `installation_development_quick`  | Met                                         | <https://github.com/oaslananka/easyeda-mcp-pro/blob/main/CONTRIBUTING.md#local-development-setup>                                                                 |
 | `external_dependencies`           | Met                                         | <https://github.com/oaslananka/easyeda-mcp-pro/blob/main/package.json> and <https://github.com/oaslananka/easyeda-mcp-pro/blob/main/pnpm-lock.yaml>               |
-| `dependency_monitoring`           | Met                                         | Dependabot, Renovate, `pnpm audit`, Socket, and CodeQL.                                                                                                           |
+| `dependency_monitoring`           | Met                                         | Renovate (sole update-PR bot; see [ADR 0002](./adr/0002-dependency-management.md)), Dependabot alerts, `pnpm audit`, Socket, and CodeQL.                          |
 | `updateable_reused_components`    | Met                                         | npm/pnpm-managed dependencies and lockfile updates.                                                                                                               |
 | `interfaces_current`              | Met                                         | TypeScript strictness, dependency monitoring, and compatibility docs.                                                                                             |
 | `automated_integration_testing`   | Met                                         | <https://github.com/oaslananka/easyeda-mcp-pro/actions/workflows/ci.yml>                                                                                          |
@@ -83,3 +83,7 @@ This file is a copy-ready evidence map for OpenSSF Best Practices self-certifica
 ## BadgeApp helper
 
 The file [`scripts/maintainer/openssf-badgeapp-autofill.js`](../scripts/maintainer/openssf-badgeapp-autofill.js) is a best-effort browser-console helper for the logged-in BadgeApp form. It only sets radio values for criteria where evidence is present. Review every value before saving.
+
+## OpenSSF Scorecard
+
+Separately from the BadgeApp self-certification above, [`.github/workflows/scorecard.yml`](../.github/workflows/scorecard.yml) runs the [OpenSSF Scorecard](https://github.com/ossf/scorecard) action on every push to `main` and weekly on a schedule. It publishes results to the public Scorecard API (`publish_results: true`) and uploads SARIF findings to GitHub code scanning. The current score is visible on the [Scorecard dashboard](https://scorecard.dev/viewer/?uri=github.com/oaslananka/easyeda-mcp-pro) and via the README badge. Scorecard findings support the `dependency_monitoring`, `static_analysis`, and `hardening` BadgeApp evidence above; review new low-scoring checks when the workflow runs and file follow-up issues for anything actionable.

--- a/docs/REPOSITORY_GOVERNANCE.md
+++ b/docs/REPOSITORY_GOVERNANCE.md
@@ -47,7 +47,7 @@ To enforce code quality, security, and a clean history, the `main` branch must h
 
 ## 2. Dependency Management Policy (Renovate)
 
-We use **Renovate** to keep our software supply chain up to date while mitigating security risks.
+We use **Renovate** to keep our software supply chain up to date while mitigating security risks. Renovate is the sole tool that opens automated dependency-update pull requests, for both npm packages and GitHub Actions; no `.github/dependabot.yml` version-update config is maintained, so that two bots cannot propose conflicting updates for the same dependency. GitHub's platform-level Dependabot alerts and Dependabot security updates (vulnerability detection, not update PRs) remain enabled separately — see the checklist in section 5. Details and rationale are recorded in [`docs/adr/0002-dependency-management.md`](./adr/0002-dependency-management.md).
 
 ### Automerge Rules
 

--- a/docs/adr/0002-dependency-management.md
+++ b/docs/adr/0002-dependency-management.md
@@ -35,3 +35,9 @@ We choose **Renovate** as our dependency automation provider.
   - Groups updates to reduce pull request and CI pipeline noise.
 - **Cons**:
   - Auto-merged PRs require robust unit and integration testing in CI to catch any regressions.
+
+## Addendum: Renovate vs. Dependabot (2026-07)
+
+Renovate is the **only** tool that opens automated dependency-update pull requests in this repository, for both npm packages (`renovate.json` default manager) and GitHub Actions (`matchManagers: ["github-actions"]` group). A `.github/dependabot.yml` version-update config is intentionally **not** present, so that two bots cannot open competing or duplicate update PRs for the same dependency.
+
+GitHub's platform-level Dependabot features — dependency graph, Dependabot alerts, and Dependabot security updates — remain **enabled** as vulnerability _detection_ (Settings > Security & analysis; see `docs/REPOSITORY_GOVERNANCE.md#5-maintainer-setup-checklist`). Those features do not require a `dependabot.yml` file; only Dependabot's _version-update_ PR feature does, and that is the piece this repository delegates to Renovate.


### PR DESCRIPTION
## Summary

- Add OpenSSF Scorecard workflow coverage for the repository.
- Clarify dependency update ownership: Renovate owns version-update PRs; Dependabot remains for platform vulnerability detection.
- Refresh OpenSSF Best Practices evidence and repository governance docs.

## Validation

- PR changes are preserved for review only.
- This PR will be superseded by a clean branch with rewritten commits before merge.