### PR TITLE
ci: bump Pages actions to Node 24 native releases

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -20,9 +20,6 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   deploy:
     if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
@@ -56,16 +53,16 @@ jobs:
         run: pnpm docs:build
 
       - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
         with:
           enablement: true
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: docs/.vitepress/dist
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 


### PR DESCRIPTION
## Summary
- The Deploy Docs run for #164's merge commit failed once, then flaked again on retry with GitHub Pages' generic "Deployment failed, try again later." (confirmed via githubstatus.com and repo Pages config that this was transient, not a config issue) — a clean re-run succeeded.
- While investigating, the run also carried a "Node.js 20 is deprecated" annotation for `actions/configure-pages`, `actions/deploy-pages`, and (via `upload-pages-artifact`) `actions/upload-artifact`, all still forced onto Node 24 via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24`.
- Bumped to the current major releases that declare `using: node24` natively: `configure-pages@v6.0.0`, `upload-pages-artifact@v5.0.0`, `deploy-pages@v5.0.0`. Verified their `action.yml` on each tag before pinning. Dropped the now-unnecessary `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` env var.

## Test plan
- [x] Verified `configure-pages@v6.0.0` still supports the `enablement` input used here.
- [x] Verified `deploy-pages@v5.0.0` still exposes the `page_url` output the job's `environment.url` depends on.
- [ ] Confirm the next Deploy Docs run on `main` shows no Node 20 deprecation annotation.