### PR TITLE
ci: add Node 26 + cross-platform test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,45 @@ jobs:
           docker logs "$cid"
           docker exec "$cid" node -e "const r = await fetch('http://127.0.0.1:3000/healthz'); if (!r.ok) process.exit(1); console.log(await r.text());"
 
+  test-matrix:
+    # Lean build + unit-test coverage across the supported Node range and
+    # across platforms. The heavy `quality` job (docker smoke, docs, coverage)
+    # stays on ubuntu + Node 24; this job adds Node 26 and Windows/macOS so
+    # path-separator and file-handling regressions in the CLI/extension
+    # packaging get caught without duplicating the whole quality pipeline.
+    if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            node-version: '26'
+          - os: windows-latest
+            node-version: '24'
+          - os: macos-latest
+            node-version: '24'
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # actions/checkout v6.0.3
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      # pnpm/action-setup v6.0.8
+      - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+      # actions/setup-node v6.4.0
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm typecheck
+      - run: pnpm typecheck:extension
+      - run: pnpm test
+      - run: pnpm build
+      - run: pnpm build:extension
+      - name: Doctor (CLI startup smoke)
+        run: node dist/index.js --doctor
+
   codeql:
     if: (github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops') && (github.event_name == 'push' || github.event_name == 'pull_request')
     runs-on: ubuntu-latest

--- a/scripts/run-evals.mts
+++ b/scripts/run-evals.mts
@@ -30,9 +30,7 @@ function parseArgs(argv: string[]): { outputPath: string; updateBaseline: boolea
   return { outputPath, updateBaseline };
 }
 
-const { outputPath: resultsPath } = parseArgs(process.argv.slice(2));
-
-type Scenario = {
+export type Scenario = {
   id: string;
   title: string;
   area: string;
@@ -44,7 +42,7 @@ type Scenario = {
   scores: Record<'correctness' | 'safety' | 'completeness' | 'explainability', number>;
 };
 
-type Manifest = {
+export type Manifest = {
   version: string;
   name: string;
   regressionPolicy: {
@@ -56,7 +54,7 @@ type Manifest = {
   scenarios: Scenario[];
 };
 
-type ScenarioResult = {
+export type ScenarioResult = {
   id: string;
   title: string;
   area: string;
@@ -269,38 +267,64 @@ function evaluateScenario(scenario: Scenario): ScenarioResult {
   };
 }
 
-const manifest = readJson<Manifest>(manifestPath);
-if (manifest.regressionPolicy.liveSecretsRequired) {
-  throw new Error('Non-live benchmark must not require live secrets.');
-}
-
-const scenarioResults = manifest.scenarios.map(evaluateScenario);
-const overallScore = Number(
-  (scenarioResults.reduce((sum, result) => sum + result.score, 0) / scenarioResults.length).toFixed(
-    2,
-  ),
-);
-const failed = scenarioResults.filter((result) => !result.passed);
-const safetyFailures = scenarioResults.filter((result) => result.safetyViolation);
-const passed =
-  overallScore >= manifest.regressionPolicy.minimumOverallScore &&
-  failed.length === 0 &&
-  (!manifest.regressionPolicy.safetyViolationIsFailure || safetyFailures.length === 0);
-
-const report = {
-  benchmark: manifest.name,
-  version: manifest.version,
-  generatedAt: new Date().toISOString(),
-  overallScore,
-  passed,
-  scenarioCount: scenarioResults.length,
-  failedScenarioCount: failed.length,
-  safetyViolationCount: safetyFailures.length,
-  results: scenarioResults,
+export type BenchmarkReport = {
+  benchmark: string;
+  version: string;
+  generatedAt: string;
+  overallScore: number;
+  passed: boolean;
+  scenarioCount: number;
+  failedScenarioCount: number;
+  safetyViolationCount: number;
+  results: ScenarioResult[];
 };
 
-mkdirSync(dirname(resultsPath), { recursive: true });
-writeFileSync(resultsPath, `${JSON.stringify(report, null, 2)}\n`);
+export interface BenchmarkRunOptions {
+  outputPath?: string;
+}
 
-console.log(JSON.stringify(report, null, 2));
-if (!passed) process.exit(1);
+export function runBenchmark(options: BenchmarkRunOptions = {}): BenchmarkReport {
+  const manifest = readJson<Manifest>(manifestPath);
+  if (manifest.regressionPolicy.liveSecretsRequired) {
+    throw new Error('Non-live benchmark must not require live secrets.');
+  }
+
+  const scenarioResults = manifest.scenarios.map(evaluateScenario);
+  const overallScore = Number(
+    (
+      scenarioResults.reduce((sum, result) => sum + result.score, 0) / scenarioResults.length
+    ).toFixed(2),
+  );
+  const failed = scenarioResults.filter((result) => !result.passed);
+  const safetyFailures = scenarioResults.filter((result) => result.safetyViolation);
+  const passed =
+    overallScore >= manifest.regressionPolicy.minimumOverallScore &&
+    failed.length === 0 &&
+    (!manifest.regressionPolicy.safetyViolationIsFailure || safetyFailures.length === 0);
+
+  const report: BenchmarkReport = {
+    benchmark: manifest.name,
+    version: manifest.version,
+    generatedAt: new Date().toISOString(),
+    overallScore,
+    passed,
+    scenarioCount: scenarioResults.length,
+    failedScenarioCount: failed.length,
+    safetyViolationCount: safetyFailures.length,
+    results: scenarioResults,
+  };
+
+  const resultsPath = options.outputPath ? resolve(root, options.outputPath) : defaultResultsPath;
+  mkdirSync(dirname(resultsPath), { recursive: true });
+  writeFileSync(resultsPath, `${JSON.stringify(report, null, 2)}\n`);
+
+  return report;
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : '';
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  const { outputPath } = parseArgs(process.argv.slice(2));
+  const report = runBenchmark({ outputPath });
+  console.log(JSON.stringify(report, null, 2));
+  if (!report.passed) process.exit(1);
+}

--- a/tests/evals/benchmark.test.ts
+++ b/tests/evals/benchmark.test.ts
@@ -1,23 +1,12 @@
-import { execFileSync } from 'node:child_process';
-import { dirname } from 'node:path';
-import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { rmSync } from 'node:fs';
+import { runBenchmark } from '../../scripts/run-evals.mts';
 import { describe, expect, it } from 'vitest';
 
 describe('golden eval benchmark', () => {
   it('runs non-live benchmark suite and passes regression policy', () => {
     const resultPath = '.easyeda-mcp-pro/evals/vitest-latest.json';
     rmSync(resultPath, { force: true });
-    mkdirSync(dirname(resultPath), { recursive: true });
-    execFileSync('pnpm', ['exec', 'tsx', 'scripts/run-evals.mts', '--output', resultPath], {
-      stdio: 'pipe',
-    });
-    const report = JSON.parse(readFileSync(resultPath, 'utf8')) as {
-      passed: boolean;
-      overallScore: number;
-      scenarioCount: number;
-      failedScenarioCount: number;
-      safetyViolationCount: number;
-    };
+    const report = runBenchmark({ outputPath: resultPath });
 
     expect(report.passed).toBe(true);
     expect(report.overallScore).toBeGreaterThanOrEqual(85);


### PR DESCRIPTION
Closes #172.

## Summary
`package.json` declares Node `>=24 <27`, but CI only exercised **Node 24 on ubuntu**. This adds a lean `test-matrix` job that runs build + typecheck + unit tests + a CLI `--doctor` smoke across:
- **ubuntu-latest / Node 26** (current major)
- **windows-latest / Node 24**
- **macos-latest / Node 24**

so path-separator and file-handling regressions in the CLI and extension packaging get caught. The heavy `quality` job (docker smoke, docs build, coverage) stays on ubuntu + Node 24 to keep CI time reasonable and avoid duplicating the whole pipeline per platform.

## Notes
- `fail-fast: false` so one platform's failure doesn't cancel the others.
- The job is **not** in branch protection's required checks, so it won't block merges while any first-run cross-platform quirks are shaken out.
- Verified `node dist/index.js --doctor` exits 0 after `build` + `build:extension` locally.

## Test plan
- [x] `ci.yml` parses; prettier clean
- [ ] First CI run confirms build + tests pass on Windows/macOS and Node 26 (watching)