### PR TITLE
extension: wire remote tool execution callback

### DIFF
--- a/easyeda-bridge-extension/src/index.ts
+++ b/easyeda-bridge-extension/src/index.ts
@@ -151,6 +151,7 @@ function getRemoteRelayClient(): RemoteRelayClient {
     log,
     showToast,
     readActiveProject: readRemoteActiveProject,
+    executeToolRequest: (toolName, input) => dispatch(toolName, isRecord(input) ? input : {}),
   });
   return remoteRelayClient;
 }


### PR DESCRIPTION
## Summary

Route hosted remote tool requests to the existing extension dispatch path. Related to #121.

## Validation

Validated locally on ops-vps-02 before opening this clean PR.