### PR TITLE
fix: initialize logger before bridge connect in live scripts

### DIFF
--- a/scripts/capture-runtime-inventory.mts
+++ b/scripts/capture-runtime-inventory.mts
@@ -2,6 +2,7 @@
 import process from 'node:process';
 import { BridgeManager } from '../src/bridge/manager.js';
 import { loadEnvConfig } from '../src/config/env.js';
+import { createLogger } from '../src/utils/logger.js';
 import {
   captureRuntimeInventorySnapshot,
   parseRuntimeInventoryCaptureConfig,
@@ -17,7 +18,9 @@ if (!config.enabled) {
   process.exit(0);
 }
 
-const bridge = new BridgeManager(loadEnvConfig());
+const envConfig = loadEnvConfig();
+createLogger(envConfig);
+const bridge = new BridgeManager(envConfig);
 const snapshot = await captureRuntimeInventorySnapshot(bridge, config);
 if (!snapshot) {
   throw new Error('Runtime inventory capture unexpectedly returned no snapshot.');

--- a/scripts/live-easyeda-smoke.mts
+++ b/scripts/live-easyeda-smoke.mts
@@ -2,6 +2,7 @@
 import process from 'node:process';
 import { BridgeManager } from '../src/bridge/manager.js';
 import { loadEnvConfig } from '../src/config/env.js';
+import { createLogger } from '../src/utils/logger.js';
 import {
   parseLiveSmokeConfig,
   runLiveSmokeChecks,
@@ -28,6 +29,7 @@ async function main(): Promise<void> {
   }
 
   const envConfig = loadEnvConfig();
+  createLogger(envConfig);
   const bridge = new BridgeManager(envConfig);
   const report = await runLiveSmokeChecks(bridge, smokeConfig);
   await writeLiveSmokeReport(smokeConfig.outputPath, report);


### PR DESCRIPTION
## Summary
- `scripts/capture-runtime-inventory.mts` and `scripts/live-easyeda-smoke.mts` called `BridgeManager.connect()` without calling `createLogger()` first, so both crashed with `Error: Logger not initialized. Call createLogger first.` before ever reaching a live EasyEDA Pro session.
- Fixed by calling `createLogger(envConfig)` before constructing `BridgeManager`, matching the pattern already used in `src/server/factory.ts`.
- Found while running the live runtime inventory + smoke gate for #125 against a real EasyEDA Pro session.

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm test` (804 passed)
- [x] Re-ran `pnpm inventory:capture` and `pnpm smoke:easyeda` against a live EasyEDA Pro session — both now connect and produce reports instead of crashing