### PR TITLE
test(tools): cover PCB constraint bridge paths

### DIFF
--- a/tests/unit/tools/pcb-constraints.test.ts
+++ b/tests/unit/tools/pcb-constraints.test.ts
@@ -110,4 +110,119 @@ describe('PCB constraint tools', () => {
     expect(result?.blocked).toBe(true);
     expect(result?.gate_mode).toBe('block');
   });
+
+  it('easyeda_pcb_production_review fetches board data from the bridge when boardData is omitted', async () => {
+    const tool = registry.get('easyeda_pcb_production_review');
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'board.getDimensions')
+        return { widthMm: 60, heightMm: 40, mountingHoleCount: 4 };
+      if (method === 'board.listLayers') return [{ id: 1 }, { id: 2 }];
+      if (method === 'board.getStackup') return { totalLayers: 2, layers: [{ id: 1 }, { id: 2 }] };
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const result = await tool?.handler(context, { projectId: 'pcb-bridge-1', gateMode: 'warn' });
+
+    expect(bridgeCall).toHaveBeenCalledWith('board.getDimensions', { projectId: 'pcb-bridge-1' });
+    expect(bridgeCall).toHaveBeenCalledWith('board.listLayers', { projectId: 'pcb-bridge-1' });
+    expect(bridgeCall).toHaveBeenCalledWith('board.getStackup', { projectId: 'pcb-bridge-1' });
+    expect(result?.project_id).toBe('pcb-bridge-1');
+    expect(result?.summary.totalChecks).toBeGreaterThan(0);
+  });
+
+  it('easyeda_pcb_production_review tolerates partial bridge failures via Promise.allSettled', async () => {
+    const tool = registry.get('easyeda_pcb_production_review');
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'board.getDimensions') throw new Error('dimensions unavailable');
+      if (method === 'board.listLayers') return { layers: [{ id: 1 }] };
+      if (method === 'board.getStackup') throw new Error('stackup unavailable');
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const result = await tool?.handler(context, { projectId: 'pcb-bridge-2', gateMode: 'warn' });
+
+    expect(result?.project_id).toBe('pcb-bridge-2');
+    expect(result?.not_available).toBeUndefined();
+  });
+
+  it('easyeda_pcb_constraint_check validates explicit board data', async () => {
+    const tool = registry.get('easyeda_pcb_constraint_check');
+    expect(tool).toBeDefined();
+
+    const result = await tool?.handler(context, {
+      projectId: 'pcb-check-1',
+      boardData: {
+        widthMm: 60,
+        heightMm: 40,
+        layerCount: 2,
+        hasOutline: true,
+        mountingHoleCount: 4,
+        hasLayerStack: true,
+        hasNetClasses: true,
+        hasClearanceRules: true,
+        hasKeepoutAreas: true,
+        hasPlacementZones: true,
+        hasFiducials: true,
+        hasTestPads: true,
+      },
+    });
+
+    expect(bridgeCall).not.toHaveBeenCalled();
+    expect(result?.project_id).toBe('pcb-check-1');
+    expect(typeof result?.valid).toBe('boolean');
+    expect(result?.summary.totalChecks).toBeGreaterThan(0);
+  });
+
+  it('easyeda_pcb_constraint_check fetches board data from the bridge when boardData is omitted', async () => {
+    const tool = registry.get('easyeda_pcb_constraint_check');
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'board.getDimensions') return { widthMm: 60, heightMm: 40 };
+      if (method === 'board.listLayers') return [];
+      if (method === 'board.getStackup') return {};
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const result = await tool?.handler(context, { projectId: 'pcb-check-2' });
+
+    expect(bridgeCall).toHaveBeenCalledTimes(3);
+    expect(result?.project_id).toBe('pcb-check-2');
+  });
+
+  it('easyeda_pcb_constraint_report builds a human-readable report from explicit board data', async () => {
+    const tool = registry.get('easyeda_pcb_constraint_report');
+    expect(tool).toBeDefined();
+
+    const result = await tool?.handler(context, {
+      projectId: 'pcb-report-1',
+      boardData: {
+        widthMm: 60,
+        heightMm: 40,
+        layerCount: 2,
+        hasOutline: true,
+        mountingHoleCount: 4,
+        hasLayerStack: true,
+      },
+    });
+
+    expect(bridgeCall).not.toHaveBeenCalled();
+    expect(result?.project_id).toBe('pcb-report-1');
+    expect(typeof result?.verdict).toBe('string');
+    expect(Array.isArray(result?.checked)).toBe(true);
+    expect(Array.isArray(result?.manualReviewRequired)).toBe(true);
+  });
+
+  it('easyeda_pcb_constraint_report fetches board data from the bridge when boardData is omitted', async () => {
+    const tool = registry.get('easyeda_pcb_constraint_report');
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'board.getDimensions') return { widthMm: 60, heightMm: 40 };
+      if (method === 'board.listLayers') return [];
+      if (method === 'board.getStackup') return {};
+      throw new Error(`unexpected method ${method}`);
+    });
+
+    const result = await tool?.handler(context, { projectId: 'pcb-report-2' });
+
+    expect(bridgeCall).toHaveBeenCalledTimes(3);
+    expect(result?.project_id).toBe('pcb-report-2');
+  });
 });


### PR DESCRIPTION
## Summary

Add tool coverage for bridge-backed board data fetching, partial bridge failures, explicit board data checks, and human-readable reports.

## Validation

Validated locally on ops-vps-02 before opening this clean PR.