### PR TITLE
docs: align baseline tool counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,13 +712,16 @@ cp .env.example .env
 # All quality gates (lint + format + typecheck + test + build)
 task verify
 
-# Or use pnpm directly:
+# CI-equivalent fallback when Go Task is unavailable:
+pnpm format:check && pnpm typecheck && pnpm typecheck:extension && pnpm lint && pnpm lint:tools && pnpm verify:tool-coverage && pnpm test && pnpm build && pnpm build:extension && pnpm check:metadata && pnpm docs:build
+
+# Or use pnpm directly for focused checks:
 pnpm format:check          # Prettier
 pnpm typecheck             # TypeScript
 pnpm lint                  # ESLint
 
 # Test
-pnpm test                  # Vitest (804 tests across 66 files)
+pnpm test                  # Vitest (812 tests across 67 files)
 pnpm test:coverage         # With coverage report
 
 # Golden E2E fixture smoke tests are included in `pnpm test`

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -107,11 +107,11 @@ Tools are organized into hierarchical profiles: `core` < `pro` < `full` < `dev` 
 - The `TOOL_PROFILE` environment variable selects which tools are enabled.
 - Each tool definition declares a minimum `profile` level.
 - Only tools at or below the active profile are registered on the MCP server.
-- `core` is the default and exposes 42 tools.
-- `pro` exposes 47 tools and adds manufacturing export tools (pick-and-place, PDF, netlist).
-- `full` exposes 56 tools and adds the controlled `easyeda_api_call` tool for direct EasyEDA API access.
-- `dev` exposes 60 tools and adds runtime probes for debugging (bridge method probing, component inspection).
-- `experimental` enables MCP Apps, Tasks, simulation, autorouter, and AI action plans.
+- `core` is the default and exposes 44 tools.
+- `pro` exposes 49 tools and adds manufacturing export tools (pick-and-place, PDF, netlist).
+- `full` exposes 58 tools and adds the controlled `easyeda_api_call` tool for direct EasyEDA API access.
+- `dev` exposes 62 tools and adds runtime probes for debugging (bridge method probing, component inspection).
+- `experimental` is reserved for future MCP Apps, Tasks, simulation, autorouter, and AI action plan capabilities; it currently does not add registered tools beyond `dev`.
 
 **Security principle:** Privilege escalation is prevented because tool registration happens at startup. Changing the active profile requires a server restart.
 


### PR DESCRIPTION
## Summary
- update security architecture profile counts to the current generated tool metadata
- document a pnpm-based CI-equivalent quality fallback for environments without Go Task
- refresh README test count wording

## Validation
- pnpm format:check
- pnpm typecheck
- pnpm typecheck:extension
- pnpm lint
- pnpm lint:tools
- pnpm verify:tool-coverage
- pnpm test
- pnpm build
- pnpm build:extension
- pnpm check:metadata
- pnpm docs:build