### PR TITLE
test(compat): gate extension runtime paths against inventory baseline

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1579,14 +1579,15 @@ Returns a JSON object matching the schema:
 
 ### Input Parameters
 
-| Parameter      | Type  | Required | Description                                      |
-| -------------- | ----- | -------- | ------------------------------------------------ |
-| `projectId`    | `any` | Yes      | The project/schematic ID                         |
-| `netName`      | `any` | Yes      | The net name to assign (e.g. VCC, GND, TEST_NET) |
-| `x`            | `any` | Yes      | X coordinate on the schematic canvas             |
-| `y`            | `any` | Yes      | Y coordinate on the schematic canvas             |
-| `rotation`     | `any` | No       | Rotation in degrees (0, 90, 180, 270)            |
-| `confirmWrite` | `any` | Yes      |                                                  |
+| Parameter        | Type  | Required | Description                                                                                                                                           |
+| ---------------- | ----- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `projectId`      | `any` | Yes      | The project/schematic ID                                                                                                                              |
+| `netName`        | `any` | Yes      | The net name to assign (e.g. VCC, GND, TEST_NET)                                                                                                      |
+| `x`              | `any` | Yes      | X coordinate on the schematic canvas                                                                                                                  |
+| `y`              | `any` | Yes      | Y coordinate on the schematic canvas                                                                                                                  |
+| `rotation`       | `any` | No       | Rotation in degrees (0, 90, 180, 270)                                                                                                                 |
+| `identification` | `any` | No       | Power-flag identification. When set, places an EasyEDA power/ground flag symbol of this type. When omitted, places a generic named net label instead. |
+| `confirmWrite`   | `any` | Yes      |                                                                                                                                                       |
 
 ### Output Format
 

--- a/easyeda-bridge-extension/src/index.ts
+++ b/easyeda-bridge-extension/src/index.ts
@@ -309,6 +309,37 @@ function readFirstPath<T>(paths: string[]): T | undefined {
   return undefined;
 }
 
+/**
+ * Best-effort extraction of a primitive id from a value returned by an EasyEDA
+ * Pro create* API. The runtime may return a plain object with primitiveId/uuid,
+ * or a primitive wrapper exposing getState_PrimitiveId()/getState().PrimitiveId.
+ */
+function extractPrimitiveId(result: unknown): string {
+  if (!result || typeof result !== 'object') return '';
+  const obj = result as Record<string, unknown>;
+  const direct = obj.primitiveId ?? obj.uuid;
+  if (direct) return String(direct);
+  try {
+    const getter = obj.getState_PrimitiveId;
+    if (typeof getter === 'function') {
+      const id = (getter as () => unknown).call(obj);
+      if (id) return String(id);
+    }
+  } catch {
+    /* ignore */
+  }
+  try {
+    const getState = obj.getState;
+    if (typeof getState === 'function') {
+      const state = (getState as () => unknown).call(obj) as Record<string, unknown> | undefined;
+      if (state?.PrimitiveId) return String(state.PrimitiveId);
+    }
+  } catch {
+    /* ignore */
+  }
+  return '';
+}
+
 function getApiCandidates(): Array<{ name: string; root: unknown }> {
   const candidates: Array<{ name: string; root: unknown }> = [];
   if (typeof eda !== 'undefined' && eda) candidates.push({ name: 'eda', root: eda });
@@ -1420,26 +1451,36 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
       const nfY = params.y as number;
       const nfName = params.netName as string;
       const nfRotation = (params.rotation as number) ?? 0;
-      const nfResult = await callFirst(
-        [
-          'SCH_PrimitiveNetLabel.create',
-          'sch_PrimitiveNetLabel.create',
-          'SCH_NetFlag.create',
-          'sch_NetFlag.create',
-        ],
-        nfX,
-        nfY,
-        nfName,
-        nfRotation,
-      );
-      const nfPrimitiveId =
-        typeof nfResult === 'object' && nfResult !== null
-          ? String(
-              (nfResult as Record<string, unknown>).primitiveId ??
-                (nfResult as Record<string, unknown>).uuid ??
-                '',
-            )
-          : '';
+      // EasyEDA Pro exposes two distinct primitives here (verified against the
+      // live runtime inventory):
+      //   - SCH_PrimitiveComponent.createNetFlag(identification, net, x, y, rotation, mirror)
+      //     is the power-symbol flag and only accepts the four power
+      //     identifications (Power / Ground / AnalogGround / ProtectGround).
+      //   - SCH_PrimitiveAttribute.createNetLabel(x, y, net) is the generic
+      //     named net label that works for any net name.
+      // Prefer the power flag when a valid identification is supplied,
+      // otherwise fall back to a generic net label.
+      const POWER_IDS = ['Power', 'Ground', 'AnalogGround', 'ProtectGround'];
+      const nfIdentification = params.identification as string | undefined;
+      let nfResult: unknown;
+      if (nfIdentification && POWER_IDS.includes(nfIdentification)) {
+        nfResult = await callFirst(
+          ['SCH_PrimitiveComponent.createNetFlag', 'sch_PrimitiveComponent.createNetFlag'],
+          nfIdentification,
+          nfName,
+          nfX,
+          nfY,
+          nfRotation,
+        );
+      } else {
+        nfResult = await callFirst(
+          ['SCH_PrimitiveAttribute.createNetLabel', 'sch_PrimitiveAttribute.createNetLabel'],
+          nfX,
+          nfY,
+          nfName,
+        );
+      }
+      const nfPrimitiveId = extractPrimitiveId(nfResult);
       return {
         primitiveId: nfPrimitiveId || `netflag_${Date.now()}`,
         netName: nfName,
@@ -1449,29 +1490,26 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
       const npX = params.x as number;
       const npY = params.y as number;
       const npName = params.netName as string;
-      const npType = (params.portType as string) ?? 'passive';
       const npRotation = (params.rotation as number) ?? 0;
+      // SCH_PrimitiveComponent.createNetPort(direction, net, x, y, rotation, mirror)
+      // where direction is one of IN / OUT / BI. Map the MCP portType onto it.
+      const portTypeMap: Record<string, 'IN' | 'OUT' | 'BI'> = {
+        input: 'IN',
+        output: 'OUT',
+        bidirectional: 'BI',
+        triState: 'BI',
+        passive: 'BI',
+      };
+      const npDirection = portTypeMap[(params.portType as string) ?? 'passive'] ?? 'BI';
       const npResult = await callFirst(
-        [
-          'SCH_PrimitiveNetPort.create',
-          'sch_PrimitiveNetPort.create',
-          'SCH_NetPort.create',
-          'sch_NetPort.create',
-        ],
+        ['SCH_PrimitiveComponent.createNetPort', 'sch_PrimitiveComponent.createNetPort'],
+        npDirection,
+        npName,
         npX,
         npY,
-        npName,
-        npType,
         npRotation,
       );
-      const npPrimitiveId =
-        typeof npResult === 'object' && npResult !== null
-          ? String(
-              (npResult as Record<string, unknown>).primitiveId ??
-                (npResult as Record<string, unknown>).uuid ??
-                '',
-            )
-          : '';
+      const npPrimitiveId = extractPrimitiveId(npResult);
       return {
         primitiveId: npPrimitiveId || `netport_${Date.now()}`,
         netName: npName,

--- a/src/tools/L1_schematic_write.ts
+++ b/src/tools/L1_schematic_write.ts
@@ -237,6 +237,13 @@ function registerSchematicWriteTools(
       x: z.number().describe('X coordinate on the schematic canvas'),
       y: z.number().describe('Y coordinate on the schematic canvas'),
       rotation: z.number().optional().describe('Rotation in degrees (0, 90, 180, 270)'),
+      identification: z
+        .enum(['Power', 'Ground', 'AnalogGround', 'ProtectGround'])
+        .optional()
+        .describe(
+          'Power-flag identification. When set, places an EasyEDA power/ground flag symbol of this type. ' +
+            'When omitted, places a generic named net label instead.',
+        ),
       confirmWrite: z.literal(true),
     }),
     outputSchema: z.object({
@@ -256,6 +263,7 @@ function registerSchematicWriteTools(
         x: number;
         y: number;
         rotation?: number;
+        identification?: string;
       };
       try {
         const result = await ctx.bridge.call('schematic.createNetFlag', {
@@ -264,6 +272,7 @@ function registerSchematicWriteTools(
           x: p.x,
           y: p.y,
           rotation: p.rotation,
+          identification: p.identification,
         });
         const data = result as { primitiveId?: string; netName?: string };
         return {

--- a/tests/fixtures/runtime-inventory/easyeda-3.2.149-baseline.json
+++ b/tests/fixtures/runtime-inventory/easyeda-3.2.149-baseline.json
@@ -1,0 +1,689 @@
+{
+  "note": "Runtime API surface captured live from EasyEDA Pro (schematic+PCB context). Ground truth for the extension method-path compatibility test. Refresh via: EASYEDA_RUNTIME_INVENTORY_CAPTURE=true pnpm inventory:capture, then copy the JSON here.",
+  "easyedaShellVersion": "3.2.149.88089769",
+  "bridgeVersion": "0.19.0",
+  "methodRegistryHash": "b9f712215583b4b5",
+  "total": 67,
+  "classes": [
+    {
+      "className": "DMT_Board",
+      "methods": [
+        "copyBoard",
+        "createBoard",
+        "deleteBoard",
+        "getAllBoardsInfo",
+        "getBoardInfo",
+        "getCurrentBoardInfo",
+        "modifyBoardName"
+      ]
+    },
+    {
+      "className": "DMT_EditorControl",
+      "methods": [
+        "activateDocument",
+        "activateSplitScreen",
+        "closeDocument",
+        "createSplitScreen",
+        "generateIndicatorMarkers",
+        "getCurrentRenderedAreaImage",
+        "getSplitScreenIdByTabId",
+        "getSplitScreenTree",
+        "getTabsBySplitScreenId",
+        "mergeAllDocumentFromSplitScreen",
+        "moveDocumentToSplitScreen",
+        "openDocument",
+        "openLibraryDocument",
+        "removeIndicatorMarkers",
+        "tileAllDocumentToSplitScreen",
+        "zoomTo",
+        "zoomToAllPrimitives",
+        "zoomToRegion",
+        "zoomToSelectedPrimitives"
+      ]
+    },
+    {
+      "className": "DMT_Event",
+      "methods": ["addEditorTabEventListener", "isEventListenerAlreadyExist", "removeEventListener"]
+    },
+    {
+      "className": "DMT_Folder",
+      "methods": [
+        "createFolder",
+        "deleteFolder",
+        "getAllFoldersUuid",
+        "getFolderInfo",
+        "modifyFolderDescription",
+        "modifyFolderName",
+        "moveFolderToFolder"
+      ]
+    },
+    {
+      "className": "DMT_Panel",
+      "methods": [
+        "copyPanel",
+        "createPanel",
+        "deletePanel",
+        "getAllPanelsInfo",
+        "getCurrentPanelInfo",
+        "getPanelInfo",
+        "modifyPanelName"
+      ]
+    },
+    {
+      "className": "DMT_Pcb",
+      "methods": [
+        "copyPcb",
+        "createPcb",
+        "deletePcb",
+        "getAllPcbsInfo",
+        "getCurrentPcbInfo",
+        "getPcbInfo",
+        "modifyPcbName"
+      ]
+    },
+    {
+      "className": "DMT_Project",
+      "methods": [
+        "copyProject",
+        "createProject",
+        "deleteProject",
+        "getAllProjectsUuid",
+        "getCurrentProjectInfo",
+        "getProjectInfo",
+        "modifyProjectCollaborationMode",
+        "modifyProjectDescription",
+        "modifyProjectFriendlyName",
+        "moveProject",
+        "moveProjectToFolder",
+        "openProject"
+      ]
+    },
+    {
+      "className": "DMT_Schematic",
+      "methods": [
+        "copySchematic",
+        "copySchematicPage",
+        "createSchematic",
+        "createSchematicPage",
+        "deleteSchematic",
+        "deleteSchematicPage",
+        "getAllSchematicPagesInfo",
+        "getAllSchematicsInfo",
+        "getCurrentSchematicAllSchematicPagesInfo",
+        "getCurrentSchematicInfo",
+        "getCurrentSchematicPageInfo",
+        "getSchematicInfo",
+        "getSchematicPageInfo",
+        "modifySchematicName",
+        "modifySchematicPageName",
+        "modifySchematicPageTitleBlock",
+        "reorderSchematicPages"
+      ]
+    },
+    {
+      "className": "DMT_SelectControl",
+      "methods": ["getCurrentDocumentInfo"]
+    },
+    {
+      "className": "DMT_Team",
+      "methods": ["getAllInvolvedTeamInfo", "getAllTeamsInfo", "getCurrentTeamInfo"]
+    },
+    {
+      "className": "DMT_Workspace",
+      "methods": ["getAllWorkspacesInfo", "getCurrentWorkspaceInfo", "toggleToWorkspace"]
+    },
+    {
+      "className": "LIB_3DModel",
+      "methods": ["copy", "create", "delete", "get", "modify", "search"]
+    },
+    {
+      "className": "LIB_Cbb",
+      "methods": [
+        "copy",
+        "create",
+        "delete",
+        "get",
+        "modify",
+        "openProjectInEditor",
+        "openSymbolInEditor",
+        "search"
+      ]
+    },
+    {
+      "className": "LIB_Classification",
+      "methods": [
+        "createPrimary",
+        "createSecondary",
+        "deleteByIndex",
+        "deleteByUuid",
+        "getAllClassificationTree",
+        "getIndexByName",
+        "getNameByIndex",
+        "getNameByUuid"
+      ]
+    },
+    {
+      "className": "LIB_Device",
+      "methods": [
+        "copy",
+        "create",
+        "delete",
+        "get",
+        "getByLcscIds",
+        "modify",
+        "search",
+        "searchByProperties"
+      ]
+    },
+    {
+      "className": "LIB_Footprint",
+      "methods": [
+        "copy",
+        "create",
+        "delete",
+        "get",
+        "getRenderImage",
+        "modify",
+        "openInEditor",
+        "search",
+        "searchByProperties",
+        "updateDocumentSource"
+      ]
+    },
+    {
+      "className": "LIB_LibrariesList",
+      "methods": [
+        "getAllLibrariesList",
+        "getFavoriteLibraryUuid",
+        "getPersonalLibraryUuid",
+        "getProjectLibraryUuid",
+        "getSystemLibraryUuid",
+        "registerExtendLibrary"
+      ]
+    },
+    {
+      "className": "LIB_PanelLibrary",
+      "methods": ["copy", "create", "delete", "get", "modify", "openInEditor", "search"]
+    },
+    {
+      "className": "LIB_SelectControl",
+      "methods": ["getSelectedLibraryRowInfo"]
+    },
+    {
+      "className": "LIB_Symbol",
+      "methods": [
+        "copy",
+        "create",
+        "delete",
+        "get",
+        "getRenderImage",
+        "modify",
+        "openInEditor",
+        "search",
+        "searchByProperties",
+        "updateDocumentSource"
+      ]
+    },
+    {
+      "className": "PCB_COMPARISON_MSG_BUS_",
+      "methods": [
+        "publish",
+        "pull",
+        "pullA",
+        "push",
+        "rpcCall",
+        "rpcReply",
+        "rpcService",
+        "subscribe",
+        "uniqueRpcTopic"
+      ]
+    },
+    {
+      "className": "PCB_Document",
+      "methods": [
+        "clearRouting",
+        "convertCanvasOriginToDataOrigin",
+        "convertDataOriginToCanvasOrigin",
+        "getCalculatingRatlineStatus",
+        "getCanvasOrigin",
+        "getCurrentFilterConfiguration",
+        "getPrimitiveAtPoint",
+        "getPrimitivesInRegion",
+        "importAutoLayoutJsonFile",
+        "importAutoRouteJsonFile",
+        "importAutoRouteSesFile",
+        "importChanges",
+        "navigateToCoordinates",
+        "navigateToRegion",
+        "save",
+        "setCanvasOrigin",
+        "startCalculatingRatline",
+        "stopCalculatingRatline",
+        "zoomToBoardOutline"
+      ]
+    },
+    {
+      "className": "PCB_Drc",
+      "methods": [
+        "addNetToEqualLengthNetGroup",
+        "addNetToNetClass",
+        "addPadPairToPadPairGroup",
+        "check",
+        "createDifferentialPair",
+        "createEqualLengthNetGroup",
+        "createNetClass",
+        "createPadPairGroup",
+        "deleteDifferentialPair",
+        "deleteEqualLengthNetGroup",
+        "deleteNetClass",
+        "deletePadPairGroup",
+        "deleteRuleConfiguration",
+        "getAllDifferentialPairs",
+        "getAllEqualLengthNetGroups",
+        "getAllNetClasses",
+        "getAllPadPairGroups",
+        "getAllRuleConfigurations",
+        "getCurrentRuleConfiguration",
+        "getCurrentRuleConfigurationName",
+        "getDefaultRuleConfigurationName",
+        "getNetByNetRules",
+        "getNetRules",
+        "getPadPairGroupMinWireLength",
+        "getRealTimeDrcStatus",
+        "getRegionRules",
+        "getRuleConfiguration",
+        "modifyDifferentialPairName",
+        "modifyDifferentialPairNegativeNet",
+        "modifyDifferentialPairPositiveNet",
+        "modifyEqualLengthNetGroupName",
+        "modifyNetClassName",
+        "modifyPadPairGroupName",
+        "overwriteCurrentRuleConfiguration",
+        "overwriteNetByNetRules",
+        "overwriteNetRules",
+        "overwriteRegionRules",
+        "removeNetFromEqualLengthNetGroup",
+        "removeNetFromNetClass",
+        "removePadPairFromPadPairGroup",
+        "renameRuleConfiguration",
+        "saveRuleConfiguration",
+        "setAsDefaultRuleConfiguration",
+        "startRealTimeDrc",
+        "stopRealTimeDrc"
+      ]
+    },
+    {
+      "className": "PCB_Event",
+      "methods": [
+        "addCrossProbeSelectEventListener",
+        "addMouseEventListener",
+        "addNetEventListener",
+        "addPrimitiveEventListener",
+        "addRealTimeDrcResultEventListener",
+        "isEventListenerAlreadyExist",
+        "removeEventListener"
+      ]
+    },
+    {
+      "className": "PCB_Layer",
+      "methods": [
+        "addCustomLayer",
+        "deletePhysicalStackingConfiguration",
+        "getAllLayers",
+        "getAllPhysicalStackingConfigurations",
+        "getCurrentLayer",
+        "getCurrentPhysicalStackingConfiguration",
+        "getCurrentPhysicalStackingConfigurationName",
+        "getDefaultPhysicalStackingConfigurationName",
+        "getPhysicalStackingConfiguration",
+        "getTheNumberOfCopperLayers",
+        "lockLayer",
+        "modifyLayer",
+        "overwriteCurrentPhysicalStackingConfiguration",
+        "removeLayer",
+        "renamePhysicalStackingConfiguration",
+        "savePhysicalStackingConfiguration",
+        "selectLayer",
+        "setAsDefaultPhysicalStackingConfiguration",
+        "setInactiveLayerDisplayMode",
+        "setInactiveLayerTransparency",
+        "setLayerColorConfiguration",
+        "setLayerInvisible",
+        "setLayerVisible",
+        "setPcbType",
+        "setTheNumberOfCopperLayers",
+        "unlockLayer"
+      ]
+    },
+    {
+      "className": "PCB_ManufactureData",
+      "methods": [
+        "deleteBomTemplate",
+        "get3DFile",
+        "get3DShellFile",
+        "getAltiumDesignerFile",
+        "getAutoLayoutJsonFile",
+        "getAutoRouteJsonFile",
+        "getAutoRouteJsonFileForJRouter",
+        "getBomFile",
+        "getBomTemplateFile",
+        "getBomTemplates",
+        "getDsnFile",
+        "getDxfFile",
+        "getFlyingProbeTestFile",
+        "getGerberFile",
+        "getIdxFile",
+        "getInteractiveBomFile",
+        "getIpc2581CFile",
+        "getIpcD356AFile",
+        "getManufactureData",
+        "getNetlistFile",
+        "getOpenDatabaseDoublePlusFile",
+        "getPadsFile",
+        "getPcbInfoFile",
+        "getPdfFile",
+        "getPickAndPlaceFile",
+        "getTestPointFile",
+        "place3DShellOrder",
+        "placeComponentsOrder",
+        "placePcbOrder",
+        "placeSmtComponentsOrder",
+        "uploadBomTemplateFile"
+      ]
+    },
+    {
+      "className": "PCB_MathPolygon",
+      "methods": [
+        "calculateBBoxHeight",
+        "calculateBBoxWidth",
+        "calculateHeight",
+        "calculateWidth",
+        "convertImageToComplexPolygon",
+        "createComplexPolygon",
+        "createPolygon",
+        "discretize",
+        "splitPolygon"
+      ]
+    },
+    {
+      "className": "PCB_Net",
+      "methods": [
+        "getAllNetName",
+        "getAllNets",
+        "getAllNetsName",
+        "getAllPrimitivesByNet",
+        "getNet",
+        "getNetColor",
+        "getNetLength",
+        "getNetlist",
+        "highlightNet",
+        "selectNet",
+        "setNetColor",
+        "setNetlist",
+        "unhighlightAllNets",
+        "unhighlightNet",
+        "unselectAllNets",
+        "unselectNet"
+      ]
+    },
+    {
+      "className": "PCB_Primitive",
+      "methods": [
+        "getPrimitiveBoardLine",
+        "getPrimitiveByPrimitiveId",
+        "getPrimitiveTypeByPrimitiveId",
+        "getPrimitivesBBox",
+        "getPrimitivesByPrimitiveId"
+      ]
+    },
+    {
+      "className": "PCB_PrimitiveArc",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_PrimitiveAttribute",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_PrimitiveComponent",
+      "methods": [
+        "create",
+        "delete",
+        "get",
+        "getAll",
+        "getAllPinsByPrimitiveId",
+        "getAllPrimitiveId",
+        "getAllPropertyNames",
+        "modify",
+        "placeComponentWithMouse",
+        "placeFootprintWithMouse"
+      ]
+    },
+    {
+      "className": "PCB_PrimitiveDimension",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_PrimitiveFill",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_PrimitiveImage",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_PrimitiveLine",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_PrimitiveObject",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_PrimitivePad",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_PrimitivePolyline",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_PrimitivePour",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_PrimitivePoured",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_PrimitiveRegion",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_PrimitiveString",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_PrimitiveVia",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "PCB_RayTracerEngine",
+      "methods": ["dispose", "init", "setRenderConfigurations"]
+    },
+    {
+      "className": "PCB_SelectControl",
+      "methods": [
+        "clearSelected",
+        "doCrossProbeSelect",
+        "doCrossProbeSelectByObject",
+        "doSelectPrimitives",
+        "getAllSelectedPrimitives",
+        "getAllSelectedPrimitives_PrimitiveId",
+        "getCurrentMousePosition",
+        "getSelectedPrimitives"
+      ]
+    },
+    {
+      "className": "SCH_Document",
+      "methods": [
+        "autoLayout",
+        "autoRouting",
+        "getCurrentFilterConfiguration",
+        "getPrimitiveAtPoint",
+        "getPrimitivesInRegion",
+        "importChanges",
+        "navigateToCoordinates",
+        "navigateToRegion",
+        "save"
+      ]
+    },
+    {
+      "className": "SCH_Drc",
+      "methods": ["check"]
+    },
+    {
+      "className": "SCH_Event",
+      "methods": [
+        "addMouseEventListener",
+        "addPrimitiveEventListener",
+        "addSimulationEnginePullEventListener",
+        "isEventListenerAlreadyExist",
+        "removeEventListener"
+      ]
+    },
+    {
+      "className": "SCH_ManufactureData",
+      "methods": [
+        "deleteBomTemplate",
+        "getAssemblyVariantsConfigs",
+        "getBomFile",
+        "getBomTemplateFile",
+        "getBomTemplates",
+        "getExportDocumentFile",
+        "getNetlistFile",
+        "getSimulationNetlistFile",
+        "placeComponentsOrder",
+        "placeSmtComponentsOrder",
+        "uploadBomTemplateFile"
+      ]
+    },
+    {
+      "className": "SCH_Net",
+      "methods": ["getAllNets", "getAllNetsName", "getCurrentProjectAllNets", "getNet"]
+    },
+    {
+      "className": "SCH_Netlist",
+      "methods": ["getNetlist", "setNetlist"]
+    },
+    {
+      "className": "SCH_Primitive",
+      "methods": [
+        "getPrimitiveByPrimitiveId",
+        "getPrimitiveTypeByPrimitiveId",
+        "getPrimitivesBBox",
+        "getPrimitivesByPrimitiveId"
+      ]
+    },
+    {
+      "className": "SCH_PrimitiveArc",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "SCH_PrimitiveAttribute",
+      "methods": [
+        "create",
+        "createNetLabel",
+        "delete",
+        "get",
+        "getAll",
+        "getAllPrimitiveId",
+        "modify"
+      ]
+    },
+    {
+      "className": "SCH_PrimitiveBus",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "SCH_PrimitiveCircle",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "SCH_PrimitiveComponent",
+      "methods": [
+        "checkComponentType",
+        "create",
+        "createCbbSymbol",
+        "createNetFlag",
+        "createNetPort",
+        "createShortCircuitFlag",
+        "delete",
+        "get",
+        "getAll",
+        "getAllPinsByPrimitiveId",
+        "getAllPrimitiveId",
+        "getAllPropertyNames",
+        "getComponentDetail",
+        "initUuid",
+        "modify",
+        "placeCbbSchematicPage",
+        "placeComponentWithMouse",
+        "placeSymbolWithMouse",
+        "setNetFlagComponentUuid_AnalogGround",
+        "setNetFlagComponentUuid_Ground",
+        "setNetFlagComponentUuid_Power",
+        "setNetFlagComponentUuid_ProtectGround",
+        "setNetPortComponentUuid_BI",
+        "setNetPortComponentUuid_IN",
+        "setNetPortComponentUuid_OUT"
+      ]
+    },
+    {
+      "className": "SCH_PrimitiveObject",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "SCH_PrimitivePin",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "SCH_PrimitivePolygon",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "SCH_PrimitiveRectangle",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "SCH_PrimitiveText",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "SCH_PrimitiveWire",
+      "methods": ["create", "delete", "get", "getAll", "getAllPrimitiveId", "modify"]
+    },
+    {
+      "className": "SCH_SelectControl",
+      "methods": [
+        "clearSelected",
+        "doCrossProbeSelect",
+        "doSelectPrimitives",
+        "getAllSelectedPrimitives",
+        "getAllSelectedPrimitives3",
+        "getAllSelectedPrimitives_PrimitiveId",
+        "getCurrentMousePosition",
+        "getSelectedPrimitives",
+        "getSelectedPrimitives_PrimitiveId"
+      ]
+    },
+    {
+      "className": "SCH_SimulationEngine",
+      "methods": ["pushData"]
+    },
+    {
+      "className": "SCH_Utils",
+      "methods": ["splitLines"]
+    }
+  ]
+}

--- a/tests/unit/easyeda-runtime/extension-method-compat.test.ts
+++ b/tests/unit/easyeda-runtime/extension-method-compat.test.ts
@@ -1,0 +1,160 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Offline compatibility gate (#170).
+ *
+ * The bridge extension calls EasyEDA Pro runtime methods through
+ * `callFirst([...])` / `readFirstPath([...])` fallback lists of `Class.method`
+ * paths. If every path in a list is wrong for the installed EasyEDA Pro
+ * version, the corresponding tool fails live with METHOD_NOT_FOUND — exactly
+ * how the net-flag (#169) and ERC (#163) gaps were discovered.
+ *
+ * This test extracts every such fallback group from the extension source and
+ * asserts that at least one path in each group resolves against a committed
+ * runtime inventory baseline. Groups where no path resolves must be listed in
+ * KNOWN_UNSUPPORTED with a reason, so a *new* all-dead group fails CI while
+ * known gaps stay tracked and visible.
+ */
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../../..');
+
+const EXTENSION_SRC = resolve(repoRoot, 'easyeda-bridge-extension/src/index.ts');
+const BASELINE = resolve(
+  repoRoot,
+  'tests/fixtures/runtime-inventory/easyeda-3.2.149-baseline.json',
+);
+
+// Runtime class-name prefixes the baseline snapshot covers. Paths whose class
+// uses a different prefix (e.g. sys_/pnl_ helpers, or bare non-prefixed paths)
+// are outside the captured inventory scope and are not checked here.
+const COVERED_PREFIXES = ['DMT_', 'SCH_', 'PCB_', 'LIB_'];
+
+/**
+ * Fallback groups where no covered path resolves against the current baseline.
+ * Each entry is the sorted `Class.method` list joined by ' | '. Keep a reason
+ * and, for real runtime gaps, a tracking issue. Refreshing the baseline may let
+ * an entry resolve again — the test flags stale entries so they get removed.
+ */
+const KNOWN_UNSUPPORTED: Record<string, string> = {
+  'SCH_Netlist.connectPin | SCH_Netlist.create | sch_Netlist.create':
+    'Intentional fallback. Primary path in connectPinToNetImpl is the SCH_PrimitiveComponent.getAll loop, which resolves.',
+  'design.erc | dmt_ERC.run':
+    'DMT_ERC absent in 3.2.149; schematic ERC is exposed as SCH_Drc.check. Tracked in #163.',
+  'design.drc | dmt_DRC.run':
+    'DMT_DRC absent in 3.2.149; DRC is exposed as PCB_Drc.check / SCH_Drc.check. Tracked in #178.',
+  'design.ruleCheck | dmt_DRC.runRuleCheck':
+    'DMT_DRC absent in 3.2.149; rule check is exposed as PCB_Drc.check / SCH_Drc.check. Tracked in #178.',
+  'dmt_Project.export | project.export':
+    'DMT_Project has no export() in 3.2.149; project export uses a different API. Tracked in #178.',
+  'board.exportGerbers | dmt_PCB.exportGerbers':
+    'DMT_PCB absent in 3.2.149; PCB fab output uses PCB_ManufactureData. Tracked in #178.',
+  'board.exportPickPlace | dmt_PCB.exportPickAndPlace | dmt_Project.exportPickPlace':
+    'DMT_PCB/DMT_Project pick-place export methods absent in 3.2.149; use PCB_ManufactureData. Tracked in #178.',
+  'dmt_PCB.exportPdf | dmt_Schematic.exportPdf | sch_Document.exportPdf':
+    'No exportPdf on these classes in 3.2.149. Tracked in #178.',
+  'dmt_Project.exportNetlist | sch_Document.exportNetlist':
+    'No exportNetlist on these classes in 3.2.149; netlist is exposed via SCH_Netlist.getNetlist / SCH_ManufactureData.getNetlistFile. Tracked in #178.',
+  'PCB_PrimitiveTrack.create | pcb_PrimitiveTrack.create':
+    'PCB_PrimitiveTrack does not exist in 3.2.149; tracks are PCB_PrimitiveLine / PCB_PrimitivePolyline. Tracked in #178.',
+};
+
+interface BaselineInventory {
+  classes: Array<{ className: string; methods: string[] }>;
+}
+
+function loadBaseline(): Map<string, Set<string>> {
+  const data = JSON.parse(readFileSync(BASELINE, 'utf8')) as BaselineInventory;
+  return new Map(data.classes.map((c) => [c.className, new Set(c.methods)]));
+}
+
+/** Normalize `sch_PrimitiveWire.create` -> { className: 'SCH_PrimitiveWire', method: 'create' }. */
+function normalizePath(path: string): { className: string; method: string } {
+  const [cls, ...rest] = path.split('.');
+  const match = cls.match(/^([a-z]+)_(.+)$/);
+  const className = match ? `${match[1].toUpperCase()}_${match[2]}` : cls;
+  return { className, method: rest.join('.') };
+}
+
+function isCovered(className: string): boolean {
+  return COVERED_PREFIXES.some((prefix) => className.startsWith(prefix));
+}
+
+/** Extract the string-literal path arrays passed to callFirst/readFirstPath. */
+function extractFallbackGroups(source: string): string[][] {
+  const groups: string[][] = [];
+  const re = /(?:callFirst|readFirstPath)\(\s*\[([^\]]*)\]/gs;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(source)) !== null) {
+    const paths = [...match[1].matchAll(/['"]([^'"]+)['"]/g)]
+      .map((m) => m[1])
+      .filter((p) => p.includes('.'));
+    if (paths.length > 0) groups.push(paths);
+  }
+  return groups;
+}
+
+function groupKey(paths: string[]): string {
+  return [...new Set(paths)].sort().join(' | ');
+}
+
+describe('extension runtime method-path compatibility', () => {
+  const baseline = loadBaseline();
+  const source = readFileSync(EXTENSION_SRC, 'utf8');
+  const groups = extractFallbackGroups(source);
+
+  const resolvesInBaseline = (path: string): boolean => {
+    const { className, method } = normalizePath(path);
+    return baseline.get(className)?.has(method) ?? false;
+  };
+
+  it('extracts a non-trivial set of fallback groups', () => {
+    // Guard against the regex silently matching nothing (e.g. after a refactor).
+    expect(groups.length).toBeGreaterThan(10);
+  });
+
+  it('every fallback group has a resolvable path or is a tracked known gap', () => {
+    const unexpectedDeadGroups: Array<{ key: string; paths: string[] }> = [];
+
+    for (const paths of groups) {
+      const checkable = paths.filter((p) => isCovered(normalizePath(p).className));
+      // No covered path in the group -> outside baseline scope, cannot assert.
+      if (checkable.length === 0) continue;
+
+      const anyResolves = checkable.some(resolvesInBaseline);
+      if (anyResolves) continue;
+
+      const key = groupKey(paths);
+      if (!(key in KNOWN_UNSUPPORTED)) {
+        unexpectedDeadGroups.push({ key, paths });
+      }
+    }
+
+    expect(
+      unexpectedDeadGroups,
+      `These extension fallback groups reference no runtime method present in the baseline. ` +
+        `Fix the runtime paths, or add the group to KNOWN_UNSUPPORTED with a tracking issue:\n` +
+        unexpectedDeadGroups.map((g) => `  - ${g.key}`).join('\n'),
+    ).toEqual([]);
+  });
+
+  it('has no stale KNOWN_UNSUPPORTED entries', () => {
+    const deadKeys = new Set<string>();
+    for (const paths of groups) {
+      const checkable = paths.filter((p) => isCovered(normalizePath(p).className));
+      if (checkable.length === 0) continue;
+      if (!checkable.some(resolvesInBaseline)) deadKeys.add(groupKey(paths));
+    }
+
+    const stale = Object.keys(KNOWN_UNSUPPORTED).filter((key) => !deadKeys.has(key));
+    expect(
+      stale,
+      `These KNOWN_UNSUPPORTED entries no longer match an all-dead group ` +
+        `(the path was fixed or the baseline now covers it) — remove them:\n` +
+        stale.map((k) => `  - ${k}`).join('\n'),
+    ).toEqual([]);
+  });
+});

--- a/tests/unit/tools/schematic.test.ts
+++ b/tests/unit/tools/schematic.test.ts
@@ -210,6 +210,7 @@ describe('Schematic Tools', () => {
       x: 100,
       y: 200,
       rotation: 0,
+      identification: undefined,
     });
     expect(result).toEqual({
       success: true,
@@ -217,6 +218,35 @@ describe('Schematic Tools', () => {
         primitiveId: 'netflag-1',
         netName: 'TEST_NET',
       },
+    });
+  });
+
+  it('easyeda_schematic_create_net_flag should forward power-flag identification', async () => {
+    const tool = registry.get('easyeda_schematic_create_net_flag');
+    expect(tool).toBeDefined();
+
+    bridgeCall.mockResolvedValue({ primitiveId: 'netflag-2', netName: 'VCC' });
+
+    const result = await tool?.handler(context, {
+      projectId: 'proj-123',
+      netName: 'VCC',
+      x: 0,
+      y: 0,
+      identification: 'Power',
+      confirmWrite: true,
+    });
+
+    expect(bridgeCall).toHaveBeenCalledWith('schematic.createNetFlag', {
+      projectId: 'proj-123',
+      netName: 'VCC',
+      x: 0,
+      y: 0,
+      rotation: undefined,
+      identification: 'Power',
+    });
+    expect(result).toEqual({
+      success: true,
+      netFlag: { primitiveId: 'netflag-2', netName: 'VCC' },
     });
   });
 


### PR DESCRIPTION
Closes #170. **Stacked on #177** (net-flag fix) — merge after #177; until then the diff shows the net-flag commit too, and it collapses to just the compat test once #177 lands.

## Summary
Adds an offline test (`tests/unit/easyeda-runtime/extension-method-compat.test.ts`) that:
- Extracts every `callFirst([...])` / `readFirstPath([...])` fallback group from the bridge extension source.
- Asserts that at least one path in each group resolves against a committed runtime inventory baseline (`tests/fixtures/runtime-inventory/easyeda-3.2.149-baseline.json`, captured live from EasyEDA Pro shell `3.2.149.88089769`).
- Requires any all-dead group (no path resolves) to be listed in `KNOWN_UNSUPPORTED` with a reason + tracking issue — so a **new** all-dead group fails CI, while known gaps stay visible.
- A companion check flags **stale** allow-list entries once a path is fixed or the baseline covers it (keeps the list honest).

Runs under `pnpm test` — no live EasyEDA session needed.

## What it surfaced
Beyond the net-flag (#169) and ERC (#163) gaps this would have caught, the scan found **eight more** wrong runtime paths — DRC (`dmt_DRC.*`), project/gerber/pick-place/pdf/netlist exports (`dmt_*` classes absent), and PCB track creation (`PCB_PrimitiveTrack` → should be `PCB_PrimitiveLine`/`Polyline`). These are allow-listed and tracked in **#178**.

## Test plan
- [x] `pnpm test` (808 passing, incl. the 3 new gate assertions)
- [x] `pnpm format:check` / `pnpm lint`
- [x] Verified the gate **fails** when a new all-dead group is introduced, and goes green when reverted.