### PR TITLE
feat: add schematic sheet info tool

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -64,6 +64,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_schematic_nets`                | `core`  | `low`    | List all nets in the schematic with their node connections.                                                                                                                                                                                                                                                   |
 | `easyeda_schematic_place_component`     | `core`  | `medium` | Place a library component/device on the active schematic sheet.                                                                                                                                                                                                                                               |
 | `easyeda_schematic_search_device`       | `core`  | `low`    | Search for schematic symbols/devices in the EasyEDA library by keywords.                                                                                                                                                                                                                                      |
+| `easyeda_schematic_sheet_info`          | `core`  | `low`    | Return read-only active schematic sheet metadata including page size, frame, origin, and grid hints for safer component placement.                                                                                                                                                                            |
 | `easyeda_schematic_validate_netlist`    | `core`  | `low`    | Validate the EasyEDA Pro schematic netlist for connectivity issues. Reports net names, connected component references and pins, floating pins, graphical wires without netlist connectivity, and mismatches between visual wires and actual SCH_Net/SCH_Netlist entries. This is a read-only diagnostic tool. |
 | `easyeda_semantic_erc_validate`         | `core`  | `medium` | Run semantic electrical-rule validation over a netlist with pin electrical types to detect output contention, floating inputs, power conflicts, missing power pins, missing decoupling, and voltage-domain mismatches.                                                                                        |
 | `easyeda_wire_probe`                    | `dev`   | `low`    | Inspect live schematic wire objects, including line coordinates, net names, methods, and state getter values, to validate EasyEDA runtime mappings.                                                                                                                                                           |
@@ -1804,6 +1805,38 @@ Returns a JSON object matching the schema:
 {
   devices: any;
   total: any;
+  not_available: any;
+  error: any;
+}
+```
+
+---
+
+## `easyeda_schematic_sheet_info`
+
+**Profile:** `core` | **Risk Level:** `low`
+
+> Return read-only active schematic sheet metadata including page size, frame, origin, and grid hints for safer component placement.
+
+### Input Parameters
+
+| Parameter   | Type  | Required | Description |
+| ----------- | ----- | -------- | ----------- |
+| `projectId` | `any` | No       |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  project_id: any;
+  sheet: any;
+  page_size: any;
+  frame: any;
+  origin: any;
+  grid: any;
+  raw: any;
   not_available: any;
   error: any;
 }

--- a/easyeda-bridge-extension/src/index.ts
+++ b/easyeda-bridge-extension/src/index.ts
@@ -884,6 +884,29 @@ async function listComponentsApi(): Promise<unknown> {
   return result;
 }
 
+async function getSchematicSheetInfoApi(): Promise<unknown> {
+  const currentPage = await callFirst([
+    'DMT_Schematic.getCurrentSchematicPageInfo',
+    'dmt_Schematic.getCurrentSchematicPageInfo',
+  ]);
+  let pages: unknown = [];
+  try {
+    pages = await callFirst([
+      'DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo',
+      'DMT_Schematic.getAllSchematicPagesInfo',
+      'dmt_Schematic.getCurrentSchematicAllSchematicPagesInfo',
+      'dmt_Schematic.getAllSchematicPagesInfo',
+    ]);
+  } catch (err) {
+    logRecoverableError('failed to read schematic pages list', err);
+  }
+
+  return {
+    currentPage: normalizeValue(currentPage, 5),
+    pages: normalizeValue(pages, 4),
+  };
+}
+
 async function listNetsApi(): Promise<unknown> {
   const schCompClass = readFirstPath<any>([
     'SCH_PrimitiveComponent',
@@ -1398,6 +1421,8 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
     }
     case 'schematic.listComponents':
       return listComponentsApi();
+    case 'schematic.getSheetInfo':
+      return getSchematicSheetInfoApi();
     case 'schematic.searchDevice':
       return callFirst(
         ['LIB_Device.search', 'lib_Device.search'],
@@ -1838,6 +1863,7 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
           'schematic.getNetDetail',
           'schematic.listComponents',
           'schematic.searchDevice',
+          'schematic.getSheetInfo',
           'schematic.placeComponent',
           'schematic.addWire',
           'schematic.deletePrimitive',

--- a/src/bridge/types.ts
+++ b/src/bridge/types.ts
@@ -8,6 +8,7 @@ export const EasyedaApiMethodSchema = z.enum([
   'schematic.getNetDetail',
   'schematic.listComponents',
   'schematic.searchDevice',
+  'schematic.getSheetInfo',
   'schematic.placeComponent',
   'schematic.addWire',
   'schematic.deletePrimitive',

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -14,14 +14,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Core',
     description:
       'High-confidence tools: diagnostics, EasyEDA API inventory, schematic, BOM, DRC/ERC, board layers/stackup, Gerber export',
-    approxToolCount: '42',
+    approxToolCount: '43',
     isDefault: true,
   },
   pro: {
     name: 'pro',
     label: 'Pro',
     description: 'Adds pick-and-place, PDF, netlist export for manufacturing workflows',
-    approxToolCount: '47',
+    approxToolCount: '48',
     isDefault: false,
   },
   full: {
@@ -29,7 +29,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls for full runtime control without raw JavaScript execution',
-    approxToolCount: '56',
+    approxToolCount: '57',
     isDefault: false,
   },
   dev: {
@@ -37,14 +37,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '60',
+    approxToolCount: '61',
     isDefault: false,
   },
   experimental: {
     name: 'experimental',
     label: 'Experimental',
     description: 'MCP Apps, Tasks, simulation, autorouter, AI action plans',
-    approxToolCount: '56',
+    approxToolCount: '57',
     isDefault: false,
   },
 };

--- a/src/tools/L1_schematic_read.ts
+++ b/src/tools/L1_schematic_read.ts
@@ -370,6 +370,96 @@ function registerSchematicReadTools(
   });
 
   registry.register({
+    name: 'easyeda_schematic_sheet_info',
+    title: 'Get schematic sheet info',
+    description:
+      'Return read-only active schematic sheet metadata including page size, frame, origin, and grid hints for safer component placement.',
+    profile: 'core',
+    evidence: ['runtime-probe'],
+    risk: 'low',
+    confirmWrite: false,
+    group: 'schematic',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+    inputSchema: z.object({
+      projectId: z.string().optional(),
+    }),
+    outputSchema: z.object({
+      project_id: z.string().optional(),
+      sheet: z.unknown().optional(),
+      page_size: z
+        .object({
+          width: z.number().optional(),
+          height: z.number().optional(),
+          unit: z.string().optional(),
+        })
+        .optional(),
+      frame: z.unknown().optional(),
+      origin: z.unknown().optional(),
+      grid: z.unknown().optional(),
+      raw: z.unknown().optional(),
+      not_available: z.boolean().optional(),
+      error: z.string().optional(),
+    }),
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const { projectId } = z.object({ projectId: z.string().optional() }).parse(params ?? {});
+      try {
+        const result = await ctx.bridge.call('schematic.getSheetInfo', { projectId });
+        const root =
+          result && typeof result === 'object' && !Array.isArray(result)
+            ? (result as Record<string, unknown>)
+            : {};
+        const current =
+          root.currentPage &&
+          typeof root.currentPage === 'object' &&
+          !Array.isArray(root.currentPage)
+            ? (root.currentPage as Record<string, unknown>)
+            : root;
+        const readNumber = (keys: string[]): number | undefined => {
+          for (const key of keys) {
+            const value = current[key] ?? root[key];
+            if (typeof value === 'number' && Number.isFinite(value)) return value;
+            if (typeof value === 'string') {
+              const parsed = Number(value.trim());
+              if (Number.isFinite(parsed)) return parsed;
+            }
+          }
+          return undefined;
+        };
+        const readString = (keys: string[]): string | undefined => {
+          for (const key of keys) {
+            const value = current[key] ?? root[key];
+            if (typeof value === 'string' && value.trim()) return value;
+          }
+          return undefined;
+        };
+        return {
+          project_id: projectId,
+          sheet: current,
+          page_size: {
+            width: readNumber(['width', 'pageWidth', 'paperWidth', 'w']),
+            height: readNumber(['height', 'pageHeight', 'paperHeight', 'h']),
+            unit: readString(['unit', 'units', 'pageUnit']),
+          },
+          frame: current.frame ?? current.titleBlock ?? root.frame,
+          origin: current.origin ?? current.canvasOrigin ?? root.origin,
+          grid: current.grid ?? current.gridSize ?? root.grid,
+          raw: result,
+        };
+      } catch (err) {
+        return {
+          project_id: projectId,
+          not_available: true,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+  });
+
+  registry.register({
     name: 'easyeda_schematic_component_pins',
     title: 'Get component pins',
     description:

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -39,14 +39,14 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for core', () => {
-    expect(PROFILE_DEFINITIONS.core.approxToolCount).toBe('42');
+    expect(PROFILE_DEFINITIONS.core.approxToolCount).toBe('43');
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('47');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('48');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('56');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('57');
   });
 });


### PR DESCRIPTION
## Summary
- Adds read-only `easyeda_schematic_sheet_info` for active schematic sheet metadata.
- Exposes normalized placement hints for page size, frame, origin, and grid while preserving the raw EasyEDA response for diagnostics.
- Adds `schematic.getSheetInfo` to the bridge method contract and EasyEDA bridge extension dispatch.
- Uses `DMT_Schematic.getCurrentSchematicPageInfo` and schematic pages info methods from the live runtime inventory baseline.

Closes #168.

## Validation
- `pnpm exec prettier --write src/bridge/types.ts src/tools/L1_schematic_read.ts easyeda-bridge-extension/src/index.ts`
- `pnpm exec tsc --noEmit`
- `pnpm typecheck:extension`
- `pnpm exec eslint .`

## Notes
- Some aggregate aliases (`pnpm verify:tool-coverage`, `pnpm exec vitest run`, `pnpm build:extension`) were blocked by the remote exec safety layer during local validation. The PR CI will run the canonical workflow including tool coverage, tests, docs, build, and extension verification.