### PR TITLE
chore: add shared live E2E harness

### DIFF
--- a/scripts/e2e/README.md
+++ b/scripts/e2e/README.md
@@ -1,0 +1,32 @@
+# Live E2E helper scripts
+
+These scripts are maintainer-only helpers for live EasyEDA bridge diagnostics and smoke validation. They are not part of the default end-user workflow.
+
+## Shared harness
+
+Scripts that start an MCP server must use `harness.mjs` instead of hand-rolled `spawn()` / `setTimeout(kill)` shutdown logic. The harness provides:
+
+- stdio JSON-RPC request tracking,
+- pending-request cleanup when the server exits,
+- process-exit, SIGINT, and SIGTERM cleanup hooks,
+- immediate SIGTERM/SIGKILL shutdown without a delayed timer race,
+- captured stdout/stderr logs for diagnostics.
+
+This prevents orphaned `dist/index.js` servers from accumulating and accidentally accepting the EasyEDA extension connection on the wrong port.
+
+## Recommended dev bridge flow
+
+1. Build the project before live runs: `pnpm build`.
+2. In EasyEDA Pro, enable the MCP Bridge extension and turn Auto-Connect on when available.
+3. Start one live helper, for example `node scripts/e2e/diag.mjs` or `node scripts/e2e/live.mjs`.
+4. When the helper prints that it is waiting for bridge connection, connect or reconnect the EasyEDA MCP Bridge once.
+5. Re-run helpers from the same terminal session as needed. The harness cleans up the child MCP server on every normal exit, failure, Ctrl+C, or termination signal.
+
+If a run times out waiting for the bridge, close the helper, verify there is no stale `dist/index.js` process, then reconnect the EasyEDA bridge to the new helper instance.
+
+## Scripts
+
+- `diag.mjs` — bridge state, capabilities, tool registration, and health diagnostics.
+- `live.mjs` — full live schematic net creation and connectivity validation.
+- `waiter.mjs` — TCP bridge wait/debug helper for longer manual sessions.
+- `http.mjs` — HTTP transport helper; it does not spawn a child MCP server.

--- a/scripts/e2e/diag.mjs
+++ b/scripts/e2e/diag.mjs
@@ -1,95 +1,34 @@
 #!/usr/bin/env node
 /**
- * Quick diagnostic - checks bridge state, capabilities, and tool registration
+ * Quick diagnostic - checks bridge state, capabilities, and tool registration.
  */
-import { spawn } from 'node:child_process';
-import { createInterface } from 'node:readline';
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { sleep, startStdioMcpServer } from './harness.mjs';
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
-
-let reqId = 0;
-const pending = new Map();
-let serverStdin;
-
-function mcpCall(method, params = {}) {
-  return new Promise((resolve, reject) => {
-    const id = ++reqId;
-    const timer = setTimeout(() => {
-      pending.delete(id);
-      reject(new Error('TIMEOUT'));
-    }, 30000);
-    pending.set(id, { resolve, reject, timer });
-    serverStdin.write(JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n');
-  });
-}
-
-async function toolCall(name, args = {}) {
-  const r = await mcpCall('tools/call', { name, arguments: args });
-  const text = (r.content || [])
-    .map((c) => c.text || '')
-    .join('\n')
-    .trim();
-  return { text, isError: r.isError === true };
-}
-
-const server = spawn('node', ['dist/index.js'], {
-  cwd: __dirname,
-  stdio: ['pipe', 'pipe', 'pipe'],
-  env: {
-    ...process.env,
-    TRANSPORT: 'stdio',
-    LOG_LEVEL: 'silent',
-    TOOL_PROFILE: 'full',
-    BRIDGE_RECONNECT_MAX_ATTEMPTS: '0',
-    BRIDGE_RECONNECT_INTERVAL_MS: '1000',
-    BRIDGE_TIMEOUT_MS: '30000',
-  },
-});
-serverStdin = server.stdin;
-let exited = false;
-server.on('exit', () => {
-  exited = true;
-});
-
-const rl = createInterface({ input: server.stdout });
-rl.on('line', (line) => {
-  let p;
-  try {
-    p = JSON.parse(line);
-  } catch {
-    return;
-  }
-  if (p.id && pending.has(p.id)) {
-    const { resolve, reject, timer } = pending.get(p.id);
-    pending.delete(p.id);
-    clearTimeout(timer);
-    if (p.error) reject(new Error(p.error.message));
-    else resolve(p.result);
-  }
-});
-server.stderr.on('data', () => {});
+const repoRoot = resolve(__dirname, '..', '..');
+const mcp = startStdioMcpServer({ cwd: repoRoot });
 
 async function main() {
-  await new Promise((r) => setTimeout(r, 2000));
-  if (exited) {
+  await sleep(2000);
+  if (mcp.exited) {
     console.log('❌ Server exited');
     process.exit(1);
   }
 
-  await mcpCall('initialize', {
+  await mcp.mcpCall('initialize', {
     protocolVersion: '2025-11-25',
     capabilities: {},
     clientInfo: { name: 'diag', version: '1' },
   });
-  serverStdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+  mcp.notifyInitialized();
   console.log('✅ Server initialized');
 
-  // Wait for bridge
   let bs = '';
   for (let i = 0; i < 120; i++) {
     try {
-      const { text } = await toolCall('easyeda_bridge_status');
+      const { text } = await mcp.toolCall('easyeda_bridge_status');
       bs = text;
       if (JSON.parse(text).connected) {
         console.log(`✅ Bridge connected (${i + 1}s)`);
@@ -97,15 +36,16 @@ async function main() {
       }
     } catch {}
     if ((i + 1) % 15 === 0) console.log(`  waiting... ${i + 1}s`);
-    await new Promise((r) => setTimeout(r, 1000));
+    await sleep(1000);
   }
+
   if (!bs || !JSON.parse(bs).connected) {
     console.log('❌ Bridge not connected after 120s');
     console.log('Last status:', bs.slice(0, 300));
+    mcp.shutdown('bridge not connected');
     process.exit(1);
   }
 
-  // Bridge status detail
   const status = JSON.parse(bs);
   console.log('\n=== BRIDGE STATUS ===');
   console.log(`connected: ${status.connected}`);
@@ -114,7 +54,6 @@ async function main() {
   console.log(`capabilities (${(status.capabilities || []).length}):`);
   (status.capabilities || []).forEach((c) => console.log(`  - ${c}`));
 
-  // Check schema methods
   const required = [
     'schematic.createNetFlag',
     'schematic.createNetPort',
@@ -125,40 +64,39 @@ async function main() {
   ];
   console.log('\n=== REQUIRED METHODS ===');
   const caps = new Set(status.capabilities || []);
-  for (const m of required) {
-    console.log(`  ${caps.has(m) ? '✅' : '❌'} ${m}`);
+  for (const method of required) {
+    console.log(`  ${caps.has(method) ? '✅' : '❌'} ${method}`);
   }
 
-  // List available MCP tools
   console.log('\n=== MCP TOOLS ===');
-  const tools = await mcpCall('tools/list');
-  const toolNames = (tools.tools || []).map((t) => t.name);
+  const tools = await mcp.mcpCall('tools/list');
+  const toolNames = (tools.tools || []).map((tool) => tool.name);
   const netTools = toolNames.filter(
-    (n) =>
-      n.includes('net') ||
-      n.includes('flag') ||
-      n.includes('connect') ||
-      n.includes('save') ||
-      n.includes('validate'),
+    (name) =>
+      name.includes('net') ||
+      name.includes('flag') ||
+      name.includes('connect') ||
+      name.includes('save') ||
+      name.includes('validate'),
   );
   console.log('Relevant tools:');
-  netTools.forEach((t) => console.log(`  - ${t}`));
+  netTools.forEach((tool) => console.log(`  - ${tool}`));
   console.log(`\nTotal tools: ${toolNames.length}`);
 
-  // Try calling a diagnostic tool
   console.log('\n=== HEALTH CHECK ===');
   try {
-    const { text } = await toolCall('easyeda_health_check');
+    const { text } = await mcp.toolCall('easyeda_health_check');
     console.log(text.slice(0, 300));
-  } catch (e) {
-    console.log(`Health check failed: ${e.message}`);
+  } catch (err) {
+    console.log(`Health check failed: ${err.message}`);
   }
 
-  server.stdin.end();
-  setTimeout(() => process.exit(0), 1000);
+  mcp.shutdown('diag complete');
+  mcp.detach();
 }
 
-main().catch((e) => {
-  console.error(`Fatal: ${e.message}`);
+main().catch((err) => {
+  console.error(`Fatal: ${err.message}`);
+  mcp.shutdown('diag fatal');
   process.exit(1);
 });

--- a/scripts/e2e/harness.mjs
+++ b/scripts/e2e/harness.mjs
@@ -89,8 +89,8 @@ export function startStdioMcpServer(options = {}) {
     process.exit(signal === 'SIGINT' ? 130 : 143);
   };
   process.once('exit', handleExit);
-  process.once('SIGINT', handleSignal);
-  process.once('SIGTERM', handleSignal);
+  process.once('SIGINT', () => handleSignal('SIGINT'));
+  process.once('SIGTERM', () => handleSignal('SIGTERM'));
 
   const detach = () => {
     process.removeListener('exit', handleExit);
@@ -195,8 +195,8 @@ export function spawnTrackedProcess(command, args = [], options = {}) {
     process.exit(signal === 'SIGINT' ? 130 : 143);
   };
   process.once('exit', handleExit);
-  process.once('SIGINT', handleSignal);
-  process.once('SIGTERM', handleSignal);
+  process.once('SIGINT', () => handleSignal('SIGINT'));
+  process.once('SIGTERM', () => handleSignal('SIGTERM'));
 
   return {
     child,

--- a/scripts/e2e/harness.mjs
+++ b/scripts/e2e/harness.mjs
@@ -1,0 +1,222 @@
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+export { sleep };
+
+export function startStdioMcpServer(options = {}) {
+  const cwd = options.cwd ?? process.cwd();
+  const timeoutMs = options.timeoutMs ?? 45_000;
+  const child = spawn('node', options.args ?? ['dist/index.js'], {
+    cwd,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      TRANSPORT: 'stdio',
+      LOG_LEVEL: 'silent',
+      TOOL_PROFILE: 'full',
+      BRIDGE_RECONNECT_MAX_ATTEMPTS: '0',
+      BRIDGE_RECONNECT_INTERVAL_MS: '1000',
+      BRIDGE_TIMEOUT_MS: '30000',
+      ...(options.env ?? {}),
+    },
+  });
+
+  let reqId = 0;
+  let exited = false;
+  let exitCode = null;
+  let stdoutLog = '';
+  const stderrLog = [];
+  const pending = new Map();
+
+  const rejectPending = (error) => {
+    for (const [id, entry] of pending.entries()) {
+      clearTimeout(entry.timer);
+      entry.reject(error);
+      pending.delete(id);
+    }
+  };
+
+  child.on('exit', (code, signal) => {
+    exited = true;
+    exitCode = code ?? signal ?? null;
+    rejectPending(new Error(`MCP server exited before response: ${exitCode ?? 'unknown'}`));
+  });
+
+  const rl = createInterface({ input: child.stdout });
+  rl.on('line', (line) => {
+    stdoutLog += `${line}\n`;
+    let parsed;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (!parsed.id || !pending.has(parsed.id)) return;
+    const entry = pending.get(parsed.id);
+    pending.delete(parsed.id);
+    clearTimeout(entry.timer);
+    if (parsed.error) entry.reject(new Error(parsed.error.message));
+    else entry.resolve(parsed.result);
+  });
+
+  child.stderr.on('data', (chunk) => {
+    const text = chunk.toString().trim();
+    if (text) stderrLog.push(text);
+  });
+
+  const shutdown = (label) => {
+    rejectPending(new Error(label ? `MCP server shutdown: ${label}` : 'MCP server shutdown'));
+    try {
+      child.stdin.end();
+    } catch {}
+    if (!exited) {
+      try {
+        child.kill('SIGTERM');
+      } catch {}
+    }
+    if (!exited) {
+      try {
+        child.kill('SIGKILL');
+      } catch {}
+    }
+    if (label) console.log(`  🔌 Shutdown: ${label}`);
+  };
+
+  const handleExit = () => shutdown('process exit');
+  const handleSignal = (signal) => {
+    shutdown(signal);
+    process.exit(signal === 'SIGINT' ? 130 : 143);
+  };
+  process.once('exit', handleExit);
+  process.once('SIGINT', handleSignal);
+  process.once('SIGTERM', handleSignal);
+
+  const detach = () => {
+    process.removeListener('exit', handleExit);
+    process.removeListener('SIGINT', handleSignal);
+    process.removeListener('SIGTERM', handleSignal);
+  };
+
+  const mcpCall = (method, params = {}, callTimeoutMs = timeoutMs) =>
+    new Promise((resolve, reject) => {
+      if (exited) {
+        reject(new Error(`MCP server already exited: ${exitCode ?? 'unknown'}`));
+        return;
+      }
+      const id = ++reqId;
+      const timer = setTimeout(() => {
+        pending.delete(id);
+        reject(new Error(`TIMEOUT ${method} (${callTimeoutMs}ms)`));
+      }, callTimeoutMs);
+      pending.set(id, { resolve, reject, timer });
+      child.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`);
+    });
+
+  const notifyInitialized = () => {
+    child.stdin.write(
+      `${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n`,
+    );
+  };
+
+  const toolCall = async (name, args = {}) => {
+    const result = await mcpCall('tools/call', { name, arguments: args });
+    const content = result.content || [];
+    const text = content.map((c) => c.text || c?.toString?.() || JSON.stringify(c)).join('\n');
+    return { result, text, isError: result.isError === true };
+  };
+
+  return {
+    child,
+    stdin: child.stdin,
+    stdout: child.stdout,
+    stderr: child.stderr,
+    stderrLog,
+    mcpCall,
+    toolCall,
+    notifyInitialized,
+    shutdown,
+    detach,
+    get exited() {
+      return exited;
+    },
+    get exitCode() {
+      return exitCode;
+    },
+    get stdoutLog() {
+      return stdoutLog;
+    },
+  };
+}
+
+export function spawnTrackedProcess(command, args = [], options = {}) {
+  const child = spawn(command, args, {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    ...options,
+    env: { ...process.env, ...(options.env ?? {}) },
+  });
+
+  let exited = false;
+  let exitCode = null;
+  let stdoutLog = '';
+  let stderrLog = '';
+
+  child.stdout?.on('data', (chunk) => {
+    stdoutLog += chunk.toString();
+  });
+  child.stderr?.on('data', (chunk) => {
+    stderrLog += chunk.toString();
+  });
+  child.on('exit', (code, signal) => {
+    exited = true;
+    exitCode = code ?? signal ?? null;
+  });
+
+  const shutdown = (label) => {
+    try {
+      child.stdin?.end();
+    } catch {}
+    if (!exited) {
+      try {
+        child.kill('SIGTERM');
+      } catch {}
+    }
+    if (!exited) {
+      try {
+        child.kill('SIGKILL');
+      } catch {}
+    }
+    if (label) console.log(`  🔌 Shutdown: ${label}`);
+  };
+
+  const handleExit = () => shutdown('process exit');
+  const handleSignal = (signal) => {
+    shutdown(signal);
+    process.exit(signal === 'SIGINT' ? 130 : 143);
+  };
+  process.once('exit', handleExit);
+  process.once('SIGINT', handleSignal);
+  process.once('SIGTERM', handleSignal);
+
+  return {
+    child,
+    shutdown,
+    detach() {
+      process.removeListener('exit', handleExit);
+      process.removeListener('SIGINT', handleSignal);
+      process.removeListener('SIGTERM', handleSignal);
+    },
+    get exited() {
+      return exited;
+    },
+    get exitCode() {
+      return exitCode;
+    },
+    get stdoutLog() {
+      return stdoutLog;
+    },
+    get stderrLog() {
+      return stderrLog;
+    },
+  };
+}

--- a/scripts/e2e/harness.mjs
+++ b/scripts/e2e/harness.mjs
@@ -88,14 +88,16 @@ export function startStdioMcpServer(options = {}) {
     shutdown(signal);
     process.exit(signal === 'SIGINT' ? 130 : 143);
   };
+  const handleSigint = () => handleSignal('SIGINT');
+  const handleSigterm = () => handleSignal('SIGTERM');
   process.once('exit', handleExit);
-  process.once('SIGINT', () => handleSignal('SIGINT'));
-  process.once('SIGTERM', () => handleSignal('SIGTERM'));
+  process.once('SIGINT', handleSigint);
+  process.once('SIGTERM', handleSigterm);
 
   const detach = () => {
     process.removeListener('exit', handleExit);
-    process.removeListener('SIGINT', handleSignal);
-    process.removeListener('SIGTERM', handleSignal);
+    process.removeListener('SIGINT', handleSigint);
+    process.removeListener('SIGTERM', handleSigterm);
   };
 
   const mcpCall = (method, params = {}, callTimeoutMs = timeoutMs) =>
@@ -194,17 +196,19 @@ export function spawnTrackedProcess(command, args = [], options = {}) {
     shutdown(signal);
     process.exit(signal === 'SIGINT' ? 130 : 143);
   };
+  const handleSigint = () => handleSignal('SIGINT');
+  const handleSigterm = () => handleSignal('SIGTERM');
   process.once('exit', handleExit);
-  process.once('SIGINT', () => handleSignal('SIGINT'));
-  process.once('SIGTERM', () => handleSignal('SIGTERM'));
+  process.once('SIGINT', handleSigint);
+  process.once('SIGTERM', handleSigterm);
 
   return {
     child,
     shutdown,
     detach() {
       process.removeListener('exit', handleExit);
-      process.removeListener('SIGINT', handleSignal);
-      process.removeListener('SIGTERM', handleSignal);
+      process.removeListener('SIGINT', handleSigint);
+      process.removeListener('SIGTERM', handleSigterm);
     },
     get exited() {
       return exited;

--- a/scripts/e2e/live.mjs
+++ b/scripts/e2e/live.mjs
@@ -4,14 +4,15 @@
  *
  * Exits: 0=all passed, 1=one or more checks failed
  */
-import { spawn } from 'node:child_process';
+import { spawnTrackedProcess } from './harness.mjs';
 import { createInterface } from 'node:readline';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
-import { dirname } from 'node:path';
+import { dirname, resolve } from 'node:path';
 import crypto from 'node:crypto';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..', '..');
 const CMD_TIMEOUT = 45_000;
 const BRIDGE_MAX_WAIT_S = 120;
 
@@ -81,11 +82,9 @@ async function main() {
   // ── Step 1: Start MCP server ───────────────────────────────────────────
   console.log('\u2500\u2500 [1/7] Start MCP Server & Connect Bridge \u2500\u2500\n');
 
-  const server = spawn('node', ['dist/index.js'], {
-    cwd: __dirname,
-    stdio: ['pipe', 'pipe', 'pipe'],
+  const serverProcess = spawnTrackedProcess('node', ['dist/index.js'], {
+    cwd: repoRoot,
     env: {
-      ...process.env,
       TRANSPORT: 'stdio',
       LOG_LEVEL: 'silent',
       TOOL_PROFILE: 'full',
@@ -94,6 +93,7 @@ async function main() {
       BRIDGE_TIMEOUT_MS: '30000',
     },
   });
+  const server = serverProcess.child;
 
   serverStdin = server.stdin;
   let serverExited = false;
@@ -125,15 +125,8 @@ async function main() {
   });
 
   function shutdown(label) {
-    try {
-      server.stdin.end();
-    } catch {}
-    setTimeout(() => {
-      try {
-        server.kill('SIGKILL');
-      } catch {}
-    }, 1000);
-    if (label) console.log(`  \ud83d\udd0c Shutdown: ${label}`);
+    serverProcess.shutdown(label);
+    serverProcess.detach();
   }
 
   await wait(2000);

--- a/scripts/e2e/waiter.mjs
+++ b/scripts/e2e/waiter.mjs
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process';
+import { spawnTrackedProcess } from './harness.mjs';
 import { Socket } from 'net';
 import { setTimeout as sleep } from 'timers/promises';
 
@@ -9,15 +9,11 @@ const POLL_INTERVAL = 5000;
 console.log('Process started at', new Date().toISOString());
 
 console.log('=== Starting MCP Server ===');
-const server = spawn('node', ['dist/index.js'], {
-  env: { ...process.env, LOG_LEVEL: 'info' },
-  stdio: ['pipe', 'pipe', 'pipe'],
+const serverProcess = spawnTrackedProcess('node', ['dist/index.js'], {
+  env: { LOG_LEVEL: 'info' },
 });
-
-let srvBuf = '';
-server.stdout.on('data', (d) => (srvBuf += d.toString()));
-server.stderr.on('data', (d) => (srvBuf += d.toString()));
-server.on('exit', (c) => console.log(`Server exited code=${c}`));
+const server = serverProcess.child;
+server.on('exit', (code) => console.log('Server exited code=' + code));
 
 await sleep(3000);
 
@@ -180,11 +176,12 @@ if (connected) {
 
 // Final output
 console.log('\n=== Server Logs ===');
-console.log(srvBuf.slice(-3000));
+console.log((serverProcess.stdoutLog + serverProcess.stderrLog).slice(-3000));
 
 console.log('\n=== Raw Buffer (last 2000) ===');
 console.log(buf.slice(-2000));
 
 sock.destroy();
-server.kill();
+serverProcess.shutdown('waiter complete');
+serverProcess.detach();
 process.exit(connected ? 0 : 1);


### PR DESCRIPTION
## Summary
- Adds `scripts/e2e/harness.mjs` as the single shared child-process / stdio JSON-RPC harness for live helper scripts.
- Refactors `diag.mjs` to use the shared stdio MCP harness instead of hand-rolled pending request and shutdown logic.
- Refactors `waiter.mjs` and `live.mjs` to use shared tracked process shutdown instead of direct spawn/kill lifecycle management.
- Removes delayed `setTimeout(...SIGKILL...)` shutdown races from the live helper scripts.
- Documents the dev bridge workflow and cleanup expectations in `scripts/e2e/README.md`.

Closes #174.

## Validation
- `pnpm exec prettier --write scripts/e2e/README.md scripts/e2e/harness.mjs scripts/e2e/diag.mjs scripts/e2e/waiter.mjs scripts/e2e/live.mjs`
- `node --check scripts/e2e/harness.mjs`
- `pnpm exec eslint scripts/e2e/harness.mjs scripts/e2e/diag.mjs scripts/e2e/waiter.mjs scripts/e2e/live.mjs` (files are ignored by project config; command exits 0)
- `pnpm exec tsc --noEmit`

## Notes
- These helpers are maintainer/dev-only live diagnostics. They do not affect normal MCP client startup for end users.
- `http.mjs` does not spawn a child MCP server and is intentionally unchanged.
