### PR TITLE
feat: add schematic placement safety guardrails

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -1754,17 +1754,21 @@ Returns a JSON object matching the schema:
 
 ### Input Parameters
 
-| Parameter      | Type  | Required | Description |
-| -------------- | ----- | -------- | ----------- |
-| `deviceItem`   | `any` | Yes      |             |
-| `x`            | `any` | Yes      |             |
-| `y`            | `any` | Yes      |             |
-| `subPartName`  | `any` | No       |             |
-| `rotation`     | `any` | No       |             |
-| `mirror`       | `any` | No       |             |
-| `addIntoBom`   | `any` | No       |             |
-| `addIntoPcb`   | `any` | No       |             |
-| `confirmWrite` | `any` | Yes      |             |
+| Parameter                 | Type  | Required | Description |
+| ------------------------- | ----- | -------- | ----------- |
+| `deviceItem`              | `any` | Yes      |             |
+| `x`                       | `any` | Yes      |             |
+| `y`                       | `any` | Yes      |             |
+| `subPartName`             | `any` | No       |             |
+| `rotation`                | `any` | No       |             |
+| `mirror`                  | `any` | No       |             |
+| `addIntoBom`              | `any` | No       |             |
+| `addIntoPcb`              | `any` | No       |             |
+| `dryRun`                  | `any` | No       |             |
+| `verifyAfterWrite`        | `any` | No       |             |
+| `checkPlacementCollision` | `any` | No       |             |
+| `collisionRadius`         | `any` | No       |             |
+| `confirmWrite`            | `any` | Yes      |             |
 
 ### Output Format
 
@@ -1774,6 +1778,9 @@ Returns a JSON object matching the schema:
 {
   success: any;
   component: any;
+  dry_run: any;
+  placement_guard: any;
+  verification: any;
   error: any;
 }
 ```

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -140,6 +140,18 @@ Mutation tools also support a registry-level write transaction flow through `wri
 
 The safe sequence for agents is: plan → preview → user confirmation → apply with `confirmWrite=true` → verify with read-only checks.
 
+### Agent schematic write safety loop
+
+Agents that author schematics should not treat a successful write call as proof that the electrical intent is correct. Use this loop for placement and connectivity:
+
+1. Read placement context with `easyeda_schematic_sheet_info` and existing design state with `easyeda_schematic_components` / `easyeda_schematic_nets`.
+2. Choose parts with `easyeda_schematic_search_device` and check normalized `pin_count` / `symbol_type` before selecting a symbol.
+3. Preview placement with `easyeda_schematic_place_component` using `dryRun=true` and `checkPlacementCollision=true`. Review `placement_guard.warnings` and `nearby_components` before applying.
+4. Apply the placement only after explicit confirmation with `confirmWrite=true`. Set `verifyAfterWrite=true` to read back component count and surface whether read-back verification was available.
+5. After wiring/net assignment, verify connectivity with `easyeda_schematic_validate_netlist` and, when appropriate, `easyeda_semantic_erc_validate` before continuing to board or export workflows.
+
+`dryRun=true` does not mutate the design. It returns the requested placement preview and optional collision warning data. `verifyAfterWrite=true` performs a read-back pass after the write and reports component-count delta evidence. These checks are guardrails, not a substitute for final human design review.
+
 **Risk tiers:**
 
 | Risk Level | Tool Type                      | Examples                                                              | confirmWrite Required |

--- a/src/tools/L1_schematic_write.ts
+++ b/src/tools/L1_schematic_write.ts
@@ -9,6 +9,102 @@ const deviceItemSchema = z
   })
   .passthrough();
 
+type SchematicComponentSnapshot = Record<string, unknown>;
+
+type PlacementGuardResult = {
+  collision_checked: boolean;
+  collision_radius: number;
+  warnings: string[];
+  nearby_components: SchematicComponentSnapshot[];
+};
+
+function schematicWriteNumberField(
+  item: SchematicComponentSnapshot,
+  keys: readonly string[],
+): number | undefined {
+  for (const key of keys) {
+    const value = item[key];
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value === 'string') {
+      const parsed = Number(value.trim());
+      if (Number.isFinite(parsed)) return parsed;
+    }
+  }
+  return undefined;
+}
+
+function schematicWriteComponentPoint(
+  item: SchematicComponentSnapshot,
+): { x: number; y: number } | undefined {
+  const directX = schematicWriteNumberField(item, ['x', 'X', 'canvasX', 'positionX']);
+  const directY = schematicWriteNumberField(item, ['y', 'Y', 'canvasY', 'positionY']);
+  if (directX !== undefined && directY !== undefined) return { x: directX, y: directY };
+
+  const position = item.position;
+  if (position && typeof position === 'object' && !Array.isArray(position)) {
+    const pos = position as SchematicComponentSnapshot;
+    const x = schematicWriteNumberField(pos, ['x', 'X']);
+    const y = schematicWriteNumberField(pos, ['y', 'Y']);
+    if (x !== undefined && y !== undefined) return { x, y };
+  }
+
+  const bbox = item.bbox ?? item.boundingBox;
+  if (bbox && typeof bbox === 'object' && !Array.isArray(bbox)) {
+    const box = bbox as SchematicComponentSnapshot;
+    const x1 = schematicWriteNumberField(box, ['x', 'left', 'minX']);
+    const y1 = schematicWriteNumberField(box, ['y', 'top', 'minY']);
+    const x2 = schematicWriteNumberField(box, ['x2', 'right', 'maxX']);
+    const y2 = schematicWriteNumberField(box, ['y2', 'bottom', 'maxY']);
+    if (x1 !== undefined && y1 !== undefined && x2 !== undefined && y2 !== undefined) {
+      return { x: (x1 + x2) / 2, y: (y1 + y2) / 2 };
+    }
+  }
+
+  return undefined;
+}
+
+function schematicWritePlacementGuard(
+  components: SchematicComponentSnapshot[] | undefined,
+  x: number,
+  y: number,
+  collisionRadius: number,
+): PlacementGuardResult {
+  const nearby: SchematicComponentSnapshot[] = [];
+  for (const component of components ?? []) {
+    const point = schematicWriteComponentPoint(component);
+    if (!point) continue;
+    const distance = Math.hypot(point.x - x, point.y - y);
+    if (distance <= collisionRadius) nearby.push({ ...component, distance });
+  }
+
+  return {
+    collision_checked: true,
+    collision_radius: collisionRadius,
+    warnings:
+      nearby.length > 0
+        ? [
+            `Placement is within ${collisionRadius} schematic units of ${nearby.length} existing component(s). Review before applying.`,
+          ]
+        : [],
+    nearby_components: nearby,
+  };
+}
+
+async function readSchematicComponentsForVerification(
+  ctx: ToolContext,
+): Promise<SchematicComponentSnapshot[] | undefined> {
+  try {
+    const result = await ctx.bridge.call('schematic.listComponents', {
+      projectId: 'active',
+      limit: 500,
+      offset: 0,
+    });
+    return Array.isArray(result) ? (result as SchematicComponentSnapshot[]) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 const placeComponentInputSchema = z.object({
   deviceItem: deviceItemSchema,
   x: z.number(),
@@ -18,6 +114,10 @@ const placeComponentInputSchema = z.object({
   mirror: z.boolean().optional(),
   addIntoBom: z.boolean().optional(),
   addIntoPcb: z.boolean().optional(),
+  dryRun: z.boolean().optional(),
+  verifyAfterWrite: z.boolean().optional(),
+  checkPlacementCollision: z.boolean().optional(),
+  collisionRadius: z.number().positive().optional(),
   confirmWrite: z.literal(true),
 });
 
@@ -68,11 +168,45 @@ function registerSchematicWriteTools(
     outputSchema: z.object({
       success: z.boolean(),
       component: z.unknown().optional(),
+      dry_run: z.boolean().optional(),
+      placement_guard: z.unknown().optional(),
+      verification: z.unknown().optional(),
       error: z.string().optional(),
     }),
     handler: async (ctx: ToolContext, params: unknown) => {
       const p = placeComponentInputSchema.parse(params);
       try {
+        const shouldReadBefore = Boolean(
+          p.dryRun || p.verifyAfterWrite || p.checkPlacementCollision,
+        );
+        const beforeComponents = shouldReadBefore
+          ? await readSchematicComponentsForVerification(ctx)
+          : undefined;
+        const collisionRadius = p.collisionRadius ?? 25;
+        const placementGuard = p.checkPlacementCollision
+          ? schematicWritePlacementGuard(beforeComponents, p.x, p.y, collisionRadius)
+          : undefined;
+
+        if (p.dryRun) {
+          return {
+            success: true,
+            dry_run: true,
+            placement_guard: placementGuard,
+            verification: {
+              applied: false,
+              before_component_count: beforeComponents?.length,
+              requested: {
+                deviceItem: p.deviceItem,
+                x: p.x,
+                y: p.y,
+                rotation: p.rotation,
+                mirror: p.mirror,
+                subPartName: p.subPartName,
+              },
+            },
+          };
+        }
+
         const result = await ctx.bridge.call('schematic.placeComponent', {
           deviceItem: p.deviceItem,
           x: p.x,
@@ -83,9 +217,33 @@ function registerSchematicWriteTools(
           addIntoBom: p.addIntoBom,
           addIntoPcb: p.addIntoPcb,
         });
+
+        if (!p.verifyAfterWrite && !placementGuard) {
+          return {
+            success: true,
+            component: result,
+          };
+        }
+
+        const afterComponents = p.verifyAfterWrite
+          ? await readSchematicComponentsForVerification(ctx)
+          : undefined;
         return {
           success: true,
           component: result,
+          placement_guard: placementGuard,
+          verification: p.verifyAfterWrite
+            ? {
+                applied: true,
+                before_component_count: beforeComponents?.length,
+                after_component_count: afterComponents?.length,
+                component_count_delta:
+                  beforeComponents && afterComponents
+                    ? afterComponents.length - beforeComponents.length
+                    : undefined,
+                readback_available: Boolean(afterComponents),
+              }
+            : undefined,
         };
       } catch (err) {
         return {

--- a/tests/unit/tools/schematic.test.ts
+++ b/tests/unit/tools/schematic.test.ts
@@ -117,6 +117,85 @@ describe('Schematic Tools', () => {
     });
   });
 
+  it('easyeda_schematic_place_component supports dry-run collision warnings', async () => {
+    const tool = registry.get('easyeda_schematic_place_component');
+    bridgeCall.mockResolvedValueOnce([
+      { reference: 'R1', position: { x: 105, y: 203 } },
+      { reference: 'C1', position: { x: 400, y: 400 } },
+    ]);
+
+    const result = await tool?.handler(context, {
+      deviceItem: { libraryUuid: 'lib-uuid', uuid: 'device-uuid' },
+      x: 100,
+      y: 200,
+      dryRun: true,
+      checkPlacementCollision: true,
+      collisionRadius: 10,
+      confirmWrite: true,
+    });
+
+    expect(bridgeCall).toHaveBeenCalledTimes(1);
+    expect(bridgeCall).toHaveBeenCalledWith('schematic.listComponents', {
+      projectId: 'active',
+      limit: 500,
+      offset: 0,
+    });
+    expect(result).toMatchObject({
+      success: true,
+      dry_run: true,
+      placement_guard: {
+        collision_checked: true,
+        collision_radius: 10,
+        nearby_components: [{ reference: 'R1' }],
+      },
+      verification: {
+        applied: false,
+        before_component_count: 2,
+      },
+    });
+  });
+
+  it('easyeda_schematic_place_component can verify write readback', async () => {
+    const tool = registry.get('easyeda_schematic_place_component');
+    bridgeCall
+      .mockResolvedValueOnce([{ reference: 'R1', position: { x: 10, y: 10 } }])
+      .mockResolvedValueOnce({ componentId: 'comp-123' })
+      .mockResolvedValueOnce([
+        { reference: 'R1', position: { x: 10, y: 10 } },
+        { reference: 'R2', position: { x: 100, y: 200 } },
+      ]);
+
+    const result = await tool?.handler(context, {
+      deviceItem: { libraryUuid: 'lib-uuid', uuid: 'device-uuid' },
+      x: 100,
+      y: 200,
+      verifyAfterWrite: true,
+      confirmWrite: true,
+    });
+
+    expect(bridgeCall).toHaveBeenCalledTimes(3);
+    expect(bridgeCall).toHaveBeenNthCalledWith(2, 'schematic.placeComponent', {
+      deviceItem: { libraryUuid: 'lib-uuid', uuid: 'device-uuid' },
+      x: 100,
+      y: 200,
+      rotation: undefined,
+      mirror: undefined,
+      subPartName: undefined,
+      addIntoBom: undefined,
+      addIntoPcb: undefined,
+    });
+    expect(result).toMatchObject({
+      success: true,
+      component: { componentId: 'comp-123' },
+      verification: {
+        applied: true,
+        before_component_count: 1,
+        after_component_count: 2,
+        component_count_delta: 1,
+        readback_available: true,
+      },
+    });
+  });
   it('easyeda_schematic_add_wire should call bridge and return success', async () => {
     const tool = registry.get('easyeda_schematic_add_wire');
     bridgeCall.mockResolvedValue({ wireId: 'wire-123' });


### PR DESCRIPTION
## Summary
- Adds opt-in placement safety controls to `easyeda_schematic_place_component` without changing the default response shape.
- Adds `dryRun=true` preview mode that does not mutate the design.
- Adds `checkPlacementCollision=true` and configurable `collisionRadius` to warn when a requested placement is near existing components.
- Adds `verifyAfterWrite=true` read-back verification using component-count delta evidence after placement.
- Documents the recommended agent loop: sheet info → device metadata check → dry-run/collision preview → confirmed write → read-back verification → netlist/ERC validation.
- Updates the generated tools reference for the new optional input/output fields.

Partially addresses #171.

## Validation
- `pnpm exec prettier --write src/tools/L1_schematic_write.ts tests/unit/tools/schematic.test.ts docs/security-architecture.md docs/reference/tools.md`
- `pnpm exec tsc --noEmit`
- `pnpm exec vitest run tests/unit/tools/schematic.test.ts` → 30 tests passed
- `pnpm exec vitest run` → 67 files / 810 tests passed
- `pnpm exec eslint .`

## Notes
- This PR implements the first safety primitive for component placement. Additional follow-up can extend the same verification pattern to wire/net write tools and richer bounding-box reads when the live bridge exposes them.
