### PR TITLE
feat(vendors): fix and expand keyless LCSC sourcing tier

### DIFF
--- a/docs/examples/bom-sourcing.md
+++ b/docs/examples/bom-sourcing.md
@@ -55,29 +55,53 @@ Check if the LCSC parts specified in your design are active, in stock, or obsole
 
 ### 3. Query Real-Time Pricing and Sourcing
 
-Fetch current pricing tiers for assembly budgeting:
+Fetch current pricing and stock for BOM parts. With an empty `.env`, this works out of
+the box: LCSC parts are resolved through the keyless jlcsearch tier
+(`KEYLESS_SOURCING_ENABLED=true` by default), no credentials required.
 
 **MCP Call**:
-`easyeda_bom_sourcing` with LCSC part numbers.
+`easyeda_bom_sourcing` with a `projectId` (an optional `suppliers` filter restricts which
+suppliers are tried; omit it to try every configured supplier).
 
 **Sourcing Output**:
 
 ```json
 {
-  "parts": {
-    "C19702": {
-      "stock": 45000,
-      "priceTiers": [
-        { "minQty": 10, "price": 0.012 },
-        { "minQty": 100, "price": 0.008 }
-      ],
-      "status": "active"
+  "project_id": "proj-123",
+  "parts": [
+    {
+      "reference": "R1",
+      "value": "10k",
+      "lcsc": "C25804",
+      "sourcing": [
+        {
+          "supplier": "lcsc",
+          "tier": "keyless",
+          "in_stock": true,
+          "quantity_available": 37165617,
+          "unit_price": 0.000842857,
+          "currency": "USD",
+          "classification": "basic",
+          "from_cache": false,
+          "cache_age_seconds": 0
+        }
+      ]
     }
-  }
+  ],
+  "total_parts": 1,
+  "keyless_sourcing_enabled": true
 }
 ```
 
-If a part is out of stock, the assistant can query `lib_recommend_part` or search LCSC using keywords to propose pin-compatible alternates.
+`tier` reports which provider answered: `keyless` (public jlcsearch data, no
+credentials) or `authenticated` (Mouser/DigiKey, requires API credentials).
+`classification` reports LCSC/JLCPCB assembly status (`basic`, `preferred`, `extended`)
+when the source provides it. A part missing from the sourcing array means no configured
+supplier had it in stock in the queried tier — the keyless tier only sees each
+category's top in-stock snapshot, so a low-stock or obscure part may need an
+authenticated supplier or manual lookup. If a part is out of stock, the assistant can
+query `lib_recommend_part` or search LCSC using keywords to propose pin-compatible
+alternates.
 
 ---
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -364,6 +364,7 @@ Returns a JSON object matching the schema:
   project_id: any;
   parts: any;
   total_parts: any;
+  keyless_sourcing_enabled: any;
   not_available: any;
 }
 ```
@@ -1813,6 +1814,7 @@ Returns a JSON object matching the schema:
 {
   devices: any;
   total: any;
+  provider_tier: any;
   not_available: any;
   error: any;
 }

--- a/docs/vendor-api-hardening.md
+++ b/docs/vendor-api-hardening.md
@@ -4,12 +4,48 @@ EasyEDA MCP Pro treats supplier and fabrication integrations as optional externa
 
 ## Supported integrations
 
-| Vendor           | Purpose                                             | Required credentials                                                          | Default state                         | Notes                                                                               |
-| ---------------- | --------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------- | ----------------------------------------------------------------------------------- |
-| LCSC / jlcsearch | Component lookup, stock, price hints                | None for public jlcsearch; optional LCSC API key for official fallback        | Enabled when `JLCSEARCH_ENABLED=true` | Public search can be unavailable or incomplete.                                     |
-| Mouser           | Component search by MPN, stock, price hints         | `MOUSER_API_KEY` when `MOUSER_ENABLED=true`                                   | Disabled                              | Returns no-match, unauthorized, rate-limited, or unavailable statuses.              |
-| DigiKey          | Component search by MPN/keyword, stock, price hints | `DIGIKEY_CLIENT_ID` and `DIGIKEY_CLIENT_SECRET` when `DIGIKEY_ENABLED=true`   | Disabled, sandbox by default          | OAuth token failures are degraded to unauthorized/unavailable sourcing results.     |
-| JLCPCB           | Fabrication quote/capability/order APIs             | `JLCPCB_CLIENT_ID` and `JLCPCB_CLIENT_SECRET` when `JLCPCB_MODE=approved_api` | Disabled                              | Order placement remains separately gated by ordering flags and confirmation policy. |
+| Vendor           | Purpose                                             | Required credentials                                                          | Default state                                                             | Notes                                                                               |
+| ---------------- | --------------------------------------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| LCSC / jlcsearch | Component lookup, stock, price, attributes          | None for public jlcsearch; optional LCSC API key for official fallback        | Enabled when `JLCSEARCH_ENABLED=true` and `KEYLESS_SOURCING_ENABLED=true` | Keyless tier only; category-scoped, in-stock-first snapshot (see below).            |
+| Mouser           | Component search by MPN, stock, price hints         | `MOUSER_API_KEY` when `MOUSER_ENABLED=true`                                   | Disabled                                                                  | Returns no-match, unauthorized, rate-limited, or unavailable statuses.              |
+| DigiKey          | Component search by MPN/keyword, stock, price hints | `DIGIKEY_CLIENT_ID` and `DIGIKEY_CLIENT_SECRET` when `DIGIKEY_ENABLED=true`   | Disabled, sandbox by default                                              | OAuth token failures are degraded to unauthorized/unavailable sourcing results.     |
+| JLCPCB           | Fabrication quote/capability/order APIs             | `JLCPCB_CLIENT_ID` and `JLCPCB_CLIENT_SECRET` when `JLCPCB_MODE=approved_api` | Disabled                                                                  | Order placement remains separately gated by ordering flags and confirmation policy. |
+
+## Keyless sourcing tier (LCSC / jlcsearch)
+
+`KEYLESS_SOURCING_ENABLED` (default `true`) governs whether sourcing tools attempt the
+keyless LCSC tier. `JLCSEARCH_ENABLED` (default `true`) governs whether the underlying
+LCSC client is constructed at all; both must be true for keyless LCSC lookups to run.
+
+The public jlcsearch API (`https://jlcsearch.tscircuit.com`) is a set of per-category
+snapshots, not a general-purpose search engine:
+
+- Each category (`resistors`, `capacitors`, `diodes`, `mosfets`, `leds`,
+  `microcontrollers`, `switches`, `led_drivers`) is served from its own
+  `/{category}/list.json` endpoint and returns only the ~100 highest-stock parts in
+  that category.
+- There is no generic cross-category full-text search and no single-part lookup
+  endpoint. `easyeda_bom_sourcing`'s keyless candidates are derived by matching
+  keywords/packages to a category and, for `getPartDetail`, scanning the cached
+  per-category snapshots for a matching LCSC id.
+- **Known limitation**: a part outside the top in-stock snapshot for its category will
+  not be found via the keyless tier, even though it exists at LCSC. This is a property
+  of the public dataset, not a bug — it is why supplier data remains advisory (see
+  `docs/vendor-terms.md`).
+- Each result reports `classification` (`basic` / `preferred` / `extended`, LCSC/JLCPCB
+  assembly terms) and `attributes` (parametric key/value pairs) when the source
+  provides them.
+
+Category responses are cached under `${CACHE_DIR}/vendors` for `SOURCING_CACHE_TTL_SECONDS`
+(default 6 hours) to reduce load on the public endpoint. Outbound vendor requests are
+additionally throttled per-hostname by `VENDOR_MIN_REQUEST_INTERVAL_MS` (default 150ms).
+Sourcing results report `from_cache` / `cache_age_seconds` so callers can tell live data
+from a cached snapshot.
+
+`easyeda_bom_sourcing` and `easyeda_bom_quality_report` unify keyless (LCSC) and
+authenticated (Mouser, DigiKey) suppliers behind `src/vendors/sourcing-facade.ts` /
+`src/bom-quality/adapter.ts`; each sourcing result reports which `tier` (`keyless` or
+`authenticated`) answered.
 
 ## Normalized supplier statuses
 
@@ -39,7 +75,11 @@ Every `easyeda_bom_quality_report` supplier datum includes:
 - optional `reason`
 - optional `status_code`
 
-The current implementation returns live data with `from_cache=false` and `cache_age_seconds=0`. The fields are present now so future cache implementations can preserve a stable response contract.
+LCSC keyless-tier lookups populate real `from_cache` / `cache_age_seconds` values once a
+category snapshot has been cached (see "Keyless sourcing tier" above). Mouser and
+DigiKey queries are not yet cached and always report `from_cache=false` /
+`cache_age_seconds=0`; the fields remain present for a stable response contract as that
+caching is added.
 
 ## Credential diagnostics
 

--- a/docs/vendor-terms.md
+++ b/docs/vendor-terms.md
@@ -18,7 +18,7 @@ This page records the compliance posture for integrations used by `easyeda-mcp-p
 1. The MCP server may read local EasyEDA project data only through the user's local EasyEDA Pro session and bridge extension.
 2. Supplier data is advisory. Stock, price, lifecycle, and replacement information must be rechecked with the vendor before ordering or manufacturing handoff.
 3. Ordering is disabled by default. Any quote/order workflow must be non-binding unless the user configures approved credentials and explicitly confirms the action.
-4. The project must not redistribute vendor catalogs, pricing databases, datasheet archives, proprietary EasyEDA runtime files, or private user designs.
+4. The project must not redistribute vendor catalogs, pricing databases, datasheet archives, proprietary EasyEDA runtime files, or private user designs. The keyless jlcsearch tier (`KEYLESS_SOURCING_ENABLED`) reads the public, unofficial in-stock parts snapshot described in `docs/vendor-api-hardening.md`; it is read-only, per-hostname rate-limited, and locally cached under `CACHE_DIR`, never committed or redistributed.
 5. The project must not imply vendor endorsement or partnership without explicit permission.
 6. Credentials must be supplied by the user through environment variables or the host secret store and must never be committed, logged, included in artifacts, or returned by MCP tools.
 7. Human review remains mandatory before fabrication, assembly, paid quotes, component substitution, or ordering.

--- a/src/bom-quality/adapter.ts
+++ b/src/bom-quality/adapter.ts
@@ -252,8 +252,11 @@ export class LcscAdapter implements SupplierAdapter {
       unitPrice,
       currency: 'USD',
       leadTimeDays: detail.leadTime,
+      classification: detail.classification,
       queriedAt: now,
-      ...freshProvenance('lcsc'),
+      source: supplierSource('lcsc'),
+      cacheAgeSeconds: detail.fromCache ? (detail.cacheAgeSeconds ?? 0) : 0,
+      fromCache: detail.fromCache ?? false,
       confidence: 'high',
     };
   }

--- a/src/bom-quality/types.ts
+++ b/src/bom-quality/types.ts
@@ -56,6 +56,8 @@ export interface SupplierQueryResult {
   unitPrice?: number;
   currency?: string;
   leadTimeDays?: number;
+  /** Supplier-specific assembly classification (e.g. LCSC/JLCPCB basic/preferred/extended). */
+  classification?: string;
   /** ISO-8601 timestamp of this supplier response. */
   queriedAt: string;
   /** Data source endpoint or integration family used for provenance. */

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -67,6 +67,10 @@ export const EnvSchema = z.object({
   LCSC_API_KEY: z.string().default(''),
   LCSC_API_SECRET: z.string().default(''),
 
+  KEYLESS_SOURCING_ENABLED: envBoolean().default(true),
+  SOURCING_CACHE_TTL_SECONDS: z.coerce.number().int().min(0).max(604800).default(21600),
+  VENDOR_MIN_REQUEST_INTERVAL_MS: z.coerce.number().int().min(0).max(10000).default(150),
+
   MOUSER_ENABLED: envBoolean().default(false),
   MOUSER_API_KEY: z.string().default(''),
   MOUSER_API_BASE_URL: z.string().default('https://api.mouser.com'),
@@ -112,6 +116,9 @@ const PROJECT_VAR_PREFIXES = [
   'JLCPCB_',
   'JLCSEARCH_',
   'LCSC_',
+  'KEYLESS_',
+  'SOURCING_',
+  'VENDOR_',
   'MOUSER_',
   'DIGIKEY_',
   'OAUTH_',

--- a/src/server/factory.ts
+++ b/src/server/factory.ts
@@ -19,6 +19,8 @@ import { LcscClient } from '../vendors/lcsc/client.js';
 import { JlcpcbClient } from '../vendors/jlcpcb/client.js';
 import { MouserClient } from '../vendors/mouser/client.js';
 import { DigiKeyClient } from '../vendors/digikey/client.js';
+import { createFileVendorCache } from '../vendors/cache.js';
+import { configureVendorRateLimit } from '../vendors/base-http-client.js';
 
 export interface McpServerInstance {
   server: McpServer;
@@ -67,7 +69,10 @@ export async function createServer(config: EnvConfig): Promise<McpServerInstance
   registry.setProfile(config.TOOL_PROFILE as ToolProfile);
   registerBuiltinTools(registry, config);
 
-  const lcscClient = config.JLCSEARCH_ENABLED ? new LcscClient(config) : null;
+  configureVendorRateLimit(config.VENDOR_MIN_REQUEST_INTERVAL_MS);
+  const vendorCache = createFileVendorCache(config.CACHE_DIR);
+
+  const lcscClient = config.JLCSEARCH_ENABLED ? new LcscClient(config, vendorCache) : null;
   const jlcClient = config.JLCPCB_MODE === 'approved_api' ? new JlcpcbClient(config) : null;
   const mouserClient = config.MOUSER_ENABLED ? new MouserClient(config) : null;
   const digikeyClient = config.DIGIKEY_ENABLED ? new DigiKeyClient(config) : null;
@@ -88,6 +93,7 @@ export async function createServer(config: EnvConfig): Promise<McpServerInstance
       artifactDir: config.ARTIFACT_DIR,
       bridgeHost: config.BRIDGE_HOST,
       bridgePort: config.BRIDGE_PORT,
+      keylessSourcingEnabled: config.KEYLESS_SOURCING_ENABLED,
     },
     vendors: {
       lcsc: lcscClient,

--- a/src/tools/L1_bom_sourcing.ts
+++ b/src/tools/L1_bom_sourcing.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_BOM_QUALITY_CONFIG,
 } from '../bom-quality/index.js';
 import type { BomQualityConfig } from '../bom-quality/types.js';
+import { resolvePartSourcing } from '../vendors/sourcing-facade.js';
 
 function registerBomSourcingTools(
   registry: { register: (def: ToolDefinition) => void },
@@ -41,23 +42,29 @@ function registerBomSourcingTools(
           sourcing: z.array(
             z.object({
               supplier: z.string(),
+              tier: z.enum(['keyless', 'authenticated']),
               in_stock: z.boolean(),
               quantity_available: z.number().int().nonnegative().optional(),
               unit_price: z.number().nonnegative().optional(),
               currency: z.string().optional(),
               lead_time_days: z.number().int().nonnegative().optional(),
+              classification: z.string().optional(),
+              from_cache: z.boolean().optional(),
+              cache_age_seconds: z.number().int().nonnegative().optional(),
             }),
           ),
         }),
       ),
       total_parts: z.number().int().nonnegative(),
+      keyless_sourcing_enabled: z.boolean().optional(),
       not_available: z.boolean().optional(),
     }),
     handler: async (ctx: ToolContext, params: unknown) => {
-      const { projectId, suppliers = ['lcsc'] } = params as {
+      const { projectId, suppliers } = params as {
         projectId: string;
         suppliers?: string[];
       };
+      const keylessSourcingEnabled = ctx.config.keylessSourcingEnabled ?? true;
       try {
         const bomResult = await ctx.bridge.call('bom.generate', {
           projectId,
@@ -77,40 +84,42 @@ function registerBomSourcingTools(
 
         const parts = await Promise.allSettled(
           bomEntries.map(async (entry) => {
-            const sourcing: Array<{
+            let sourcing: Array<{
               supplier: string;
+              tier: 'keyless' | 'authenticated';
               in_stock: boolean;
               quantity_available?: number;
               unit_price?: number;
               currency?: string;
               lead_time_days?: number;
+              classification?: string;
+              from_cache?: boolean;
+              cache_age_seconds?: number;
             }> = [];
 
-            if (suppliers.includes('lcsc') && ctx.vendors.lcsc && entry.lcsc) {
-              try {
-                const detail = await ctx.vendors.lcsc.getPartDetail(entry.lcsc);
-                if (detail) {
-                  const rawDetail = detail as unknown as Record<string, unknown>;
-                  sourcing.push({
-                    supplier: 'lcsc',
-                    in_stock: (detail.stockCount ?? detail.stock ?? 0) > 0,
-                    quantity_available: detail.stockCount ?? detail.stock,
-                    unit_price:
-                      (rawDetail.priceBreaks as Array<{ unitPrice?: number }> | undefined)?.[0]
-                        ?.unitPrice ??
-                      (typeof rawDetail.price === 'number'
-                        ? rawDetail.price
-                        : typeof rawDetail.price === 'string'
-                          ? parseFloat(rawDetail.price)
-                          : undefined),
-                    currency: 'USD',
-                    lead_time_days: detail.leadTime,
-                  });
-                }
-                // eslint-disable-next-line @typescript-eslint/no-unused-vars
-              } catch (_err) {
-                // ignore and continue
-              }
+            try {
+              const results = await resolvePartSourcing(
+                ctx.vendors,
+                { lcsc: entry.lcsc },
+                { suppliers, keylessSourcingEnabled },
+              );
+              sourcing = results
+                .filter((r) => r.found)
+                .map((r) => ({
+                  supplier: r.supplier,
+                  tier: r.tier,
+                  in_stock: r.in_stock,
+                  quantity_available: r.quantity_available,
+                  unit_price: r.unit_price,
+                  currency: r.currency,
+                  lead_time_days: r.lead_time_days,
+                  classification: r.classification,
+                  from_cache: r.from_cache,
+                  cache_age_seconds: r.cache_age_seconds,
+                }));
+              // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            } catch (_err) {
+              // ignore and continue with no sourcing data for this entry
             }
 
             return {
@@ -128,6 +137,7 @@ function registerBomSourcingTools(
             r.status === 'fulfilled' ? r.value : { reference: '', value: '', sourcing: [] },
           ),
           total_parts: bomEntries.length,
+          keyless_sourcing_enabled: keylessSourcingEnabled,
         };
       } catch (err) {
         return {

--- a/src/tools/L1_schematic_read.ts
+++ b/src/tools/L1_schematic_read.ts
@@ -338,6 +338,9 @@ function registerSchematicReadTools(
           .passthrough(),
       ),
       total: z.number().int().nonnegative(),
+      /** Where the result came from. Always 'local_library' — this tool queries the
+       *  active EasyEDA Pro session's device library, not vendor/supplier catalogs. */
+      provider_tier: z.literal('local_library').optional(),
       not_available: z.boolean().optional(),
       error: z.string().optional(),
     }),
@@ -357,6 +360,7 @@ function registerSchematicReadTools(
         return {
           devices,
           total: devices.length,
+          provider_tier: 'local_library' as const,
         };
       } catch (err) {
         return {

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -78,6 +78,7 @@ export interface ToolContext {
     artifactDir: string;
     bridgeHost: string;
     bridgePort: number;
+    keylessSourcingEnabled?: boolean;
     [key: string]: unknown;
   };
   vendors: {

--- a/src/vendors/base-http-client.ts
+++ b/src/vendors/base-http-client.ts
@@ -11,6 +11,37 @@ export const DEFAULT_BASE_DELAY_MS = 1000;
 /** Default timeout for HTTP requests (30 seconds). */
 export const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
+let vendorMinIntervalMs = 0;
+const lastRequestAtByHost = new Map<string, number>();
+
+/**
+ * Configure the minimum interval between outbound requests to the same
+ * vendor hostname. Applied by {@link httpRequestWithRetry} before every
+ * attempt (including retries). Set to 0 to disable rate limiting.
+ */
+export function configureVendorRateLimit(minIntervalMs: number): void {
+  vendorMinIntervalMs = Math.max(0, minIntervalMs);
+}
+
+/** Test-only: reset rate limiter state between test cases. */
+export function resetVendorRateLimitStateForTests(): void {
+  lastRequestAtByHost.clear();
+  vendorMinIntervalMs = 0;
+}
+
+async function waitForVendorRateLimit(hostname: string): Promise<void> {
+  if (vendorMinIntervalMs <= 0) return;
+  const last = lastRequestAtByHost.get(hostname);
+  const now = Date.now();
+  if (last !== undefined) {
+    const elapsed = now - last;
+    if (elapsed < vendorMinIntervalMs) {
+      await new Promise((resolve) => setTimeout(resolve, vendorMinIntervalMs - elapsed));
+    }
+  }
+  lastRequestAtByHost.set(hostname, Date.now());
+}
+
 /**
  * Read the entire body of a readable stream and return it as a UTF-8 string.
  * Works with both Buffer and string chunks.
@@ -75,6 +106,7 @@ export async function httpRequestWithRetry(
   for (let attempt = 1; attempt <= maxRetries + 1; attempt++) {
     try {
       logger.debug({ url, method, attempt }, 'http request');
+      await waitForVendorRateLimit(vendorName);
 
       const { statusCode, body } = await request(url, {
         method,

--- a/src/vendors/cache.ts
+++ b/src/vendors/cache.ts
@@ -1,0 +1,82 @@
+/**
+ * Vendor response cache — a small file-based TTL cache shared by vendor
+ * clients so repeated lookups (e.g. category snapshots) avoid re-hitting
+ * rate-limited public APIs.
+ *
+ * @module
+ */
+
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { createHash } from 'node:crypto';
+
+export interface CacheReadResult<T> {
+  value: T;
+  storedAt: number;
+}
+
+export interface VendorCache {
+  get<T>(key: string): Promise<CacheReadResult<T> | null>;
+  set<T>(key: string, value: T, ttlSeconds: number): Promise<void>;
+}
+
+/** Build a stable cache key from an ordered list of key parts. */
+export function cacheKey(parts: Array<string | number | Record<string, unknown>>): string {
+  const stable = parts
+    .map((part) => (typeof part === 'object' ? stableStringify(part) : String(part)))
+    .join('|');
+  return createHash('sha256').update(stable).digest('hex');
+}
+
+function stableStringify(obj: Record<string, unknown>): string {
+  const sortedKeys = Object.keys(obj).sort();
+  const sorted: Record<string, unknown> = {};
+  for (const key of sortedKeys) sorted[key] = obj[key];
+  return JSON.stringify(sorted);
+}
+
+/** A cache that never stores or returns anything. Safe default for callers that opt out. */
+export function createNoopVendorCache(): VendorCache {
+  return {
+    async get() {
+      return null;
+    },
+    async set() {
+      // no-op
+    },
+  };
+}
+
+interface CacheEntry<T> {
+  value: T;
+  storedAt: number;
+  ttlSeconds: number;
+}
+
+/** A file-based TTL cache rooted at `${cacheDir}/vendors`. Failures are swallowed — caching is best-effort. */
+export function createFileVendorCache(cacheDir: string): VendorCache {
+  const dir = path.join(cacheDir, 'vendors');
+
+  return {
+    async get<T>(key: string): Promise<CacheReadResult<T> | null> {
+      try {
+        const raw = await fs.readFile(path.join(dir, `${key}.json`), 'utf-8');
+        const entry = JSON.parse(raw) as CacheEntry<T>;
+        const ageSeconds = (Date.now() - entry.storedAt) / 1000;
+        if (ageSeconds > entry.ttlSeconds) return null;
+        return { value: entry.value, storedAt: entry.storedAt };
+      } catch {
+        return null;
+      }
+    },
+    async set<T>(key: string, value: T, ttlSeconds: number): Promise<void> {
+      try {
+        await fs.mkdir(dir, { recursive: true });
+        const entry: CacheEntry<T> = { value, storedAt: Date.now(), ttlSeconds };
+        await fs.writeFile(path.join(dir, `${key}.json`), JSON.stringify(entry), 'utf-8');
+      } catch {
+        // best-effort cache; write failures must never break a vendor call
+      }
+    },
+  };
+}

--- a/src/vendors/lcsc/client.ts
+++ b/src/vendors/lcsc/client.ts
@@ -3,6 +3,31 @@ import { EasyEdaMcpError } from '../../schemas/common.js';
 import { getLogger } from '../../utils/logger.js';
 import type pino from 'pino';
 import { httpRequestWithRetry, DEFAULT_REQUEST_TIMEOUT_MS } from '../base-http-client.js';
+import { type VendorCache, createNoopVendorCache, cacheKey } from '../cache.js';
+
+/**
+ * Component categories exposed by the public jlcsearch API
+ * (https://jlcsearch.tscircuit.com), each backed by its own
+ * `/{category}/list.json` endpoint. There is no generic cross-category
+ * full-text search or single-part lookup endpoint — every lookup is a
+ * category-scoped, in-stock-first snapshot capped at 100 results.
+ */
+export const LCSC_CATEGORIES = [
+  'resistors',
+  'capacitors',
+  'diodes',
+  'mosfets',
+  'leds',
+  'microcontrollers',
+  'switches',
+  'led_drivers',
+] as const;
+
+export type LcscCategory = (typeof LCSC_CATEGORIES)[number];
+
+export function isLcscCategory(value: string): value is LcscCategory {
+  return (LCSC_CATEGORIES as readonly string[]).includes(value);
+}
 
 export interface LcscPart {
   lcsc: string;
@@ -18,11 +43,102 @@ export interface LcscPart {
   leadTime?: number;
   discontinued?: boolean;
   priceBreaks?: Array<{ quantity?: number; unitPrice?: number }>;
+  /** LCSC/JLCPCB assembly classification, when the backing dataset exposes it. */
+  classification?: 'basic' | 'preferred' | 'extended';
+  /** Parametric attributes (e.g. Resistance, Tolerance) as reported by the source. */
+  attributes?: Record<string, string>;
+  /** Whether this result was served from the vendor cache. */
+  fromCache?: boolean;
+  /** Age of the cached data in seconds; 0 when live. */
+  cacheAgeSeconds?: number;
 }
 
 export interface LcscSearchResponse {
   parts: LcscPart[];
   total: number;
+  fromCache?: boolean;
+  cacheAgeSeconds?: number;
+}
+
+/** Raw shape of a single component as returned by a jlcsearch `list.json` endpoint. */
+interface RawJlcsearchComponent {
+  lcsc: number | string;
+  mfr?: string;
+  description?: string;
+  stock?: number;
+  price1?: number;
+  in_stock?: boolean;
+  package?: string;
+  is_basic?: boolean;
+  is_preferred?: boolean;
+  attributes?: string | Record<string, string>;
+  [key: string]: unknown;
+}
+
+interface CategoryFetchResult {
+  items: RawJlcsearchComponent[];
+  fromCache: boolean;
+  cacheAgeSeconds: number;
+}
+
+const CATEGORY_KEYWORDS: Record<LcscCategory, string[]> = {
+  resistors: ['resistor', 'resistors', 'ohm'],
+  capacitors: ['capacitor', 'capacitors', 'ceramic cap'],
+  diodes: ['diode', 'diodes', 'zener', 'schottky'],
+  mosfets: ['mosfet', 'mosfets', 'nmos', 'pmos'],
+  leds: ['led', 'leds', 'light emitting diode'],
+  microcontrollers: ['microcontroller', 'microcontrollers', 'mcu', 'esp32', 'stm32'],
+  switches: ['switch', 'switches', 'button', 'tactile'],
+  led_drivers: ['led driver', 'led-driver', 'led_driver', 'constant current driver'],
+};
+
+const PACKAGE_PATTERN =
+  /\b(0201|0402|0603|0805|1206|1210|SOT-?23\w*|SOD-?123\w*|TO-?\d+\w*|SOIC-?\d+\w*|QFN-?\d+\w*)\b/i;
+
+function normalizeLcscCode(raw: unknown): string {
+  const asString = String(raw);
+  const num = typeof raw === 'number' ? raw : parseInt(asString.replace(/^c/i, ''), 10);
+  return Number.isFinite(num) ? `C${num}` : asString;
+}
+
+function toRawLcscId(code: string): number | null {
+  const num = parseInt(code.replace(/^c/i, ''), 10);
+  return Number.isFinite(num) ? num : null;
+}
+
+function parseAttributes(raw: RawJlcsearchComponent['attributes']): Record<string, string> {
+  if (!raw) return {};
+  if (typeof raw === 'object') return raw;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === 'object' ? (parsed as Record<string, string>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function normalizeRawPart(raw: RawJlcsearchComponent, category: LcscCategory): LcscPart {
+  const stock = typeof raw.stock === 'number' ? raw.stock : 0;
+  const classification: LcscPart['classification'] = raw.is_basic
+    ? 'basic'
+    : raw.is_preferred
+      ? 'preferred'
+      : 'extended';
+
+  return {
+    lcsc: normalizeLcscCode(raw.lcsc),
+    manufacturer: typeof raw.mfr === 'string' ? raw.mfr : '',
+    description: typeof raw.description === 'string' ? raw.description : '',
+    datasheet: '',
+    stock,
+    stockCount: stock,
+    price: raw.price1 !== undefined ? String(raw.price1) : '',
+    category,
+    package: typeof raw.package === 'string' ? raw.package : '',
+    inStock: typeof raw.in_stock === 'boolean' ? raw.in_stock : stock > 0,
+    classification,
+    attributes: parseAttributes(raw.attributes),
+  };
 }
 
 export class LcscClient {
@@ -30,12 +146,16 @@ export class LcscClient {
   private logger: pino.Logger;
   private jlcsearchBase: string;
   private lcscApiKey: string;
+  private cache: VendorCache;
+  private cacheTtlSeconds: number;
 
-  constructor(config: EnvConfig) {
+  constructor(config: EnvConfig, cache: VendorCache = createNoopVendorCache()) {
     this.config = config;
     this.logger = getLogger();
     this.jlcsearchBase = config.JLCSEARCH_BASE_URL.replace(/\/+$/, '');
     this.lcscApiKey = config.LCSC_API_KEY;
+    this.cache = cache;
+    this.cacheTtlSeconds = config.SOURCING_CACHE_TTL_SECONDS;
   }
 
   private async jlcsearchRequest<T>(
@@ -43,7 +163,13 @@ export class LcscClient {
     options: { method?: string; query?: Record<string, string> },
   ): Promise<T> {
     const method = options.method ?? 'GET';
-    const queryString = options.query ? '?' + new URLSearchParams(options.query).toString() : '';
+    const query = options.query
+      ? Object.fromEntries(
+          Object.entries(options.query).filter(([, v]) => v !== undefined && v !== ''),
+        )
+      : undefined;
+    const queryString =
+      query && Object.keys(query).length > 0 ? '?' + new URLSearchParams(query).toString() : '';
     const url = `${this.jlcsearchBase}${path}${queryString}`;
 
     const { statusCode, responseText } = await httpRequestWithRetry(
@@ -108,40 +234,122 @@ export class LcscClient {
     return JSON.parse(responseText) as T;
   }
 
+  /** Fetch one category's `list.json`, transparently caching the raw item list. */
+  private async fetchCategory(
+    category: LcscCategory,
+    query: Record<string, string>,
+  ): Promise<CategoryFetchResult> {
+    const key = this.cacheTtlSeconds > 0 ? cacheKey(['lcsc', category, query]) : undefined;
+
+    if (key) {
+      const cached = await this.cache.get<RawJlcsearchComponent[]>(key);
+      if (cached) {
+        return {
+          items: cached.value,
+          fromCache: true,
+          cacheAgeSeconds: Math.floor((Date.now() - cached.storedAt) / 1000),
+        };
+      }
+    }
+
+    const data = await this.jlcsearchRequest<Record<string, RawJlcsearchComponent[]>>(
+      `/${category}/list.json`,
+      { query },
+    );
+    const items = data[category] ?? [];
+
+    if (key) {
+      await this.cache.set(key, items, this.cacheTtlSeconds);
+    }
+
+    return { items, fromCache: false, cacheAgeSeconds: 0 };
+  }
+
   /**
-   * Search LCSC parts by keyword query.
-   * Uses the jlcsearch API as primary backend, falls back to LCSC official API if available.
-   * @param query - The search keyword
-   * @param options - Optional search configuration (limit, page)
-   * @returns Search results with parts list and total count
+   * Search a single known category with jlcsearch's native parametric filters
+   * (e.g. `package`, `resistance`, `capacitance`, `in_stock`).
+   */
+  async searchCategory(
+    category: LcscCategory,
+    filters: Record<string, string> = {},
+    options?: { limit?: number },
+  ): Promise<LcscSearchResponse> {
+    if (!isLcscCategory(category)) {
+      return { parts: [], total: 0, fromCache: false, cacheAgeSeconds: 0 };
+    }
+
+    const query: Record<string, string> = { ...filters };
+    if (options?.limit) query.limit = String(Math.min(options.limit, 100));
+
+    const { items, fromCache, cacheAgeSeconds } = await this.fetchCategory(category, query);
+    const parts = items.map((raw) => normalizeRawPart(raw, category));
+    return { parts, total: parts.length, fromCache, cacheAgeSeconds };
+  }
+
+  /**
+   * Best-effort keyword search. jlcsearch has no generic full-text search
+   * endpoint, so this maps recognizable keywords (resistor, mosfet, 0603, ...)
+   * to one or more category snapshots and filters them client-side. Queries
+   * that don't match a known category scan all categories with a small
+   * per-category limit.
    */
   async searchParts(
     query: string,
     options?: { limit?: number; page?: number },
   ): Promise<LcscSearchResponse> {
     const limit = options?.limit ?? 20;
-    const page = options?.page ?? 1;
+    const lower = query.toLowerCase().trim();
+    if (!lower) return { parts: [], total: 0, fromCache: false, cacheAgeSeconds: 0 };
+
+    const packageMatch = query.match(PACKAGE_PATTERN);
+    const filters: Record<string, string> = {};
+    if (packageMatch) filters.package = packageMatch[0].toUpperCase();
+
+    const matchedCategories = (Object.entries(CATEGORY_KEYWORDS) as Array<[LcscCategory, string[]]>)
+      .filter(([, keywords]) => keywords.some((k) => lower.includes(k)))
+      .map(([category]) => category);
+
+    const categoriesToScan = matchedCategories.length > 0 ? matchedCategories : LCSC_CATEGORIES;
+    const perCategoryLimit = matchedCategories.length > 0 ? Math.min(Math.max(limit, 20), 100) : 20;
 
     try {
-      const data = await this.jlcsearchRequest<{
-        results?: LcscPart[];
-        count?: number;
-        parts?: LcscPart[];
-        total?: number;
-      }>('/api/search', {
-        query: { keyword: query, limit: String(limit), page: String(page) },
-      });
+      const results = await Promise.all(
+        categoriesToScan.map((category) =>
+          this.searchCategory(category, filters, { limit: perCategoryLimit }),
+        ),
+      );
 
-      const parts = data.results ?? data.parts ?? [];
-      const total = data.count ?? data.total ?? parts.length;
+      let parts = results.flatMap((r) => r.parts);
 
-      return { parts, total };
+      if (matchedCategories.length === 0) {
+        const packageToken = packageMatch?.[0]?.toLowerCase();
+        const tokens = lower.split(/\s+/).filter((t) => t.length > 1 && t !== packageToken);
+        if (tokens.length > 0) {
+          parts = parts.filter((p) =>
+            tokens.some(
+              (t) =>
+                p.manufacturer.toLowerCase().includes(t) ||
+                p.description.toLowerCase().includes(t) ||
+                p.package.toLowerCase().includes(t),
+            ),
+          );
+        }
+      }
+
+      parts.sort((a, b) => (b.stockCount ?? 0) - (a.stockCount ?? 0));
+      const limited = parts.slice(0, limit);
+      const fromCache = results.length > 0 && results.every((r) => r.fromCache);
+      const cacheAgeSeconds = fromCache
+        ? Math.min(...results.map((r) => r.cacheAgeSeconds ?? 0))
+        : 0;
+
+      return { parts: limited, total: limited.length, fromCache, cacheAgeSeconds };
     } catch (err) {
       if (this.lcscApiKey) {
         this.logger.debug('jlcsearch failed, falling back to lcsc official api');
         return this.lcscOfficialRequest<LcscSearchResponse>('/search', {
           method: 'POST',
-          body: { keyword: query, limit, page },
+          body: { keyword: query, limit, page: options?.page ?? 1 },
         });
       }
       throw err;
@@ -150,50 +358,67 @@ export class LcscClient {
 
   /**
    * Get detailed information for a specific LCSC part by its LCSC code.
-   * @param lcscCode - The LCSC part number (e.g., "C12345")
-   * @returns The part detail or null if not found
+   *
+   * jlcsearch has no single-part lookup endpoint, so this scans the cached
+   * per-category snapshots (each capped at the top 100 in-stock parts) for a
+   * matching `lcsc` id. Parts outside that in-stock snapshot will not be
+   * found via the keyless tier even though they exist at LCSC — this is a
+   * known limitation of the public dataset, not a bug.
    */
   async getPartDetail(lcscCode: string): Promise<LcscPart | null> {
-    try {
-      const data = await this.jlcsearchRequest<{ part?: LcscPart } | LcscPart>(
-        `/api/part/${encodeURIComponent(lcscCode)}`,
-        {},
-      );
-      const part = 'part' in data ? data.part : (data as LcscPart);
-      return part ?? null;
-    } catch (err) {
-      if (this.lcscApiKey) {
-        this.logger.debug('jlcsearch failed, falling back to lcsc official api');
-        return this.lcscOfficialRequest<LcscPart | null>(
-          `/part/${encodeURIComponent(lcscCode)}`,
-          {},
-        );
-      }
-      throw err;
+    const numericId = toRawLcscId(lcscCode);
+    if (numericId === null) {
+      return this.lcscApiKey ? this.officialPartDetail(lcscCode) : null;
     }
+
+    const settled = await Promise.allSettled(
+      LCSC_CATEGORIES.map(async (category) => ({
+        category,
+        ...(await this.fetchCategory(category, { limit: '100' })),
+      })),
+    );
+
+    const successes = settled.filter(
+      (s): s is PromiseFulfilledResult<CategoryFetchResult & { category: LcscCategory }> =>
+        s.status === 'fulfilled',
+    );
+
+    for (const { value } of successes) {
+      const match = value.items.find((raw) => Number(raw.lcsc) === numericId);
+      if (match) {
+        return {
+          ...normalizeRawPart(match, value.category),
+          fromCache: value.fromCache,
+          cacheAgeSeconds: value.cacheAgeSeconds,
+        };
+      }
+    }
+
+    if (successes.length === 0) {
+      if (this.lcscApiKey) {
+        this.logger.debug('jlcsearch unavailable, falling back to lcsc official api');
+        return this.officialPartDetail(lcscCode);
+      }
+      throw new EasyEdaMcpError({
+        code: 'VENDOR_API_UNAVAILABLE',
+        message: 'LCSC jlcsearch API is unavailable across all categories',
+        suggestion: 'Check JLCSEARCH_BASE_URL and network connectivity, or configure LCSC_API_KEY.',
+        retryable: true,
+      });
+    }
+
+    // Categories were reachable but no match was found in the in-stock snapshot.
+    return null;
   }
 
-  /**
-   * Get parts by category from LCSC.
-   * @param category - The category name or ID
-   * @returns Array of parts in the category
-   */
+  private async officialPartDetail(lcscCode: string): Promise<LcscPart | null> {
+    return this.lcscOfficialRequest<LcscPart | null>(`/part/${encodeURIComponent(lcscCode)}`, {});
+  }
+
+  /** Get parts for a known category. Unknown categories return an empty list. */
   async getPartsByCategory(category: string): Promise<LcscPart[]> {
-    try {
-      const data = await this.jlcsearchRequest<{ parts?: LcscPart[]; results?: LcscPart[] }>(
-        `/api/categories/${encodeURIComponent(category)}/parts`,
-        {},
-      );
-      return data.parts ?? data.results ?? [];
-    } catch (err) {
-      if (this.lcscApiKey) {
-        this.logger.debug('jlcsearch failed, falling back to lcsc official api');
-        return this.lcscOfficialRequest<LcscPart[]>(
-          `/categories/${encodeURIComponent(category)}/parts`,
-          {},
-        );
-      }
-      throw err;
-    }
+    if (!isLcscCategory(category)) return [];
+    const { parts } = await this.searchCategory(category);
+    return parts;
   }
 }

--- a/src/vendors/sourcing-facade.ts
+++ b/src/vendors/sourcing-facade.ts
@@ -1,0 +1,97 @@
+/**
+ * Sourcing facade — a single entry point for tools to resolve part
+ * sourcing/pricing data across the keyless tier (LCSC via jlcsearch) and
+ * authenticated tiers (Mouser, DigiKey), reusing the {@link SupplierAdapter}
+ * normalization already built for BOM quality checks.
+ *
+ * @module
+ */
+
+import { type ToolContext } from '../tools/types.js';
+import { createAdapters } from '../bom-quality/adapter.js';
+import { type SupplierQueryResult } from '../bom-quality/types.js';
+
+export type SourcingTier = 'keyless' | 'authenticated';
+
+export interface SourcingIdentifier {
+  lcsc?: string;
+  mpn?: string;
+}
+
+export interface SourcingTierResult {
+  supplier: string;
+  tier: SourcingTier;
+  found: boolean;
+  in_stock: boolean;
+  quantity_available?: number;
+  unit_price?: number;
+  currency?: string;
+  lead_time_days?: number;
+  classification?: string;
+  status: string;
+  source: string;
+  from_cache: boolean;
+  cache_age_seconds: number;
+  reason?: string;
+}
+
+export interface ResolvePartSourcingOptions {
+  /** Restrict to these supplier keys (case-insensitive). Omit to try every configured supplier. */
+  suppliers?: string[];
+  /** Whether the keyless LCSC tier should be attempted. Defaults to true. */
+  keylessSourcingEnabled?: boolean;
+}
+
+function toTierResult(result: SupplierQueryResult, tier: SourcingTier): SourcingTierResult {
+  return {
+    supplier: result.supplier,
+    tier,
+    found: result.found,
+    in_stock: result.found && result.stock > 0,
+    quantity_available: result.found ? result.stock : undefined,
+    unit_price: result.unitPrice,
+    currency: result.currency,
+    lead_time_days: result.leadTimeDays,
+    classification: result.classification,
+    status: result.status,
+    source: result.source,
+    from_cache: result.fromCache,
+    cache_age_seconds: result.cacheAgeSeconds,
+    reason: result.reason,
+  };
+}
+
+/**
+ * Resolve sourcing/pricing data for a single part identifier across every
+ * configured, available supplier. LCSC is queried keyless-first via the
+ * public jlcsearch dataset when an LCSC code is known; Mouser/DigiKey are
+ * queried only when a manufacturer part number is known, since neither
+ * exposes a keyless tier.
+ */
+export async function resolvePartSourcing(
+  vendors: ToolContext['vendors'],
+  identifier: SourcingIdentifier,
+  options?: ResolvePartSourcingOptions,
+): Promise<SourcingTierResult[]> {
+  const requested = options?.suppliers?.map((s) => s.toLowerCase());
+  const wants = (supplier: string) => !requested || requested.includes(supplier);
+  const keylessEnabled = options?.keylessSourcingEnabled ?? true;
+
+  const adapters = createAdapters(vendors);
+  const results: SourcingTierResult[] = [];
+
+  if (wants('lcsc') && keylessEnabled && adapters.lcsc.isAvailable() && identifier.lcsc) {
+    const result = await adapters.lcsc.queryPart({ lcsc: identifier.lcsc });
+    if (result) results.push(toTierResult(result, 'keyless'));
+  }
+
+  for (const kind of ['mouser', 'digikey'] as const) {
+    if (!wants(kind)) continue;
+    const adapter = adapters[kind];
+    if (!adapter.isAvailable() || !identifier.mpn) continue;
+    const result = await adapter.queryPart({ mpn: identifier.mpn });
+    if (result) results.push(toTierResult(result, 'authenticated'));
+  }
+
+  return results;
+}

--- a/tests/unit/server/factory.test.ts
+++ b/tests/unit/server/factory.test.ts
@@ -76,6 +76,9 @@ function config(overrides: Partial<EnvConfig> = {}): EnvConfig {
     JLCPCB_MODE: 'disabled',
     MOUSER_ENABLED: false,
     DIGIKEY_ENABLED: false,
+    CACHE_DIR: '.easyeda-mcp-pro/cache',
+    VENDOR_MIN_REQUEST_INTERVAL_MS: 0,
+    KEYLESS_SOURCING_ENABLED: true,
     ...overrides,
   } as EnvConfig;
 }

--- a/tests/unit/tools/bom.test.ts
+++ b/tests/unit/tools/bom.test.ts
@@ -86,6 +86,7 @@ describe('BOM Tools Sourcing & Validate', () => {
       sourcing: [
         {
           supplier: 'lcsc',
+          tier: 'keyless',
           in_stock: true,
           quantity_available: 1500,
           unit_price: 0.015,
@@ -95,6 +96,37 @@ describe('BOM Tools Sourcing & Validate', () => {
       ],
     });
     expect(result.parts[1]?.sourcing).toHaveLength(0);
+    expect(result.keyless_sourcing_enabled).toBe(true);
+  });
+
+  it('easyeda_bom_sourcing surfaces classification metadata from the keyless tier', async () => {
+    const tool = registry.get('easyeda_bom_sourcing');
+
+    bridgeCall.mockResolvedValue([{ reference: 'R1', value: '10k', lcsc: 'C12345', quantity: 1 }]);
+    getPartDetailMock.mockResolvedValue({
+      lcsc: 'C12345',
+      stockCount: 1500,
+      price: '0.015',
+      classification: 'basic',
+    });
+
+    const result = await tool?.handler(context, { projectId: 'proj-123' });
+
+    expect(result.parts[0]?.sourcing[0]).toMatchObject({ classification: 'basic' });
+  });
+
+  it('easyeda_bom_sourcing skips the keyless tier when KEYLESS_SOURCING_ENABLED is false', async () => {
+    const tool = registry.get('easyeda_bom_sourcing');
+
+    bridgeCall.mockResolvedValue([{ reference: 'R1', value: '10k', lcsc: 'C12345', quantity: 1 }]);
+    getPartDetailMock.mockResolvedValue({ lcsc: 'C12345', stockCount: 1500 });
+    context.config.keylessSourcingEnabled = false;
+
+    const result = await tool?.handler(context, { projectId: 'proj-123' });
+
+    expect(getPartDetailMock).not.toHaveBeenCalled();
+    expect(result.parts[0]?.sourcing).toEqual([]);
+    expect(result.keyless_sourcing_enabled).toBe(false);
   });
 
   it('easyeda_bom_validate should categorize missing, invalid, and obsolete parts', async () => {

--- a/tests/unit/tools/schematic.test.ts
+++ b/tests/unit/tools/schematic.test.ts
@@ -663,7 +663,11 @@ describe('Schematic Tools', () => {
         itemsOfPage: 20,
         page: 1,
       });
-      expect(result).toEqual({ devices: [{ libraryUuid: 'lib-1', uuid: 'dev-1' }], total: 1 });
+      expect(result).toEqual({
+        devices: [{ libraryUuid: 'lib-1', uuid: 'dev-1' }],
+        total: 1,
+        provider_tier: 'local_library',
+      });
     });
 
     it('treats a non-array bridge response as no results', async () => {
@@ -672,7 +676,7 @@ describe('Schematic Tools', () => {
 
       const result = await tool?.handler(context, { key: 'resistor' });
 
-      expect(result).toEqual({ devices: [], total: 0 });
+      expect(result).toEqual({ devices: [], total: 0, provider_tier: 'local_library' });
     });
 
     it('returns not_available on bridge error', async () => {

--- a/tests/unit/vendors/base-http-client.test.ts
+++ b/tests/unit/vendors/base-http-client.test.ts
@@ -1,6 +1,10 @@
 import { Readable } from 'node:stream';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { httpRequestWithRetry } from '../../../src/vendors/base-http-client.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  httpRequestWithRetry,
+  configureVendorRateLimit,
+  resetVendorRateLimitStateForTests,
+} from '../../../src/vendors/base-http-client.js';
 import {
   getGlobalMetricsCollector,
   resetGlobalMetricsCollector,
@@ -54,5 +58,69 @@ describe('base http client observability', () => {
       requestCount: 1,
       errorCount: 1,
     });
+  });
+});
+
+describe('vendor rate limiting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetVendorRateLimitStateForTests();
+  });
+
+  afterEach(() => {
+    resetVendorRateLimitStateForTests();
+  });
+
+  it('does not delay requests when rate limiting is disabled (default)', async () => {
+    requestMock.mockResolvedValue({ statusCode: 200, body: Readable.from(['{}']) });
+
+    const start = Date.now();
+    await httpRequestWithRetry('https://vendor.example/a', {}, logger, 0);
+    await httpRequestWithRetry('https://vendor.example/b', {}, logger, 0);
+    expect(Date.now() - start).toBeLessThan(50);
+  });
+
+  it('delays a second request to the same host until the configured interval has elapsed', async () => {
+    vi.useFakeTimers();
+    try {
+      configureVendorRateLimit(200);
+      requestMock.mockResolvedValue({ statusCode: 200, body: Readable.from(['{}']) });
+
+      const first = httpRequestWithRetry('https://vendor.example/a', {}, logger, 0);
+      await vi.runAllTimersAsync();
+      await first;
+
+      const second = httpRequestWithRetry('https://vendor.example/b', {}, logger, 0);
+      let resolved = false;
+      void second.then(() => {
+        resolved = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(50);
+      expect(resolved).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(200);
+      await second;
+      expect(resolved).toBe(true);
+    } finally {
+      vi.useRealTimers();
+      configureVendorRateLimit(0);
+    }
+  });
+
+  it('does not delay requests to different hosts', async () => {
+    vi.useFakeTimers();
+    try {
+      configureVendorRateLimit(5000);
+      requestMock.mockResolvedValue({ statusCode: 200, body: Readable.from(['{}']) });
+
+      await httpRequestWithRetry('https://vendor-a.example/x', {}, logger, 0);
+      const second = httpRequestWithRetry('https://vendor-b.example/y', {}, logger, 0);
+      await vi.advanceTimersByTimeAsync(10);
+      await expect(second).resolves.toMatchObject({ statusCode: 200 });
+    } finally {
+      vi.useRealTimers();
+      configureVendorRateLimit(0);
+    }
   });
 });

--- a/tests/unit/vendors/cache.test.ts
+++ b/tests/unit/vendors/cache.test.ts
@@ -1,0 +1,83 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  createFileVendorCache,
+  createNoopVendorCache,
+  cacheKey,
+} from '../../../src/vendors/cache.js';
+
+describe('cacheKey', () => {
+  it('is stable regardless of object key order', () => {
+    const a = cacheKey(['lcsc', 'resistors', { b: '2', a: '1' }]);
+    const b = cacheKey(['lcsc', 'resistors', { a: '1', b: '2' }]);
+    expect(a).toBe(b);
+  });
+
+  it('differs for different inputs', () => {
+    const a = cacheKey(['lcsc', 'resistors', { a: '1' }]);
+    const b = cacheKey(['lcsc', 'capacitors', { a: '1' }]);
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('createNoopVendorCache', () => {
+  it('always returns null and never persists anything', async () => {
+    const cache = createNoopVendorCache();
+    await cache.set('key', { foo: 'bar' }, 60);
+    const result = await cache.get('key');
+    expect(result).toBeNull();
+  });
+});
+
+describe('createFileVendorCache', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vendor-cache-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('returns null for a key that was never set', async () => {
+    const cache = createFileVendorCache(dir);
+    const result = await cache.get('missing');
+    expect(result).toBeNull();
+  });
+
+  it('round-trips a value written with set', async () => {
+    const cache = createFileVendorCache(dir);
+    await cache.set('key', { foo: 'bar' }, 3600);
+    const result = await cache.get<{ foo: string }>('key');
+    expect(result?.value).toEqual({ foo: 'bar' });
+    expect(result?.storedAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  it('expires an entry once its TTL has elapsed', async () => {
+    const cache = createFileVendorCache(dir);
+    const key = 'expiring';
+    await cache.set(key, { foo: 'bar' }, 3600);
+
+    // Rewrite the entry's storedAt to simulate it being far in the past.
+    const file = path.join(dir, 'vendors', `${key}.json`);
+    const entry = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    entry.storedAt = Date.now() - 7200 * 1000;
+    fs.writeFileSync(file, JSON.stringify(entry), 'utf-8');
+
+    const result = await cache.get(key);
+    expect(result).toBeNull();
+  });
+
+  it('does not throw when the cache directory cannot be created', async () => {
+    // Point at a path where a parent segment is a file, not a directory.
+    const blockerFile = path.join(dir, 'blocker');
+    fs.writeFileSync(blockerFile, 'not a directory');
+    const cache = createFileVendorCache(path.join(blockerFile, 'nested'));
+
+    await expect(cache.set('key', { foo: 'bar' }, 60)).resolves.toBeUndefined();
+    await expect(cache.get('key')).resolves.toBeNull();
+  });
+});

--- a/tests/unit/vendors/lcsc.test.ts
+++ b/tests/unit/vendors/lcsc.test.ts
@@ -2,6 +2,7 @@ import { Readable } from 'node:stream';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { EnvSchema } from '../../../src/config/env.js';
 import { LcscClient } from '../../../src/vendors/lcsc/client.js';
+import { createNoopVendorCache, type VendorCache } from '../../../src/vendors/cache.js';
 
 const requestMock = vi.hoisted(() => vi.fn());
 
@@ -32,10 +33,47 @@ function createTestConfigWithApiKey() {
   });
 }
 
+function resistor(overrides: Record<string, unknown> = {}) {
+  return {
+    lcsc: 25804,
+    mfr: '0603WAF1002T5E',
+    description: '',
+    stock: 37165617,
+    price1: 0.000842857,
+    in_stock: true,
+    package: '0603',
+    is_basic: true,
+    is_preferred: false,
+    attributes: JSON.stringify({ Resistance: '10kΩ', Tolerance: '±1%' }),
+    ...overrides,
+  };
+}
+
+/** Mock every category endpoint with an empty list, for tests that only care about one category. */
+function mockAllCategoriesEmpty() {
+  requestMock.mockImplementation(async (url: string) => {
+    for (const category of [
+      'resistors',
+      'capacitors',
+      'diodes',
+      'mosfets',
+      'leds',
+      'microcontrollers',
+      'switches',
+      'led_drivers',
+    ]) {
+      if (typeof url === 'string' && url.includes(`/${category}/list.json`)) {
+        return jsonResponse(200, { [category]: [] });
+      }
+    }
+    return jsonResponse(200, {});
+  });
+}
+
 describe('LcscClient', () => {
   beforeEach(() => {
     requestMock.mockReset();
-    requestMock.mockResolvedValue(jsonResponse(200, { results: [], count: 0 }));
+    mockAllCategoriesEmpty();
   });
 
   it('should construct with default config', () => {
@@ -50,6 +88,7 @@ describe('LcscClient', () => {
     expect(typeof client.searchParts).toBe('function');
     expect(typeof client.getPartDetail).toBe('function');
     expect(typeof client.getPartsByCategory).toBe('function');
+    expect(typeof client.searchCategory).toBe('function');
   });
 
   it('should handle empty search gracefully', async () => {
@@ -60,42 +99,145 @@ describe('LcscClient', () => {
     expect(result.total).toBe(0);
   });
 
-  describe('requests', () => {
-    it('returns parts from the jlcsearch API on success', async () => {
-      requestMock.mockResolvedValueOnce(jsonResponse(200, { results: [{ lcsc: 'C1' }], count: 1 }));
+  describe('searchCategory', () => {
+    it('fetches a known category and normalizes fields', async () => {
+      requestMock.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/resistors/list.json')) {
+          return jsonResponse(200, { resistors: [resistor()] });
+        }
+        return jsonResponse(200, {});
+      });
 
       const client = new LcscClient(createTestConfig());
-      const result = await client.searchParts('resistor', { limit: 10, page: 1 });
+      const result = await client.searchCategory('resistors', { resistance: '10k' });
 
-      expect(result).toEqual({ parts: [{ lcsc: 'C1' }], total: 1 });
+      expect(result.total).toBe(1);
+      expect(result.parts[0]).toMatchObject({
+        lcsc: 'C25804',
+        manufacturer: '0603WAF1002T5E',
+        category: 'resistors',
+        package: '0603',
+        stock: 37165617,
+        inStock: true,
+        classification: 'basic',
+        attributes: { Resistance: '10kΩ', Tolerance: '±1%' },
+      });
       expect(requestMock).toHaveBeenCalledWith(
-        expect.stringContaining('/api/search'),
+        expect.stringContaining('/resistors/list.json'),
         expect.objectContaining({ method: 'GET' }),
       );
     });
 
-    it('rethrows when jlcsearch fails and no LCSC_API_KEY is configured', async () => {
-      vi.useFakeTimers();
-      try {
-        requestMock.mockResolvedValue(textResponse(500, 'boom'));
-
-        const client = new LcscClient(createTestConfig());
-        const pending = client.searchParts('resistor');
-        const assertion = expect(pending).rejects.toMatchObject({
-          code: 'VENDOR_API_UNAVAILABLE',
-        });
-        await vi.runAllTimersAsync();
-        await assertion;
-        // no api key configured -> only jlcsearch was ever hit (all retries)
-        for (const call of requestMock.mock.calls) {
-          expect(call[0]).toContain('jlcsearch');
-        }
-      } finally {
-        vi.useRealTimers();
-      }
+    it('returns empty results for an unrecognized category without hitting the network', async () => {
+      const client = new LcscClient(createTestConfig());
+      // @ts-expect-error -- intentionally passing an unsupported category
+      const result = await client.searchCategory('inductors');
+      expect(result).toEqual({ parts: [], total: 0, fromCache: false, cacheAgeSeconds: 0 });
+      expect(requestMock).not.toHaveBeenCalled();
     });
 
-    it('falls back to the LCSC official API when jlcsearch fails and a key is configured', async () => {
+    it('marks classification as extended when is_basic and is_preferred are both false', async () => {
+      requestMock.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/resistors/list.json')) {
+          return jsonResponse(200, {
+            resistors: [resistor({ is_basic: false, is_preferred: false })],
+          });
+        }
+        return jsonResponse(200, {});
+      });
+
+      const client = new LcscClient(createTestConfig());
+      const result = await client.searchCategory('resistors');
+      expect(result.parts[0]?.classification).toBe('extended');
+    });
+  });
+
+  describe('caching', () => {
+    function createMemoryCache(): VendorCache {
+      const store = new Map<string, { value: unknown; storedAt: number }>();
+      return {
+        async get(key) {
+          return (store.get(key) as { value: unknown; storedAt: number } | undefined) ?? null;
+        },
+        async set(key, value) {
+          store.set(key, { value, storedAt: Date.now() });
+        },
+      };
+    }
+
+    it('serves a repeated category query from cache without a second HTTP call', async () => {
+      requestMock.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/resistors/list.json')) {
+          return jsonResponse(200, { resistors: [resistor()] });
+        }
+        return jsonResponse(200, {});
+      });
+
+      const cache = createMemoryCache();
+      const client = new LcscClient(createTestConfig(), cache);
+
+      const first = await client.searchCategory('resistors', { resistance: '10k' });
+      expect(first.fromCache).toBe(false);
+      const callCountAfterFirst = requestMock.mock.calls.length;
+
+      const second = await client.searchCategory('resistors', { resistance: '10k' });
+      expect(second.fromCache).toBe(true);
+      expect(second.parts).toEqual(first.parts);
+      expect(requestMock.mock.calls.length).toBe(callCountAfterFirst);
+    });
+
+    it('does not cache when a noop cache is used (the default)', async () => {
+      requestMock.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/resistors/list.json')) {
+          return jsonResponse(200, { resistors: [resistor()] });
+        }
+        return jsonResponse(200, {});
+      });
+
+      const client = new LcscClient(createTestConfig(), createNoopVendorCache());
+      await client.searchCategory('resistors');
+      const callCountAfterFirst = requestMock.mock.calls.length;
+      await client.searchCategory('resistors');
+      expect(requestMock.mock.calls.length).toBeGreaterThan(callCountAfterFirst - 1);
+      expect(requestMock.mock.calls.length).toBe(callCountAfterFirst * 2);
+    });
+  });
+
+  describe('searchParts', () => {
+    it('maps a recognized keyword to its category and applies an extracted package filter', async () => {
+      requestMock.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/resistors/list.json')) {
+          expect(url).toContain('package=0603');
+          return jsonResponse(200, { resistors: [resistor()] });
+        }
+        return jsonResponse(200, {});
+      });
+
+      const client = new LcscClient(createTestConfig());
+      const result = await client.searchParts('10k resistor 0603');
+
+      expect(result.parts).toHaveLength(1);
+      expect(result.parts[0]?.category).toBe('resistors');
+    });
+
+    it('scans all categories and filters client-side for an unrecognized query', async () => {
+      requestMock.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/resistors/list.json')) {
+          return jsonResponse(200, {
+            resistors: [resistor({ mfr: 'ACME-WIDGET-1' })],
+          });
+        }
+        return jsonResponse(200, {});
+      });
+
+      const client = new LcscClient(createTestConfig());
+      const result = await client.searchParts('acme-widget');
+
+      expect(result.parts).toHaveLength(1);
+      expect(result.parts[0]?.manufacturer).toBe('ACME-WIDGET-1');
+    });
+
+    it('falls back to the LCSC official API when jlcsearch is entirely unavailable and a key is configured', async () => {
       vi.useFakeTimers();
       try {
         requestMock.mockImplementation(async (url: string) => {
@@ -110,7 +252,7 @@ describe('LcscClient', () => {
         await vi.runAllTimersAsync();
         const result = await pending;
 
-        expect(result.parts[0].lcsc).toBe('C2');
+        expect(result.parts[0]?.lcsc).toBe('C2');
         const fallbackCall = requestMock.mock.calls.find(
           (call) => typeof call[0] === 'string' && call[0].includes('lcsc.com/api/search'),
         );
@@ -121,31 +263,136 @@ describe('LcscClient', () => {
       }
     });
 
-    it('returns a single part detail, unwrapping a { part } envelope', async () => {
-      requestMock.mockResolvedValueOnce(jsonResponse(200, { part: { lcsc: 'C3' } }));
+    it('rethrows when jlcsearch fails and no LCSC_API_KEY is configured', async () => {
+      vi.useFakeTimers();
+      try {
+        requestMock.mockResolvedValue(textResponse(500, 'boom'));
+
+        const client = new LcscClient(createTestConfig());
+        const pending = client.searchParts('capacitor');
+        const assertion = expect(pending).rejects.toMatchObject({
+          code: 'VENDOR_API_UNAVAILABLE',
+        });
+        await vi.runAllTimersAsync();
+        await assertion;
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('getPartDetail', () => {
+    it('finds a part by scanning cached category snapshots', async () => {
+      requestMock.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/resistors/list.json')) {
+          return jsonResponse(200, { resistors: [resistor({ lcsc: 25804 })] });
+        }
+        return jsonResponse(200, {});
+      });
 
       const client = new LcscClient(createTestConfig());
-      const part = await client.getPartDetail('C3');
+      const part = await client.getPartDetail('C25804');
 
-      expect(part).toEqual({ lcsc: 'C3' });
+      expect(part).toMatchObject({
+        lcsc: 'C25804',
+        category: 'resistors',
+        classification: 'basic',
+      });
     });
 
-    it('rethrows a not-found error when there is no fallback key', async () => {
-      requestMock.mockResolvedValue(textResponse(404, 'not found'));
+    it('accepts a bare numeric code without the C prefix', async () => {
+      requestMock.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/resistors/list.json')) {
+          return jsonResponse(200, { resistors: [resistor({ lcsc: 25804 })] });
+        }
+        return jsonResponse(200, {});
+      });
 
       const client = new LcscClient(createTestConfig());
-      await expect(client.getPartDetail('missing')).rejects.toMatchObject({
+      const part = await client.getPartDetail('25804');
+      expect(part?.lcsc).toBe('C25804');
+    });
+
+    it('returns null when every category is reachable but none contain the part', async () => {
+      const client = new LcscClient(createTestConfig());
+      const part = await client.getPartDetail('C999999999');
+      expect(part).toBeNull();
+    });
+
+    it('throws when jlcsearch is entirely unreachable and no LCSC_API_KEY is configured', async () => {
+      requestMock.mockResolvedValue(textResponse(500, 'boom'));
+
+      const client = new LcscClient(createTestConfig());
+      await expect(client.getPartDetail('C1')).rejects.toMatchObject({
         code: 'VENDOR_API_UNAVAILABLE',
       });
     });
 
-    it('returns parts by category, preferring `parts` over `results`', async () => {
-      requestMock.mockResolvedValueOnce(jsonResponse(200, { parts: [{ lcsc: 'C4' }] }));
+    it('falls back to the official API when jlcsearch is entirely unreachable and a key is configured', async () => {
+      requestMock.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('jlcsearch')) {
+          return textResponse(500, 'boom');
+        }
+        return jsonResponse(200, { lcsc: 'C1', manufacturer: 'fallback-mfr' });
+      });
+
+      const client = new LcscClient(createTestConfigWithApiKey());
+      const part = await client.getPartDetail('C1');
+
+      expect(part).toMatchObject({ lcsc: 'C1', manufacturer: 'fallback-mfr' });
+      const fallbackCall = requestMock.mock.calls.find(
+        (call) => typeof call[0] === 'string' && call[0].includes('lcsc.com/api/part'),
+      );
+      expect(fallbackCall).toBeDefined();
+    });
+
+    it('surfaces cache metadata on the returned part', async () => {
+      requestMock.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/resistors/list.json')) {
+          return jsonResponse(200, { resistors: [resistor({ lcsc: 25804 })] });
+        }
+        return jsonResponse(200, {});
+      });
+
+      const store = new Map<string, { value: unknown; storedAt: number }>();
+      const cache: VendorCache = {
+        async get(key) {
+          return (store.get(key) as { value: unknown; storedAt: number } | undefined) ?? null;
+        },
+        async set(key, value) {
+          store.set(key, { value, storedAt: Date.now() });
+        },
+      };
+
+      const client = new LcscClient(createTestConfig(), cache);
+      await client.getPartDetail('C25804');
+      const second = await client.getPartDetail('C25804');
+
+      expect(second?.fromCache).toBe(true);
+      expect(second?.cacheAgeSeconds).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('getPartsByCategory', () => {
+    it('returns parts for a known category', async () => {
+      requestMock.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/capacitors/list.json')) {
+          return jsonResponse(200, { capacitors: [resistor({ lcsc: 14663 })] });
+        }
+        return jsonResponse(200, {});
+      });
 
       const client = new LcscClient(createTestConfig());
-      const parts = await client.getPartsByCategory('resistors');
+      const parts = await client.getPartsByCategory('capacitors');
+      expect(parts).toHaveLength(1);
+      expect(parts[0]?.lcsc).toBe('C14663');
+    });
 
-      expect(parts).toEqual([{ lcsc: 'C4' }]);
+    it('returns an empty array for an unknown category', async () => {
+      const client = new LcscClient(createTestConfig());
+      const parts = await client.getPartsByCategory('not-a-real-category');
+      expect(parts).toEqual([]);
+      expect(requestMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/tests/unit/vendors/sourcing-facade.test.ts
+++ b/tests/unit/vendors/sourcing-facade.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { resolvePartSourcing } from '../../../src/vendors/sourcing-facade.js';
+import { type ToolContext } from '../../../src/tools/types.js';
+
+function vendors(overrides: Partial<ToolContext['vendors']> = {}): ToolContext['vendors'] {
+  return { lcsc: null, jlcpcb: null, mouser: null, digikey: null, ...overrides };
+}
+
+describe('resolvePartSourcing', () => {
+  it('returns no results when no vendors are configured', async () => {
+    const results = await resolvePartSourcing(vendors(), { lcsc: 'C1', mpn: 'MPN1' });
+    expect(results).toEqual([]);
+  });
+
+  it('queries LCSC keyless-first when an LCSC code is known', async () => {
+    const getPartDetail = vi.fn().mockResolvedValue({
+      lcsc: 'C1',
+      stockCount: 100,
+      price: '0.01',
+      classification: 'basic',
+    });
+    const results = await resolvePartSourcing(vendors({ lcsc: { getPartDetail } as any }), {
+      lcsc: 'C1',
+    });
+
+    expect(getPartDetail).toHaveBeenCalledWith('C1');
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({
+      supplier: 'lcsc',
+      tier: 'keyless',
+      found: true,
+      in_stock: true,
+      classification: 'basic',
+    });
+  });
+
+  it('skips the keyless LCSC tier when keylessSourcingEnabled is false', async () => {
+    const getPartDetail = vi.fn().mockResolvedValue({ lcsc: 'C1', stockCount: 100 });
+    const results = await resolvePartSourcing(
+      vendors({ lcsc: { getPartDetail } as any }),
+      { lcsc: 'C1' },
+      { keylessSourcingEnabled: false },
+    );
+
+    expect(getPartDetail).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
+
+  it('does not query Mouser/DigiKey when no MPN is known', async () => {
+    const searchByPartNumber = vi.fn();
+    const results = await resolvePartSourcing(vendors({ mouser: { searchByPartNumber } as any }), {
+      lcsc: 'C1',
+    });
+
+    expect(searchByPartNumber).not.toHaveBeenCalled();
+    expect(results).toEqual([]);
+  });
+
+  it('queries Mouser as an authenticated-tier result when an MPN is known', async () => {
+    const searchByPartNumber = vi
+      .fn()
+      .mockResolvedValue([
+        { manufacturer: 'MPN1', availability: 42, priceBreaks: [{ price: 1.5 }] },
+      ]);
+    const results = await resolvePartSourcing(vendors({ mouser: { searchByPartNumber } as any }), {
+      mpn: 'MPN1',
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ supplier: 'mouser', tier: 'authenticated', found: true });
+  });
+
+  it('honors an explicit suppliers filter', async () => {
+    const getPartDetail = vi.fn().mockResolvedValue({ lcsc: 'C1', stockCount: 100 });
+    const searchByPartNumber = vi
+      .fn()
+      .mockResolvedValue([{ manufacturer: 'MPN1', availability: 5 }]);
+
+    const results = await resolvePartSourcing(
+      vendors({ lcsc: { getPartDetail } as any, mouser: { searchByPartNumber } as any }),
+      { lcsc: 'C1', mpn: 'MPN1' },
+      { suppliers: ['mouser'] },
+    );
+
+    expect(getPartDetail).not.toHaveBeenCalled();
+    expect(searchByPartNumber).toHaveBeenCalled();
+    expect(results).toHaveLength(1);
+    expect(results[0]?.supplier).toBe('mouser');
+  });
+
+  it('includes a not-found result rather than omitting it', async () => {
+    const getPartDetail = vi.fn().mockResolvedValue(null);
+    const results = await resolvePartSourcing(vendors({ lcsc: { getPartDetail } as any }), {
+      lcsc: 'C1',
+    });
+
+    expect(results).toHaveLength(1);
+    expect(results[0]).toMatchObject({ supplier: 'lcsc', found: false, in_stock: false });
+  });
+});


### PR DESCRIPTION
## Summary

WS-01 (Keyless Sourcing Expansion), scoped to the LCSC keyless tier fix and unification.

- The existing `LcscClient` targeted endpoints that don't exist on the public jlcsearch
  service (`/api/search`, `/api/part/:code`, `/api/categories/:cat/parts`), so keyless
  lookups silently returned nothing in production. Rewrote it against the real API:
  per-category `/{category}/list.json` snapshots (resistors, capacitors, diodes,
  mosfets, leds, microcontrollers, switches, led_drivers), with `classification`
  (basic/preferred/extended) and parsed parametric `attributes`.
- Added `src/vendors/sourcing-facade.ts`, unifying the keyless LCSC tier and
  authenticated Mouser/DigiKey tiers behind the existing BOM-quality supplier
  adapters; each result reports which `tier` answered.
- `easyeda_bom_sourcing` now goes through the facade (previously hardcoded to LCSC
  only) and reports `tier`/`classification`/`from_cache`/`cache_age_seconds` per
  result. `easyeda_schematic_search_device` reports `provider_tier: 'local_library'`
  for consistency (it queries the local EasyEDA device library only, unchanged).
- Added a file-based vendor response cache under `CACHE_DIR` and a per-hostname
  outbound rate limiter in the shared HTTP client, both new and opt-in.
- New env vars: `KEYLESS_SOURCING_ENABLED` (default `true`), `SOURCING_CACHE_TTL_SECONDS`
  (default 6h), `VENDOR_MIN_REQUEST_INTERVAL_MS` (default 150ms).
- Documented the real jlcsearch API's shape and known limitation (each category
  snapshot only covers its top ~100 in-stock parts; a low-stock/obscure part won't be
  found via the keyless tier) in `docs/vendor-api-hardening.md`, `docs/vendor-terms.md`,
  and `docs/examples/bom-sourcing.md`.

No new runtime dependencies were added.

## Test plan

- [x] `pnpm verify` (format, typecheck incl. extension, lint, tool-metadata lint,
      tool-coverage, full test suite, build incl. extension, metadata check, docs build)
      — all green.
- [x] New/updated unit tests: `LcscClient` against the real API shape (category
      fetch, classification, attribute parsing, caching, code-lookup scan,
      official-API fallback), the file cache module, the per-hostname rate limiter,
      the sourcing facade's tier resolution and supplier filtering, and
      `easyeda_bom_sourcing` / `easyeda_schematic_search_device` tool behavior.
- [x] Verified the real jlcsearch API shape manually against
      `https://jlcsearch.tscircuit.com` to confirm the endpoint/field rewrite is
      accurate (category-scoped `list.json` endpoints, `is_basic`/`is_preferred`,
      JSON-string `attributes`, `price1`, no generic search/lookup endpoint).