### PR TITLE
feat(circuit): add component planning synthesis

### DIFF
--- a/docs/circuit-ir.md
+++ b/docs/circuit-ir.md
@@ -134,16 +134,21 @@ User/AI ──► DesignIntent ──► Validate ──► Compile ──► Ci
 1. **Validate** DesignIntent against the schema
 2. **Transform** functional block requirements into `Block` nodes
 3. **Create** `Rail` nodes from power rail requirements
-4. **Stub** `Device` slots (one per block) — users fill in MPNs during planning
-5. **Generate** placeholder `Net` entries for each power rail
+4. **Plan** one candidate `Device` per block via `component-planning.ts` — a
+   deterministic refdes, a component role, and a package-family hint (see
+   [Component planning](#component-planning) below)
+5. **Generate** `Net` entries for each power rail plus one synthesized
+   common-ground `Net`
 6. **Synthesize** professional planning context:
-   - `powerDomains[]` from rails
+   - `powerDomains[]` from rails, with device load/source wiring when
+     unambiguous (see [Component planning](#component-planning))
    - `signalClasses[]` from power/electrical intent
    - `physicalConstraints[]` from mechanical and safety intent
+   - `interfaces[]` candidate stubs for blocks classified as connectors
 7. **Copy** mechanical constraints into `pcb` fields
 8. **Copy** manufacturing intent into `manufacturing` fields
 9. **Validate** the output CircuitIR (structural + cross-reference checks)
-10. Return draft CircuitIR + original DesignIntent (for traceability)
+10. Return draft CircuitIR + original DesignIntent + compiler warnings (for traceability)
 
 ### Compiler best-practice synthesis
 
@@ -151,10 +156,51 @@ The compiler now creates first-pass electronics planning structures from DesignI
 
 - each rail becomes a `PowerDomain` with voltage, tolerance, current, rail reference, and traceability;
 - power nets are linked to their rail, power domain, and the `sc-power` signal class;
+- a synthesized `GND` net models the board's common ground reference;
 - high-frequency electrical requirements create a `sc-high-speed` planning class;
-- board dimensions, mounting holes, and isolation requirements become physical constraints.
+- board dimensions, mounting holes, and isolation requirements become physical constraints;
+- connector-role blocks get a candidate `Interface` stub (pinout left empty for schematic entry).
 
 These synthesized structures are conservative planning hints. They do not replace human review, ERC/DRC, datasheets, or manufacturing rules; they make those review steps explicit and machine-checkable.
+
+### Component planning
+
+`src/circuit/component-planning.ts` replaces the old generic `U?` device stub
+with a deterministic component-role plan for every block:
+
+1. **Role inference** (`determineComponentRole`) — keyword matches on the
+   block's purpose text (`connector`/`header`/`usb`/`jack`, `fuse`/`polyfuse`/`ptc`,
+   `filter`/`decoupl`/`bypass`) take priority over the coarse `BlockType`
+   enum, because a "power-management" block may in practice be a regulator
+   _or_ a passive filter stage. Roles: `power-regulator`, `mcu-module`,
+   `sensor`, `communication-ic`, `analog-ic`, `connector`, `protection-diode`,
+   `fuse`, `passive-support`, `generic-ic`.
+2. **Deterministic refdes** — each role maps to a fixed refdes family
+   (`U`, `J`, `D`, `F`, `C`; see `ROLE_REFDES_PREFIX`), numbered sequentially
+   in block order. Refdes assignment is stable across repeated compiles of
+   the same DesignIntent.
+3. **Package-family hint** — a conservative footprint _family_ suggestion
+   per role (`ROLE_PACKAGE_HINT`), e.g. "SOT-23-5 or TO-220" for a
+   regulator. This is not a final footprint selection.
+4. **Planning-state marker** — every Device records `role`, `packageHint`,
+   and `planningState` (`candidate` for high-confidence roles, `placeholder`
+   for the `generic-ic` fallback) as `Device.metadata` entries, so downstream
+   tooling (including future BOM-sourcing integration) can tell a
+   manufacturable candidate apart from an unclassified placeholder. A
+   compiler warning is emitted for every `placeholder` device.
+
+The compiler never invents an `mpn`, `manufacturer`, or `package` value —
+those fields stay unset until a human or a BOM-sourcing step selects a real
+part. This is a deliberate non-goal: the planner narrows the search space,
+it does not select or order parts.
+
+Device-to-power-domain wiring (`Device.powerDomainRef` and
+`PowerDomain.loadDeviceRefs`) is populated automatically only when a design
+has exactly one power rail — an unambiguous case. DesignIntent does not
+specify which rail a given block operates on, so for multi-rail designs the
+compiler emits a warning instead of guessing a possibly-wrong rail
+assignment; assign `Device.powerDomainRef` manually during CircuitIR review
+in that case.
 
 ### Traceability model
 
@@ -248,20 +294,34 @@ if (!isReadyForEasyEDA(validated)) {
   "devices": [
     {
       "id": "dev-block-req-input",
-      "ref": "U?",
+      "ref": "D1",
       "blockRef": "block-req-input",
-      "designIntentRef": [{ "requirementId": "req-input" }]
+      "designIntentRef": [{ "requirementId": "req-input" }],
+      "metadata": [
+        { "key": "role", "value": "protection-diode" },
+        {
+          "key": "packageHint",
+          "value": "SOD-123/SMA (select by clamping voltage and current rating)"
+        },
+        { "key": "planningState", "value": "candidate" }
+      ]
     },
     {
       "id": "dev-block-req-regulator",
-      "ref": "U?",
+      "ref": "U1",
       "blockRef": "block-req-regulator",
-      "designIntentRef": [{ "requirementId": "req-regulator" }]
+      "designIntentRef": [{ "requirementId": "req-regulator" }],
+      "metadata": [
+        { "key": "role", "value": "power-regulator" },
+        { "key": "packageHint", "value": "SOT-23-5 or TO-220 (select by current/thermal rating)" },
+        { "key": "planningState", "value": "candidate" }
+      ]
     }
   ],
   "nets": [
     { "id": "net-rail-12V_IN", "name": "12V_IN", "type": "power", "nodes": [] },
-    { "id": "net-rail-3V3_OUT", "name": "3V3_OUT", "type": "power", "nodes": [] }
+    { "id": "net-rail-3V3_OUT", "name": "3V3_OUT", "type": "power", "nodes": [] },
+    { "id": "net-gnd", "name": "GND", "type": "ground", "nodes": [] }
   ],
   "rails": [
     {
@@ -318,10 +378,12 @@ src/circuit/
 ├── errors.ts             # Circuit-specific error types
 ├── design-intent.ts      # DesignIntent schema + validation
 ├── circuit-ir.ts         # CircuitIR schema + validation
+├── component-planning.ts # Component role, refdes, and package-hint synthesis
 └── compiler.ts           # DesignIntent → CircuitIR compiler
 
 tests/unit/circuit/
-├── design-intent.test.ts # DesignIntent validation tests
-├── circuit-ir.test.ts    # CircuitIR validation tests
-└── compiler.test.ts      # Compiler + review gate tests
+├── design-intent.test.ts       # DesignIntent validation tests
+├── circuit-ir.test.ts          # CircuitIR validation tests
+├── component-planning.test.ts  # Component role/refdes planning tests
+└── compiler.test.ts            # Compiler + review gate tests
 ```

--- a/src/circuit/compiler.ts
+++ b/src/circuit/compiler.ts
@@ -10,10 +10,13 @@
  *   1. Validates the input DesignIntent.
  *   2. Transforms functional block requirements into Blocks.
  *   3. Creates power Rails from the DesignIntent's rail requirements.
- *   4. Creates empty Device slots with traceability refs.
- *   5. Generates placeholder Nets for each power rail.
- *   6. Copies manufacturing, mechanical, and safety intent into CircuitIR fields.
- *   7. Preserves all traceability IDs.
+ *   4. Plans one candidate Device per Block: a deterministic refdes, a
+ *      component role, and a package-family hint (see component-planning.ts).
+ *   5. Generates power Nets for each rail plus a synthesized common-ground Net.
+ *   6. Wires device/power-domain load relationships when unambiguous, and
+ *      synthesizes candidate connector Interfaces.
+ *   7. Copies manufacturing, mechanical, and safety intent into CircuitIR fields.
+ *   8. Preserves all traceability IDs.
  *
  * @module
  */
@@ -30,9 +33,11 @@ import {
   PowerDomain,
   SignalClass,
   PhysicalConstraint,
+  Interface,
 } from './circuit-ir.js';
 import { ValidationStatus, NetType, ConstraintSeverity } from './types.js';
 import { CircuitError, CircuitErrorCode, fromZodError } from './errors.js';
+import { planComponents, getDeviceRole } from './component-planning.js';
 
 // ── Compile options ───────────────────────────────────────────────────────
 
@@ -94,23 +99,6 @@ function compilePowerRails(designIntent: DesignIntent, blocks: Block[]): PowerRa
   });
 }
 
-function compileDeviceStubs(blocks: Block[]): Device[] {
-  // We create one stub Device per block as a placeholder. The user fills
-  // in actual MPNs during the planning step.
-  return blocks.map((block) => ({
-    id: `dev-${block.id}`,
-    ref: `U?`,
-    mpn: undefined,
-    manufacturer: undefined,
-    package: undefined,
-    datasheet: '',
-    lcsc: undefined,
-    blockRef: block.id,
-    designIntentRef: block.designIntentRef,
-    metadata: [],
-  }));
-}
-
 function compilePowerDomainId(rail: PowerRail): string {
   return `pd-${rail.id}`;
 }
@@ -144,6 +132,91 @@ function compilePowerDomains(rails: PowerRail[]): PowerDomain[] {
     designIntentRef: rail.designIntentRef,
     metadata: [],
   }));
+}
+
+/**
+ * Synthesize a single common-ground net. Every board with at least one power
+ * rail needs a ground reference; this net is intentionally board-wide (not
+ * tied to a specific rail or power domain) since DesignIntent does not model
+ * multiple isolated ground planes.
+ */
+function compileGroundNet(rails: PowerRail[]): Net[] {
+  if (rails.length === 0) return [];
+  return [
+    {
+      id: 'net-gnd',
+      name: 'GND',
+      type: NetType.Ground,
+      nodes: [],
+      designIntentRef: [],
+      metadata: [{ key: 'source', value: 'synthesized-common-ground' }],
+    },
+  ];
+}
+
+/**
+ * Synthesize a candidate Interface entry for each block whose planned
+ * component role is `connector`. Pinout is intentionally empty — DesignIntent
+ * does not specify pin-level connector detail — but the Interface node makes
+ * the connector's existence and traceability explicit before schematic entry.
+ */
+function compileInterfaceStubs(blocks: Block[], devices: Device[]): Interface[] {
+  const deviceByBlockRef = new Map(devices.map((d) => [d.blockRef, d]));
+  return blocks
+    .filter((block) => {
+      const device = deviceByBlockRef.get(block.id);
+      return device ? getDeviceRole(device) === 'connector' : false;
+    })
+    .map((block) => ({
+      id: `iface-${block.id}`,
+      name: block.name,
+      type: 'connector',
+      pinout: [],
+      blockRef: block.id,
+      designIntentRef: block.designIntentRef,
+    }));
+}
+
+/**
+ * Attach each device to the power domain it most plausibly draws from or
+ * supplies, and back-fill each power domain's `loadDeviceRefs`.
+ *
+ * This is intentionally conservative: DesignIntent does not specify which
+ * rail a given functional block operates on, so device-level power-domain
+ * assignment is only attempted when the design has exactly one rail overall
+ * (an unambiguous case). For multi-rail designs the compiler emits a warning
+ * instead of guessing a wrong rail assignment.
+ */
+function wirePowerDomainLoads(
+  devices: Device[],
+  rails: PowerRail[],
+  powerDomains: PowerDomain[],
+): { devices: Device[]; powerDomains: PowerDomain[]; warnings: string[] } {
+  const warnings: string[] = [];
+
+  if (rails.length !== 1 || powerDomains.length !== 1) {
+    if (rails.length > 1) {
+      warnings.push(
+        `Design declares ${rails.length} power rails; automatic device-to-rail power-domain ` +
+          `assignment was skipped because DesignIntent does not specify which rail each block ` +
+          `operates on. Assign each Device.powerDomainRef manually during CircuitIR review.`,
+      );
+    }
+    return { devices, powerDomains, warnings };
+  }
+
+  const domain = powerDomains[0];
+  if (!domain) {
+    return { devices, powerDomains, warnings };
+  }
+
+  const loadDeviceRefs = devices.map((device) => device.id);
+  const updatedDevices = devices.map((device) => ({ ...device, powerDomainRef: domain.id }));
+  const updatedDomains = powerDomains.map((pd) =>
+    pd.id === domain.id ? { ...pd, loadDeviceRefs } : pd,
+  );
+
+  return { devices: updatedDevices, powerDomains: updatedDomains, warnings };
 }
 
 function compileSignalClasses(designIntent: DesignIntent, powerNets: Net[]): SignalClass[] {
@@ -234,6 +307,7 @@ function buildCircuitIR(
   powerDomains: PowerDomain[],
   signalClasses: SignalClass[],
   physicalConstraints: PhysicalConstraint[],
+  interfaces: Interface[],
   opts: CompileOptions,
 ): CircuitIR {
   return {
@@ -251,7 +325,7 @@ function buildCircuitIR(
     powerDomains,
     signalClasses,
     physicalConstraints,
-    interfaces: [],
+    interfaces,
     constraints: [],
     bom: { excludeRefs: [], preferredVendors: [] },
     pcb: {
@@ -314,16 +388,27 @@ export function compile(input: unknown, options?: CompileOptions): CompileResult
   // ── 3. Compile Power Rails ──────────────────────────────────────────────
   const rails = compilePowerRails(designIntent, blocks);
 
-  // ── 4. Create Device stubs ──────────────────────────────────────────────
-  const devices = compileDeviceStubs(blocks);
+  // ── 4. Plan candidate component roles, refdes, and package hints ───────
+  const componentPlan = planComponents(blocks);
+  warnings.push(...componentPlan.warnings);
 
-  // ── 5. Create power nets ───────────────────────────────────────────────
-  const nets = compilePowerNets(rails);
+  // ── 5. Create power + ground nets ───────────────────────────────────────
+  const powerNets = compilePowerNets(rails);
+  const groundNet = compileGroundNet(rails);
+  const nets = [...powerNets, ...groundNet];
 
   // ── 6. Compile professional planning context ───────────────────────────
-  const powerDomains = compilePowerDomains(rails);
-  const signalClasses = compileSignalClasses(designIntent, nets);
+  const powerDomainWiring = wirePowerDomainLoads(
+    componentPlan.devices,
+    rails,
+    compilePowerDomains(rails),
+  );
+  warnings.push(...powerDomainWiring.warnings);
+  const devices = powerDomainWiring.devices;
+  const powerDomains = powerDomainWiring.powerDomains;
+  const signalClasses = compileSignalClasses(designIntent, powerNets);
   const physicalConstraints = compilePhysicalConstraints(designIntent);
+  const interfaces = compileInterfaceStubs(blocks, devices);
 
   // ── 7. Build CircuitIR ──────────────────────────────────────────────────
   const circuitIR = buildCircuitIR(
@@ -335,6 +420,7 @@ export function compile(input: unknown, options?: CompileOptions): CompileResult
     powerDomains,
     signalClasses,
     physicalConstraints,
+    interfaces,
     opts,
   );
 

--- a/src/circuit/component-planning.ts
+++ b/src/circuit/component-planning.ts
@@ -1,0 +1,187 @@
+/**
+ * Component role and refdes planning for CircuitIR device synthesis.
+ *
+ * Replaces generic `U?` device stubs with a deterministic, traceable
+ * component-role plan: a refdes family, a package/footprint hint, and a
+ * planning-state marker that differentiates a confidently-classified
+ * candidate device from a low-confidence placeholder.
+ *
+ * This module intentionally does not select real MPNs, manufacturers, or
+ * footprints — it narrows the search space (role + refdes + package family)
+ * so a human, BOM-sourcing tool, or downstream planning step can make the
+ * final manufacturable selection. See docs/circuit-ir.md for the full
+ * synthesis pipeline this module is part of.
+ *
+ * @module
+ */
+
+import { BlockType } from './types.js';
+import type { Block, Device } from './circuit-ir.js';
+
+// ── Component roles ───────────────────────────────────────────────────────
+
+export type ComponentRole =
+  | 'power-regulator'
+  | 'mcu-module'
+  | 'sensor'
+  | 'communication-ic'
+  | 'analog-ic'
+  | 'connector'
+  | 'protection-diode'
+  | 'fuse'
+  | 'passive-support'
+  | 'generic-ic';
+
+/** Confidence that the role was inferred correctly from the DesignIntent block. */
+export type RoleConfidence = 'high' | 'low';
+
+export interface ComponentRolePlan {
+  role: ComponentRole;
+  confidence: RoleConfidence;
+}
+
+/** Deterministic refdes family per component role, matching common schematic convention. */
+export const ROLE_REFDES_PREFIX: Record<ComponentRole, string> = {
+  'power-regulator': 'U',
+  'mcu-module': 'U',
+  sensor: 'U',
+  'communication-ic': 'U',
+  'analog-ic': 'U',
+  connector: 'J',
+  'protection-diode': 'D',
+  fuse: 'F',
+  'passive-support': 'C',
+  'generic-ic': 'U',
+};
+
+/** Conservative package/footprint family hint per role — not a final footprint selection. */
+export const ROLE_PACKAGE_HINT: Record<ComponentRole, string> = {
+  'power-regulator': 'SOT-23-5 or TO-220 (select by current/thermal rating)',
+  'mcu-module': 'QFN/LQFP or module footprint (select by MCU family)',
+  sensor: 'Manufacturer-specific package (verify against the selected sensor datasheet)',
+  'communication-ic': 'SOIC/QFN (select by the selected transceiver/PHY datasheet)',
+  'analog-ic': 'SOIC/SOT package (select by the selected part datasheet)',
+  connector: 'THT or SMD connector footprint (select by mechanical/mating requirements)',
+  'protection-diode': 'SOD-123/SMA (select by clamping voltage and current rating)',
+  fuse: '0603/1206 SMD fuse or THT fuse holder (select by current rating)',
+  'passive-support': '0402/0603 SMD passive (select values during schematic entry)',
+  'generic-ic': 'TBD — insufficient design intent to suggest a package family',
+};
+
+/** Metadata keys the compiler attaches to each planned Device. */
+export const COMPONENT_PLAN_METADATA_KEYS = {
+  role: 'role',
+  packageHint: 'packageHint',
+  planningState: 'planningState',
+} as const;
+
+/**
+ * Determine a component role for a Block from its `type` and free-text
+ * `description` (the compiled block's purpose). Keyword matches on the
+ * description take priority over the coarse `type` field because the
+ * DesignIntent functional-block `type` is intentionally low-resolution
+ * (e.g. "power-management" covers both regulators and passive filter
+ * stages).
+ */
+export function determineComponentRole(block: {
+  type: string;
+  description?: string;
+}): ComponentRolePlan {
+  const text = `${block.type} ${block.description ?? ''}`.toLowerCase();
+
+  if (
+    text.includes('connector') ||
+    text.includes('header') ||
+    text.includes('usb') ||
+    text.includes('jack')
+  ) {
+    return { role: 'connector', confidence: 'high' };
+  }
+  if (text.includes('fuse') || text.includes('polyfuse') || text.includes('ptc')) {
+    return { role: 'fuse', confidence: 'high' };
+  }
+  if (text.includes('filter') || text.includes('decoupl') || text.includes('bypass')) {
+    return { role: 'passive-support', confidence: 'high' };
+  }
+
+  switch (block.type) {
+    case BlockType.PowerManagement:
+      return { role: 'power-regulator', confidence: 'high' };
+    case BlockType.Microcontroller:
+      return { role: 'mcu-module', confidence: 'high' };
+    case BlockType.Sensor:
+      return { role: 'sensor', confidence: 'high' };
+    case BlockType.Communication:
+      return { role: 'communication-ic', confidence: 'high' };
+    case BlockType.Interface:
+      return { role: 'connector', confidence: 'high' };
+    case BlockType.Protection:
+      return { role: 'protection-diode', confidence: 'high' };
+    case BlockType.Analog:
+      return { role: 'analog-ic', confidence: 'high' };
+    default:
+      return { role: 'generic-ic', confidence: 'low' };
+  }
+}
+
+export interface ComponentPlanResult {
+  devices: Device[];
+  warnings: string[];
+}
+
+/**
+ * Plan one candidate Device per Block: a deterministic refdes, a component
+ * role, and a package-family hint, recorded as Device metadata alongside
+ * a `planningState` of `candidate` (role inferred with high confidence) or
+ * `placeholder` (role could not be determined; manual classification
+ * required).
+ *
+ * Refdes numbering is deterministic and stable across repeated compiles of
+ * the same DesignIntent, because it is derived solely from block order.
+ */
+export function planComponents(blocks: Block[]): ComponentPlanResult {
+  const refdesCounters: Record<string, number> = {};
+  const warnings: string[] = [];
+
+  const devices = blocks.map((block) => {
+    const plan = determineComponentRole({ type: block.type, description: block.description });
+    const prefix = ROLE_REFDES_PREFIX[plan.role];
+    refdesCounters[prefix] = (refdesCounters[prefix] ?? 0) + 1;
+    const ref = `${prefix}${refdesCounters[prefix]}`;
+    const planningState = plan.confidence === 'high' ? 'candidate' : 'placeholder';
+
+    if (planningState === 'placeholder') {
+      warnings.push(
+        `Block "${block.name}" (${block.id}): insufficient design intent to determine a ` +
+          `component role; using a generic placeholder device (${ref}). Provide a more ` +
+          `specific block type or purpose to enable manufacturable candidate planning.`,
+      );
+    }
+
+    const device: Device = {
+      id: `dev-${block.id}`,
+      ref,
+      mpn: undefined,
+      manufacturer: undefined,
+      package: undefined,
+      datasheet: '',
+      lcsc: undefined,
+      blockRef: block.id,
+      designIntentRef: block.designIntentRef,
+      metadata: [
+        { key: COMPONENT_PLAN_METADATA_KEYS.role, value: plan.role },
+        { key: COMPONENT_PLAN_METADATA_KEYS.packageHint, value: ROLE_PACKAGE_HINT[plan.role] },
+        { key: COMPONENT_PLAN_METADATA_KEYS.planningState, value: planningState },
+      ],
+    };
+    return device;
+  });
+
+  return { devices, warnings };
+}
+
+/** Read a Device's planned component role back out of its metadata, if present. */
+export function getDeviceRole(device: Device): ComponentRole | undefined {
+  const value = device.metadata.find((m) => m.key === COMPONENT_PLAN_METADATA_KEYS.role)?.value;
+  return value as ComponentRole | undefined;
+}

--- a/src/circuit/index.ts
+++ b/src/circuit/index.ts
@@ -68,3 +68,19 @@ export type {
 // Compiler
 export { compile, setValidationStatus, isReadyForEasyEDA } from './compiler.js';
 export type { CompileOptions, CompileResult } from './compiler.js';
+
+// Component planning
+export {
+  ROLE_REFDES_PREFIX,
+  ROLE_PACKAGE_HINT,
+  COMPONENT_PLAN_METADATA_KEYS,
+  determineComponentRole,
+  planComponents,
+  getDeviceRole,
+} from './component-planning.js';
+export type {
+  ComponentRole,
+  RoleConfidence,
+  ComponentRolePlan,
+  ComponentPlanResult,
+} from './component-planning.js';

--- a/tests/unit/circuit/compiler.test.ts
+++ b/tests/unit/circuit/compiler.test.ts
@@ -72,7 +72,10 @@ describe('compile', () => {
     const result = compile(powerSupplyIntent);
     expect(result.circuitIR).toBeDefined();
     expect(result.designIntent).toBeDefined();
-    expect(result.warnings).toEqual([]);
+    // Two rails with no explicit block/rail mapping is an ambiguous case;
+    // the compiler flags it instead of guessing a device-to-rail assignment.
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]).toContain('2 power rails');
 
     // Check compilation output
     const cir = result.circuitIR;
@@ -110,25 +113,53 @@ describe('compile', () => {
     expect(cir.rails[1].tolerance).toBe(3);
   });
 
-  it('creates device stubs for each block', () => {
+  it('creates a candidate device plan for each block', () => {
     const result = compile(powerSupplyIntent);
     const cir = result.circuitIR;
 
-    // One stub device per block
+    // One planned device per block
     expect(cir.devices).toHaveLength(3);
     for (const device of cir.devices) {
       expect(device.blockRef).toMatch(/^block-req-/);
       expect(device.designIntentRef).toHaveLength(1);
+      expect(device.metadata.map((m) => m.key)).toEqual(
+        expect.arrayContaining(['role', 'packageHint', 'planningState']),
+      );
     }
+
+    // Roles are inferred from block type/purpose and drive the refdes family.
+    const byBlock = Object.fromEntries(cir.devices.map((d) => [d.blockRef, d]));
+    expect(byBlock['block-req-input'].ref).toMatch(/^D\d+$/);
+    expect(byBlock['block-req-regulator'].ref).toMatch(/^U\d+$/);
+    // "Output ripple filtering and decoupling" is keyword-classified as a
+    // passive support device, not a generic IC.
+    expect(byBlock['block-req-output'].ref).toMatch(/^C\d+$/);
   });
 
-  it('creates power nets for each rail', () => {
+  it('creates power nets for each rail plus a synthesized ground net', () => {
     const result = compile(powerSupplyIntent);
     const cir = result.circuitIR;
 
-    expect(cir.nets).toHaveLength(2);
+    expect(cir.nets).toHaveLength(3);
     expect(cir.nets[0].name).toBe('12V_IN');
     expect(cir.nets[1].name).toBe('3V3_OUT');
+    expect(cir.nets[2]).toMatchObject({ name: 'GND', type: 'ground', nodes: [] });
+  });
+
+  it('does not synthesize a ground net when there are no power rails', () => {
+    // A design must declare at least one rail per DesignIntent validation,
+    // so exercise the zero-rails compiler path directly via skipValidation.
+    const zeroRailsIntent = {
+      ...powerSupplyIntent,
+      requirements: {
+        ...powerSupplyIntent.requirements,
+        electrical: {},
+        power: { rails: [] },
+        safety: {},
+      },
+    };
+    const result = compile(zeroRailsIntent, { skipValidation: true });
+    expect(result.circuitIR.nets.find((n) => n.name === 'GND')).toBeUndefined();
   });
 
   it('synthesizes power domains for each rail', () => {
@@ -186,6 +217,104 @@ describe('compile', () => {
       'pc-mounting-holes',
       'pc-isolation-clearance',
     ]);
+  });
+
+  it('wires devices to the sole power domain when there is exactly one rail', () => {
+    const singleRailIntent = {
+      $schema: DESIGN_INTENT_SCHEMA_VERSION,
+      project: {
+        name: 'USB Sensor Node',
+        goal: 'A USB-powered MCU board reading a sensor over I2C',
+        boardType: BoardType.McuBoard,
+      },
+      requirements: {
+        functionalBlocks: [
+          {
+            id: 'req-usb',
+            name: 'USB-C Connector',
+            type: 'interface',
+            purpose: 'USB-C connector for power and data',
+          },
+          {
+            id: 'req-mcu',
+            name: 'Main MCU',
+            type: 'microcontroller',
+            purpose: 'Runs the application firmware',
+          },
+          {
+            id: 'req-sensor',
+            name: 'Temperature Sensor',
+            type: 'sensor',
+            purpose: 'I2C temperature sensor',
+          },
+        ],
+        power: {
+          rails: [{ id: '5V_USB', voltage: 5.0, maxCurrentAmps: 0.5 }],
+        },
+        mechanical: { widthMm: 25, heightMm: 15, layers: 2 },
+        manufacturing: {},
+      },
+      assumptions: [],
+      unknowns: [],
+    };
+
+    const result = compile(singleRailIntent);
+    const cir = result.circuitIR;
+
+    // Unambiguous single-rail design: every device and the domain's
+    // loadDeviceRefs get wired automatically, with no ambiguity warning.
+    expect(result.warnings).toEqual([]);
+    expect(cir.powerDomains).toHaveLength(1);
+    expect(cir.powerDomains[0].loadDeviceRefs.sort()).toEqual(cir.devices.map((d) => d.id).sort());
+    for (const device of cir.devices) {
+      expect(device.powerDomainRef).toBe(cir.powerDomains[0].id);
+    }
+
+    // Role inference: connector, MCU/module, and sensor cases.
+    const byBlock = Object.fromEntries(cir.devices.map((d) => [d.blockRef, d]));
+    expect(byBlock['block-req-usb'].ref).toMatch(/^J\d+$/);
+    expect(byBlock['block-req-mcu'].ref).toMatch(/^U\d+$/);
+    expect(byBlock['block-req-sensor'].ref).toMatch(/^U\d+$/);
+
+    // The connector block gets a synthesized candidate Interface.
+    expect(cir.interfaces).toHaveLength(1);
+    expect(cir.interfaces[0]).toMatchObject({
+      name: 'USB-C Connector',
+      type: 'connector',
+      blockRef: 'block-req-usb',
+      pinout: [],
+    });
+  });
+
+  it('flags a generic/low-confidence role with a compiler warning', () => {
+    const vagueIntent = {
+      $schema: DESIGN_INTENT_SCHEMA_VERSION,
+      project: {
+        name: 'Custom Board',
+        goal: 'A board with an unclassified block',
+        boardType: BoardType.Custom,
+      },
+      requirements: {
+        functionalBlocks: [
+          {
+            id: 'req-mystery',
+            name: 'Mystery Block',
+            type: 'custom',
+            purpose: 'Something not yet decided',
+          },
+        ],
+        power: { rails: [{ id: 'VCC', voltage: 3.3 }] },
+        mechanical: {},
+        manufacturing: {},
+      },
+      assumptions: [],
+      unknowns: ['Component role has not been decided'],
+    };
+
+    const result = compile(vagueIntent);
+    expect(result.warnings.some((w) => w.includes('generic placeholder device'))).toBe(true);
+    const device = result.circuitIR.devices[0];
+    expect(device.metadata).toContainEqual({ key: 'planningState', value: 'placeholder' });
   });
 
   it('preserves traceability IDs from DesignIntent to CircuitIR', () => {

--- a/tests/unit/circuit/component-planning.test.ts
+++ b/tests/unit/circuit/component-planning.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import {
+  determineComponentRole,
+  planComponents,
+  getDeviceRole,
+  ROLE_REFDES_PREFIX,
+  ROLE_PACKAGE_HINT,
+} from '../../../src/circuit/component-planning.js';
+import { BlockType } from '../../../src/circuit/types.js';
+import type { Block } from '../../../src/circuit/circuit-ir.js';
+
+function makeBlock(overrides: Partial<Block> & Pick<Block, 'id' | 'name' | 'type'>): Block {
+  return {
+    description: undefined,
+    designIntentRef: [{ requirementId: `req-${overrides.id}` }],
+    children: [],
+    ...overrides,
+  };
+}
+
+describe('determineComponentRole', () => {
+  it('classifies a power-management block as a power regulator', () => {
+    const plan = determineComponentRole({ type: BlockType.PowerManagement });
+    expect(plan).toEqual({ role: 'power-regulator', confidence: 'high' });
+  });
+
+  it('classifies a microcontroller block as an MCU module', () => {
+    const plan = determineComponentRole({ type: BlockType.Microcontroller });
+    expect(plan).toEqual({ role: 'mcu-module', confidence: 'high' });
+  });
+
+  it('classifies a sensor block', () => {
+    const plan = determineComponentRole({ type: BlockType.Sensor });
+    expect(plan).toEqual({ role: 'sensor', confidence: 'high' });
+  });
+
+  it('classifies a communication block', () => {
+    const plan = determineComponentRole({ type: BlockType.Communication });
+    expect(plan).toEqual({ role: 'communication-ic', confidence: 'high' });
+  });
+
+  it('classifies an analog block', () => {
+    const plan = determineComponentRole({ type: BlockType.Analog });
+    expect(plan).toEqual({ role: 'analog-ic', confidence: 'high' });
+  });
+
+  it('classifies an interface block as a connector', () => {
+    const plan = determineComponentRole({ type: BlockType.Interface });
+    expect(plan).toEqual({ role: 'connector', confidence: 'high' });
+  });
+
+  it('classifies a protection block as a protection diode', () => {
+    const plan = determineComponentRole({ type: BlockType.Protection });
+    expect(plan).toEqual({ role: 'protection-diode', confidence: 'high' });
+  });
+
+  it('falls back to a low-confidence generic role for unclassified types', () => {
+    const plan = determineComponentRole({ type: 'custom' });
+    expect(plan).toEqual({ role: 'generic-ic', confidence: 'low' });
+  });
+
+  it('prioritizes connector keywords over the coarse type field', () => {
+    const plan = determineComponentRole({
+      type: 'custom',
+      description: 'USB-C connector for host interface',
+    });
+    expect(plan.role).toBe('connector');
+    expect(plan.confidence).toBe('high');
+  });
+
+  it('detects a fuse from keywords even on a protection-typed block', () => {
+    const plan = determineComponentRole({
+      type: BlockType.Protection,
+      description: 'Resettable polyfuse on the input rail',
+    });
+    expect(plan.role).toBe('fuse');
+  });
+
+  it('detects a passive filter/decoupling block from keywords', () => {
+    const plan = determineComponentRole({
+      type: BlockType.PowerManagement,
+      description: 'Output ripple filtering and decoupling',
+    });
+    expect(plan).toEqual({ role: 'passive-support', confidence: 'high' });
+  });
+
+  it('is case-insensitive when matching keywords', () => {
+    const plan = determineComponentRole({ type: 'custom', description: 'USB Header' });
+    expect(plan.role).toBe('connector');
+  });
+});
+
+describe('ROLE_REFDES_PREFIX / ROLE_PACKAGE_HINT', () => {
+  it('defines a refdes prefix and package hint for every role', () => {
+    for (const role of Object.keys(ROLE_REFDES_PREFIX) as Array<keyof typeof ROLE_REFDES_PREFIX>) {
+      expect(ROLE_REFDES_PREFIX[role]).toMatch(/^[A-Z]$/);
+      expect(ROLE_PACKAGE_HINT[role]).toBeTruthy();
+    }
+  });
+});
+
+describe('planComponents', () => {
+  it('assigns deterministic, sequential refdes numbers per prefix family', () => {
+    const blocks: Block[] = [
+      makeBlock({ id: 'a', name: 'Regulator A', type: BlockType.PowerManagement }),
+      makeBlock({ id: 'b', name: 'Regulator B', type: BlockType.PowerManagement }),
+      makeBlock({ id: 'c', name: 'Connector', type: BlockType.Interface }),
+    ];
+
+    const { devices } = planComponents(blocks);
+    expect(devices.map((d) => d.ref)).toEqual(['U1', 'U2', 'J1']);
+  });
+
+  it('is stable across repeated compiles of the same blocks', () => {
+    const blocks: Block[] = [
+      makeBlock({ id: 'a', name: 'MCU', type: BlockType.Microcontroller }),
+      makeBlock({ id: 'b', name: 'Sensor', type: BlockType.Sensor }),
+    ];
+
+    const first = planComponents(blocks);
+    const second = planComponents(blocks);
+    expect(first.devices.map((d) => d.ref)).toEqual(second.devices.map((d) => d.ref));
+  });
+
+  it('does not fabricate mpn, manufacturer, or package fields', () => {
+    const blocks: Block[] = [makeBlock({ id: 'a', name: 'MCU', type: BlockType.Microcontroller })];
+    const { devices } = planComponents(blocks);
+    expect(devices[0].mpn).toBeUndefined();
+    expect(devices[0].manufacturer).toBeUndefined();
+    expect(devices[0].package).toBeUndefined();
+  });
+
+  it('marks high-confidence roles as candidate and low-confidence roles as placeholder', () => {
+    const blocks: Block[] = [
+      makeBlock({ id: 'a', name: 'MCU', type: BlockType.Microcontroller }),
+      makeBlock({ id: 'b', name: 'Mystery', type: 'custom' }),
+    ];
+    const { devices, warnings } = planComponents(blocks);
+
+    const mcuDevice = devices.find((d) => d.blockRef === 'a')!;
+    const mysteryDevice = devices.find((d) => d.blockRef === 'b')!;
+    expect(mcuDevice.metadata).toContainEqual({ key: 'planningState', value: 'candidate' });
+    expect(mysteryDevice.metadata).toContainEqual({ key: 'planningState', value: 'placeholder' });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('Mystery');
+  });
+
+  it('records the role and package hint as device metadata', () => {
+    const blocks: Block[] = [
+      makeBlock({ id: 'a', name: 'Regulator', type: BlockType.PowerManagement }),
+    ];
+    const { devices } = planComponents(blocks);
+    const device = devices[0];
+    expect(getDeviceRole(device)).toBe('power-regulator');
+    expect(device.metadata.find((m) => m.key === 'packageHint')?.value).toBe(
+      ROLE_PACKAGE_HINT['power-regulator'],
+    );
+  });
+});
+
+describe('getDeviceRole', () => {
+  it('returns undefined when the device has no role metadata', () => {
+    const device = {
+      id: 'dev-1',
+      ref: 'U1',
+      datasheet: '',
+      designIntentRef: [],
+      metadata: [],
+    } as const;
+    expect(getDeviceRole(device)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Add component planning and synthesis support for CircuitIR compilation. This clean PR carries only the CircuitIR/component-planning slice and leaves stale/unrelated changes behind.