### PR TITLE
chore: add pnpm verify script

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,12 +710,12 @@ pnpm install
 cp .env.example .env
 
 # All quality gates (lint + format + typecheck + test + build)
+pnpm verify
+
+# Or, if you use Go Task:
 task verify
 
-# CI-equivalent fallback when Go Task is unavailable:
-pnpm format:check && pnpm typecheck && pnpm typecheck:extension && pnpm lint && pnpm lint:tools && pnpm verify:tool-coverage && pnpm test && pnpm build && pnpm build:extension && pnpm check:metadata && pnpm docs:build
-
-# Or use pnpm directly for focused checks:
+# Use focused checks while iterating:
 pnpm format:check          # Prettier
 pnpm typecheck             # TypeScript
 pnpm lint                  # ESLint
@@ -742,15 +742,17 @@ pnpm inspector
 
 This project includes a `Taskfile.yml` with the following commands:
 
-| Command          | Description                     |
-| ---------------- | ------------------------------- |
-| `task install`   | Install dependencies            |
-| `task lint`      | Run ESLint                      |
-| `task format`    | Check formatting with Prettier  |
-| `task typecheck` | Run TypeScript type checking    |
-| `task test`      | Run tests                       |
-| `task build`     | Build the project               |
-| `task verify`    | Run all quality gates (CI gate) |
+| Command          | Description                        |
+| ---------------- | ---------------------------------- |
+| `task install`   | Install dependencies               |
+| `task lint`      | Run ESLint                         |
+| `task format`    | Check formatting with Prettier     |
+| `task typecheck` | Run TypeScript type checking       |
+| `task test`      | Run tests                          |
+| `task build`     | Build the project                  |
+| `task verify`    | Run all quality gates via Taskfile |
+
+The package also exposes `pnpm verify`, which runs the same CI-equivalent local gate without requiring Go Task.
 
 Install [Go Task](https://taskfile.dev/installation/) to use these commands.
 

--- a/package.json
+++ b/package.json
@@ -73,7 +73,8 @@
     "inventory:capture": "tsx scripts/capture-runtime-inventory.mts",
     "inventory:diff": "tsx scripts/diff-runtime-inventory.mts",
     "eval:golden": "tsx scripts/run-evals.mts",
-    "eval:golden:update": "tsx scripts/run-evals.mts --update-baseline"
+    "eval:golden:update": "tsx scripts/run-evals.mts --update-baseline",
+    "verify": "pnpm format:check && pnpm typecheck && pnpm typecheck:extension && pnpm lint && pnpm lint:tools && pnpm verify:tool-coverage && pnpm test && pnpm build && pnpm build:extension && pnpm check:metadata && pnpm docs:build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary
- add a package-level pnpm verify script for environments without Go Task
- make README recommend pnpm verify as the default local quality gate
- keep task verify documented as the optional Taskfile path

## Validation
- pnpm format:check
- pnpm typecheck
- pnpm typecheck:extension
- pnpm lint
- pnpm lint:tools
- pnpm verify:tool-coverage
- pnpm exec vitest run
- pnpm build
- pnpm build:extension

Note: direct pnpm verify, check:metadata, and docs:build invocations were blocked by the remote exec safety layer in this session; CI will run the full workflow.