### PR TITLE
ci: retry transient GitHub Pages publish failures

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -25,7 +25,7 @@ jobs:
     if: github.repository_owner == 'oaslananka' || github.repository_owner == 'oaslananka-ops'
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.deploy1.outputs.page_url || steps.deploy2.outputs.page_url || steps.deploy3.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -62,7 +62,32 @@ jobs:
         with:
           path: docs/.vitepress/dist
 
-      - name: Deploy to GitHub Pages
-        id: deployment
+      # GitHub Pages' publish API intermittently returns "Deployment failed,
+      # try again later." even when the build and artifact are fine. Retry the
+      # publish step (only) up to three times with backoff. The build and
+      # artifact upload above run once. The final attempt is NOT
+      # continue-on-error, so a genuinely failed deploy still fails the job.
+      - name: Deploy to GitHub Pages (attempt 1)
+        id: deploy1
+        continue-on-error: true
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+
+      - name: Backoff before retry 2
+        if: steps.deploy1.outcome == 'failure'
+        run: sleep 15
+
+      - name: Deploy to GitHub Pages (attempt 2)
+        id: deploy2
+        if: steps.deploy1.outcome == 'failure'
+        continue-on-error: true
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
+
+      - name: Backoff before retry 3
+        if: steps.deploy1.outcome == 'failure' && steps.deploy2.outcome == 'failure'
+        run: sleep 30
+
+      - name: Deploy to GitHub Pages (attempt 3)
+        id: deploy3
+        if: steps.deploy1.outcome == 'failure' && steps.deploy2.outcome == 'failure'
         uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 


### PR DESCRIPTION
Closes #175.

## Summary
`actions/deploy-pages` intermittently fails with GitHub Pages' generic `Deployment failed, try again later.` even when the build and artifact are fine — a clean re-run always succeeds (it took three manual re-runs recently). This retries **only the publish step** up to three times with 15s/30s backoff.

- Build + artifact upload run **once** (no duplicate-artifact races).
- Attempts 1 & 2 are `continue-on-error` and gated on the previous attempt failing; **attempt 3 is not** `continue-on-error`, so a genuinely failed deploy still fails the job.
- `environment.url` coalesces `page_url` across the three attempts.
- No new marketplace dependency — reuses the existing SHA-pinned `deploy-pages@v5.0.0` with step-level `if`/`continue-on-error` gating, consistent with the repo's pin-everything policy.

## Test plan
- [x] `deploy-docs.yml` parses; prettier clean
- [x] Retry logic reviewed: success on attempt 1 skips 2/3; all-three-fail fails the job
- [ ] Post-merge: trigger via `workflow_dispatch` to confirm a normal deploy still succeeds (the workflow doesn't auto-run on `.github/**` changes)