### PR TITLE
feat(diagnostics): enrich health checks and add doctor --fix guidance

### DIFF
--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -32,7 +32,16 @@ The AI client (e.g. Claude Desktop or Cursor) displays an error: `"Failed to sta
    ```bash
    npx easyeda-mcp-pro doctor
    ```
+   Add `--fix` to print a suggested-fixes section with the exact command or setting to
+   change for each detected failure (Node version, missing pnpm, invalid env, missing
+   build artifacts, unreachable bridge port, missing vendor credentials). `doctor --fix`
+   never modifies files — it only prints guidance.
 4. **Port Scan Configuration**: If you changed ports, ensure the server env var `BRIDGE_PORT` or `BRIDGE_PORT_SCAN` aligns with the extension's configured port (default is `49620`).
+5. **Extension Version Mismatch**: `easyeda_health_check` and `easyeda_run_self_test` report
+   `extension_version_mismatch: true` (and the mismatched versions) when the connected
+   bridge extension's version differs from the installed `easyeda-mcp-pro` package
+   version. Update the extension in EasyEDA Pro (Settings → Extensions → Extension
+   Manager) or reinstall `easyeda-bridge-extension.eext` from a matching release.
 
 ---
 
@@ -66,7 +75,25 @@ To bypass this locally, bind to `127.0.0.1`. For production deployments, configu
 
 ---
 
-## 5. Release Pipeline / NPM Token Failures
+## 5. Stale MCP Client Config
+
+### Symptom:
+
+Running `npx easyeda-mcp-pro setup <client>` (or `setup all`) prints "Stale entry
+detected and replaced" for a client instead of "Existing entry was already up to date."
+
+### Rationale & Solution:
+
+This means the client's MCP config file already had an `easyeda-mcp-pro` entry that
+differed from the one `setup` just wrote (for example, an entry from an older version
+that pointed at a local build path, or one missing a `TOOL_PROFILE` env var). The lines
+under "Stale entry detected and replaced" list exactly what changed
+(`command`, `args`, or `env`). `setup` always writes the correct current entry, so no
+further action is needed — restart the client to pick up the corrected config.
+
+---
+
+## 6. Release Pipeline / NPM Token Failures
 
 ### Symptom:
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -31,7 +31,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_get_feature_flags`             | `core`  | `low`    | Return current feature flag values.                                                                                                                                                                                                                                                                           |
 | `easyeda_get_server_config`             | `core`  | `low`    | Return safe (redacted) server configuration. Secrets are never exposed.                                                                                                                                                                                                                                       |
 | `easyeda_get_tool_profiles`             | `core`  | `low`    | List available tool profiles and their descriptions.                                                                                                                                                                                                                                                          |
-| `easyeda_health_check`                  | `core`  | `low`    | Return server health status, including runtime version, active profile, bridge state, and config validity.                                                                                                                                                                                                    |
+| `easyeda_health_check`                  | `core`  | `low`    | Return server health status in one call: runtime version, active profile, bridge state, EasyEDA version, keyless sourcing state, and starter catalog size. Intended as the single actionable status check after first connecting the bridge extension.                                                        |
 | `easyeda_jlcpcb_quote_workflow`         | `pro`   | `medium` | Prepare a non-binding JLCPCB quote workflow snapshot with explicit human-review gates and audit evidence. This tool never places orders or performs paid operations.                                                                                                                                          |
 | `easyeda_live_smoke_report`             | `dev`   | `low`    | Run a read-only live smoke report against the connected EasyEDA bridge and return status, API inventory, components, wires, and schematic nets in one response.                                                                                                                                               |
 | `easyeda_observability_report`          | `core`  | `low`    | Return latency budgets, runtime metrics, cache/vendor timing snapshot, and storage retention policy for performance diagnostics.                                                                                                                                                                              |
@@ -780,7 +780,7 @@ Returns a JSON object matching the schema:
 
 **Profile:** `core` | **Risk Level:** `low`
 
-> Return server health status, including runtime version, active profile, bridge state, and config validity.
+> Return server health status in one call: runtime version, active profile, bridge state, EasyEDA version, keyless sourcing state, and starter catalog size. Intended as the single actionable status check after first connecting the bridge extension.
 
 ### Input Parameters
 
@@ -798,6 +798,11 @@ Returns a JSON object matching the schema:
   profile: any;
   transport: any;
   bridge_connected: any;
+  easyeda_version: any;
+  extension_version: any;
+  extension_version_mismatch: any;
+  keyless_sourcing_enabled: any;
+  catalog_device_count: any;
   ups: any;
 }
 ```

--- a/src/bridge/manager.ts
+++ b/src/bridge/manager.ts
@@ -57,6 +57,7 @@ export class BridgeManager extends EventEmitter {
   private reconnectStartMs = 0;
   private pairingChallenges = new Map<string, PairingEntry>();
   private _methodRegistryHash: string;
+  private _extensionVersion: string | undefined;
 
   constructor(config: EnvConfig) {
     super();
@@ -102,6 +103,21 @@ export class BridgeManager extends EventEmitter {
 
   get methodRegistryHash(): string {
     return this._methodRegistryHash;
+  }
+
+  /** EasyEDA Pro application version reported at the last successful handshake. */
+  get easyedaVersion(): string | undefined {
+    return this.hello?.easyedaVersion;
+  }
+
+  /** Bridge extension version reported at the last successful handshake. */
+  get extensionVersion(): string | undefined {
+    return this._extensionVersion;
+  }
+
+  /** Whether the connected extension's version differs from this server's version. */
+  get extensionVersionMismatch(): boolean {
+    return this._extensionVersion !== undefined && this._extensionVersion !== SERVER_VERSION;
   }
 
   private isLoopbackHost(host: string): boolean {
@@ -266,6 +282,7 @@ export class BridgeManager extends EventEmitter {
       this.state = 'connecting';
       this._connectedAtMs = 0;
       this.hello = null;
+      this._extensionVersion = undefined;
       this.stopStaleSweep();
       this.stopHeartbeat();
 
@@ -337,6 +354,7 @@ export class BridgeManager extends EventEmitter {
 
     // Extension version mismatch warning
     const extVer = parsed.data.extensionVersion;
+    this._extensionVersion = extVer;
     if (extVer && extVer !== SERVER_VERSION) {
       logger.warn(
         `⚠️ EasyEDA Pro bridge extension version mismatch: extension is v${extVer}, but MCP server is v${SERVER_VERSION}. Please update the extension in EasyEDA Pro.`,
@@ -511,6 +529,7 @@ export class BridgeManager extends EventEmitter {
     }
 
     this.hello = null;
+    this._extensionVersion = undefined;
     this.reconnectAttempts = 0;
     this.emit('stateChanged', this.state, prev);
     this.emit('disconnected', reason ?? 'unknown');

--- a/src/cli/auto-setup.ts
+++ b/src/cli/auto-setup.ts
@@ -91,6 +91,39 @@ function mergeServerEntry(
   return { ...existing, [serverKey]: servers };
 }
 
+/** Read the existing server entry for this project under `serverKey`, if any. */
+function readExistingEntry(
+  existing: Record<string, unknown>,
+  serverKey: string,
+): Record<string, unknown> | undefined {
+  const servers = existing[serverKey] as Record<string, unknown> | undefined;
+  const entry = servers?.[SERVER_NAME];
+  return entry && typeof entry === 'object' ? (entry as Record<string, unknown>) : undefined;
+}
+
+function describeStaleConfig(
+  previous: Record<string, unknown>,
+  next: Record<string, unknown>,
+): string[] {
+  const notes: string[] = [];
+  const prevCommand = JSON.stringify(previous.command);
+  const nextCommand = JSON.stringify(next.command);
+  if (prevCommand !== nextCommand) {
+    notes.push(`command: ${prevCommand} -> ${nextCommand}`);
+  }
+  const prevArgs = JSON.stringify(previous.args ?? []);
+  const nextArgs = JSON.stringify(next.args ?? []);
+  if (prevArgs !== nextArgs) {
+    notes.push(`args: ${prevArgs} -> ${nextArgs}`);
+  }
+  const prevEnv = JSON.stringify(previous.env ?? {});
+  const nextEnv = JSON.stringify(next.env ?? {});
+  if (prevEnv !== nextEnv) {
+    notes.push(`env: ${prevEnv} -> ${nextEnv}`);
+  }
+  return notes;
+}
+
 // ── Core: setup a single client ─────────────────────────────
 
 function setupClient(client: ClientDefinition, profile: string): string[] {
@@ -105,6 +138,7 @@ function setupClient(client: ClientDefinition, profile: string): string[] {
   const serverEntry = buildServerEntry(profile, client);
   const fileExists = existsSync(configPath);
   const existing = fileExists ? readJsonFile(configPath) : {};
+  const previousEntry = readExistingEntry(existing, client.serverKey);
   const merged = mergeServerEntry(existing, client.serverKey, serverEntry);
 
   writeJsonFile(configPath, merged);
@@ -114,6 +148,19 @@ function setupClient(client: ClientDefinition, profile: string): string[] {
   } else {
     lines.push(ok(`Created ${client.displayName} config`));
   }
+
+  if (previousEntry) {
+    const staleNotes = describeStaleConfig(previousEntry, serverEntry);
+    if (staleNotes.length > 0) {
+      lines.push(warn(`Stale entry detected and replaced:`));
+      for (const note of staleNotes) {
+        lines.push(info(`  ${note}`));
+      }
+    } else {
+      lines.push(info('Existing entry was already up to date.'));
+    }
+  }
+
   lines.push(info(`Path: ${configPath}`));
 
   return lines;

--- a/src/cli/local-setup.ts
+++ b/src/cli/local-setup.ts
@@ -19,6 +19,7 @@ export interface ParsedCliArgs {
   setupProfile?: string;
   extensionOpen?: boolean;
   extensionCopy?: string;
+  doctorFix?: boolean;
 }
 
 interface PackageInfo {
@@ -142,7 +143,7 @@ export function parseCliArgs(args: string[]): ParsedCliArgs {
     }
     case '--doctor':
     case 'doctor':
-      return { command: 'doctor' };
+      return { command: 'doctor', doctorFix: args.includes('--fix') };
     case '--init':
     case 'init':
       return { command: 'init' };
@@ -273,7 +274,81 @@ export async function createDoctorReport(
   };
 }
 
-export function formatDoctorReport(report: DoctorReport): string {
+/** Build the "Suggested fixes" lines for `doctor --fix`, one block per detected failure. */
+function buildSuggestedFixes(report: DoctorReport): string[] {
+  const fixes: string[] = [];
+  const reachable = report.bridgePorts.find((port) => port.reachable);
+
+  if (!report.nodeSupported) {
+    const major = Number(report.nodeVersion.split('.')[0]);
+    fixes.push(
+      `Node.js ${report.nodeVersion} is not supported (need >=24 <27, found major ${Number.isFinite(major) ? major : '?'}).`,
+      '  Fix: nvm install 24 && nvm use 24   (or upgrade Node.js from https://nodejs.org)',
+    );
+  }
+
+  if (!report.pnpmVersion) {
+    fixes.push(
+      'pnpm was not found on PATH.',
+      '  Fix: npm install -g pnpm   (only needed for local development, not for npx usage)',
+    );
+  }
+
+  if (!report.envValid) {
+    fixes.push('Environment configuration is invalid:');
+    for (const issue of report.envIssues) {
+      fixes.push(`  Fix: set/correct ${issue}`);
+    }
+  }
+
+  if (!report.setup.serverEntryExists) {
+    fixes.push(
+      `MCP server entry not found at ${report.setup.serverEntryPath}.`,
+      '  Fix: pnpm build   (or reinstall via npx easyeda-mcp-pro if using the published package)',
+    );
+  }
+
+  if (!report.setup.extensionPackageExists) {
+    fixes.push(
+      `Bridge extension package not found at ${report.setup.extensionPackagePath}.`,
+      '  Fix: pnpm build:extension   (or reinstall the npm package, which bundles the .eext)',
+    );
+  }
+
+  if (!reachable) {
+    fixes.push(
+      `Bridge server is not reachable on ${report.bridgeHost} (scanned ports: ${report.bridgePorts.map((p) => p.port).join(', ')}).`,
+      '  This is expected until your MCP client starts easyeda-mcp-pro. If your MCP client is running and this persists:',
+      '  Fix 1: In EasyEDA Pro, go to Settings > Extensions > Extension Manager and confirm the bridge extension is imported.',
+      '  Fix 2: Enable "Allow External Interaction" for the extension, then click MCP Bridge > Connect in the menu bar.',
+      '  Fix 3: If another process holds the configured port, set BRIDGE_PORT to a free port and update BRIDGE_PORT_SCAN to include it.',
+    );
+  } else if (reachable.port !== report.bridgePorts[0]?.port) {
+    fixes.push(
+      `Bridge is reachable on a fallback port (${reachable.port}) rather than the first scanned port (${report.bridgePorts[0]?.port}).`,
+      `  Fix: set BRIDGE_PORT=${reachable.port} to pin it and avoid future port-scan ambiguity.`,
+    );
+  }
+
+  if (report.vendorDiagnostics) {
+    for (const [name, vendor] of Object.entries(report.vendorDiagnostics)) {
+      if (vendor.credentialStatus === 'missing') {
+        fixes.push(
+          `${name} is enabled but missing required credentials (mode: ${vendor.mode}).`,
+          `  Fix: set the ${name} credential environment variables documented in docs/vendor-api-hardening.md, or disable it.`,
+        );
+      }
+    }
+  }
+
+  if (fixes.length === 0) {
+    fixes.push('No issues detected — nothing to fix.');
+  }
+
+  return fixes;
+}
+
+export function formatDoctorReport(report: DoctorReport, options?: { fix?: boolean }): string {
   const reachable = report.bridgePorts.find((port) => port.reachable);
   const bridgeStatus = reachable
     ? `reachable on ${report.bridgeHost}:${reachable.port}`
@@ -294,7 +369,7 @@ export function formatDoctorReport(report: DoctorReport): string {
     ? `Profile '${report.toolCounts.profile}' with ${report.toolCounts.enabled} / ${report.toolCounts.total} tools enabled`
     : 'Unknown tool configuration';
 
-  return [
+  const lines = [
     'easyeda-mcp-pro doctor',
     '',
     `Node.js: ${status(report.nodeSupported)} ${report.nodeVersion} (supported: >=24 <27)`,
@@ -309,7 +384,13 @@ export function formatDoctorReport(report: DoctorReport): string {
     reachable
       ? 'Bridge server is running. If EasyEDA is not connected, reload the extension and click MCP Bridge > Connect.'
       : 'Bridge server is not running yet. This is normal until your MCP client starts easyeda-mcp-pro.',
-  ].join('\n');
+  ];
+
+  if (options?.fix) {
+    lines.push('', 'Suggested fixes:', ...buildSuggestedFixes(report));
+  }
+
+  return lines.join('\n');
 }
 
 export function formatHelp(): string {
@@ -330,7 +411,8 @@ export function formatHelp(): string {
     '             --copy <dir>  Copy .eext to the specified directory',
     '',
     '  easyeda-mcp-pro --setup-local                Print MCP client config (legacy)',
-    '  easyeda-mcp-pro --doctor                     Check runtime, package, and bridge status',
+    '  easyeda-mcp-pro --doctor [--fix]              Check runtime, package, and bridge status',
+    '    --fix     Print suggested fixes for each detected failure (no files are changed)',
     '  easyeda-mcp-pro --version                    Print package version',
     '',
     'Examples:',

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,9 @@ async function main() {
   }
 
   if (cli.command === 'doctor') {
-    process.stdout.write(`${formatDoctorReport(await createDoctorReport())}\n`);
+    process.stdout.write(
+      `${formatDoctorReport(await createDoctorReport(), { fix: cli.doctorFix })}\n`,
+    );
     return;
   }
 

--- a/src/server/factory.ts
+++ b/src/server/factory.ts
@@ -87,6 +87,27 @@ export async function createServer(config: EnvConfig): Promise<McpServerInstance
         logger.debug({ method }, 'bridge call');
         return bridge.call(method, params, opts);
       },
+      get uptimeMs() {
+        return bridge.uptimeMs;
+      },
+      get activePort() {
+        return bridge.activePort;
+      },
+      get lastHeartbeatMs() {
+        return bridge.lastHeartbeatMs;
+      },
+      get methodRegistryHash() {
+        return bridge.methodRegistryHash;
+      },
+      get easyedaVersion() {
+        return bridge.easyedaVersion;
+      },
+      get extensionVersion() {
+        return bridge.extensionVersion;
+      },
+      get extensionVersionMismatch() {
+        return bridge.extensionVersionMismatch;
+      },
     },
     config: {
       bridgeTimeoutMs: config.BRIDGE_TIMEOUT_MS,

--- a/src/tools/L0_diagnostics_core.ts
+++ b/src/tools/L0_diagnostics_core.ts
@@ -3,6 +3,7 @@ import { type BridgeDiagnosticsSnapshot, type ToolDefinition, type ToolContext }
 import { type EnvConfig } from '../config/env.js';
 import { PROFILE_DEFINITIONS } from '../config/profiles.js';
 import { SERVER_VERSION } from '../config/version.js';
+import { STARTER_DEVICE_CATALOG } from '../catalog/index.js';
 import {
   DEFAULT_LATENCY_BUDGETS,
   DEFAULT_RETENTION_POLICY,
@@ -44,13 +45,13 @@ function registerDiagnosticsCore(
     name: 'easyeda_health_check',
     title: 'Health check',
     description:
-      'Return server health status, including runtime version, active profile, bridge state, and config validity.',
+      'Return server health status in one call: runtime version, active profile, bridge state, EasyEDA version, keyless sourcing state, and starter catalog size. Intended as the single actionable status check after first connecting the bridge extension.',
     profile: 'core',
     evidence: ['official-docs'],
     risk: 'low',
     confirmWrite: false,
     group: 'diagnostics',
-    version: '1.0.0',
+    version: '1.1.0',
     annotations: {
       readOnlyHint: true,
       idempotentHint: true,
@@ -63,16 +64,31 @@ function registerDiagnosticsCore(
       profile: z.string(),
       transport: z.string(),
       bridge_connected: z.boolean(),
+      easyeda_version: z.string().optional(),
+      extension_version: z.string().optional(),
+      extension_version_mismatch: z.boolean(),
+      keyless_sourcing_enabled: z.boolean(),
+      catalog_device_count: z.number().int().nonnegative(),
       ups: z.number(),
     }),
     handler: async (ctx: ToolContext, _params: unknown) => {
+      const extensionVersionMismatch = ctx.bridge.extensionVersionMismatch ?? false;
       return {
-        status: ctx.bridge.connected ? ('ok' as const) : ('degraded' as const),
+        status: !ctx.bridge.connected
+          ? ('degraded' as const)
+          : extensionVersionMismatch
+            ? ('degraded' as const)
+            : ('ok' as const),
         version: SERVER_VERSION,
         node_version: process.version,
         profile: ctx.profile,
         transport: config.TRANSPORT,
         bridge_connected: ctx.bridge.connected,
+        easyeda_version: ctx.bridge.easyedaVersion,
+        extension_version: ctx.bridge.extensionVersion,
+        extension_version_mismatch: extensionVersionMismatch,
+        keyless_sourcing_enabled: ctx.config.keylessSourcingEnabled ?? true,
+        catalog_device_count: STARTER_DEVICE_CATALOG.length,
         ups: process.uptime(),
       };
     },
@@ -466,10 +482,32 @@ function registerDiagnosticsCore(
           status: ctx.bridge.connected ? ('pass' as const) : ('warn' as const),
           message: ctx.bridge.connected ? 'Bridge connected' : 'Bridge not connected',
         },
+        {
+          name: 'easyeda_version_detected',
+          status: ctx.bridge.easyedaVersion ? ('pass' as const) : ('skipped' as const),
+          message: ctx.bridge.easyedaVersion
+            ? `EasyEDA Pro version ${ctx.bridge.easyedaVersion}`
+            : ctx.bridge.connected
+              ? 'Skipped: bridge connected but did not report an EasyEDA version'
+              : 'Skipped: bridge not connected',
+        },
+        {
+          name: 'extension_version_match',
+          status: !ctx.bridge.extensionVersion
+            ? ('skipped' as const)
+            : ctx.bridge.extensionVersionMismatch
+              ? ('warn' as const)
+              : ('pass' as const),
+          message: !ctx.bridge.extensionVersion
+            ? 'Skipped: extension did not report a version'
+            : ctx.bridge.extensionVersionMismatch
+              ? `Extension version ${ctx.bridge.extensionVersion} does not match server version ${SERVER_VERSION}; update the extension in EasyEDA Pro`
+              : 'Extension version matches server version',
+        },
       ];
 
       return {
-        passed: checks.every((c) => c.status === 'pass'),
+        passed: checks.every((c) => c.status === 'pass' || c.status === 'skipped'),
         checks,
       };
     },

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -72,6 +72,9 @@ export interface ToolContext {
     lastHeartbeatMs?: number;
     methodRegistryHash?: string;
     telemetry?: unknown;
+    easyedaVersion?: string;
+    extensionVersion?: string;
+    extensionVersionMismatch?: boolean;
   };
   config: {
     bridgeTimeoutMs: number;

--- a/tests/unit/bridge/manager.test.ts
+++ b/tests/unit/bridge/manager.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { EnvSchema } from '../../../src/config/env.js';
 import { BridgeManager, parsePortScanSpec } from '../../../src/bridge/manager.js';
 import { getLogger } from '../../../src/utils/logger.js';
+import { SERVER_VERSION } from '../../../src/config/version.js';
 
 function createTestConfig(overrides: Record<string, unknown> = {}) {
   return EnvSchema.parse({
@@ -194,9 +195,65 @@ describe('BridgeManager', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       expect.stringContaining('version mismatch: extension is v0.0.1'),
     );
+    expect(manager.extensionVersion).toBe('0.0.1');
+    expect(manager.extensionVersionMismatch).toBe(true);
+    expect(manager.easyedaVersion).toBe('test');
 
     warnSpy.mockRestore();
     socket.close();
+    manager.disconnect('test complete');
+  });
+
+  it('reports no version mismatch when the extension version matches the server version', async () => {
+    const port = await getFreePort();
+    const config = createTestConfig({ BRIDGE_HOST: '127.0.0.1', BRIDGE_PORT_SCAN: String(port) });
+    const manager = new BridgeManager(config);
+    await manager.connect();
+
+    const socket = await openSocket(port);
+    socket.send(
+      JSON.stringify({
+        type: 'handshake',
+        protocol: 'easyeda-mcp-pro.bridge',
+        protocolVersion: '1.0.0',
+        clientName: 'easyeda-mcp-pro',
+        extensionVersion: SERVER_VERSION,
+        easyedaVersion: '2.0.0',
+        devMode: false,
+      }),
+    );
+
+    await expect(waitForMessage(socket)).resolves.toMatchObject({ type: 'hello' });
+
+    expect(manager.extensionVersion).toBe(SERVER_VERSION);
+    expect(manager.extensionVersionMismatch).toBe(false);
+    expect(manager.easyedaVersion).toBe('2.0.0');
+
+    socket.close();
+    manager.disconnect('test complete');
+  });
+
+  it('clears extensionVersion/easyedaVersion on disconnect', async () => {
+    const port = await getFreePort();
+    const config = createTestConfig({ BRIDGE_HOST: '127.0.0.1', BRIDGE_PORT_SCAN: String(port) });
+    const manager = new BridgeManager(config);
+    await manager.connect();
+
+    const socket = await openSocket(port);
+    sendHandshake(socket);
+    await expect(waitForMessage(socket)).resolves.toMatchObject({ type: 'hello' });
+    expect(manager.easyedaVersion).toBeDefined();
+
+    const closed = waitForClose(socket);
+    socket.close();
+    await closed;
+    // Give the manager's close handler a tick to run.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(manager.extensionVersion).toBeUndefined();
+    expect(manager.extensionVersionMismatch).toBe(false);
+    expect(manager.easyedaVersion).toBeUndefined();
+
     manager.disconnect('test complete');
   });
 });

--- a/tests/unit/cli/auto-setup.test.ts
+++ b/tests/unit/cli/auto-setup.test.ts
@@ -52,7 +52,40 @@ describe('auto-setup CLI module', () => {
 
     const result = runSetup({ client: 'cursor', profile: 'pro' });
     expect(result).toContain('Updated Cursor IDE config');
+    expect(result).not.toContain('Stale entry detected');
+    expect(result).not.toContain('already up to date');
     expect(fs.writeFileSync).toHaveBeenCalled();
+  });
+
+  it('detects and replaces a stale existing server entry', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        mcpServers: {
+          'easyeda-mcp-pro': { command: 'node', args: ['/old/path/dist/index.js'] },
+        },
+      }),
+    );
+
+    const result = runSetup({ client: 'cursor', profile: 'pro' });
+    expect(result).toContain('Stale entry detected and replaced');
+    expect(result).toContain('command:');
+    expect(result).toContain('args:');
+  });
+
+  it('reports an existing entry as already up to date when it matches exactly', () => {
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({
+        mcpServers: {
+          'easyeda-mcp-pro': { command: 'npx', args: ['-y', 'easyeda-mcp-pro@latest'] },
+        },
+      }),
+    );
+
+    const result = runSetup({ client: 'cursor', profile: 'core' });
+    expect(result).toContain('Existing entry was already up to date.');
+    expect(result).not.toContain('Stale entry detected');
   });
 
   it('runs extension command and detects path', () => {

--- a/tests/unit/cli/local-setup.test.ts
+++ b/tests/unit/cli/local-setup.test.ts
@@ -73,6 +73,11 @@ describe('local setup CLI helpers', () => {
     expect(parseCliArgs(['--not-a-real-flag']).command).toBe('server');
   });
 
+  it('parses the doctor --fix flag', () => {
+    expect(parseCliArgs(['doctor', '--fix'])).toEqual({ command: 'doctor', doctorFix: true });
+    expect(parseCliArgs(['--doctor'])).toEqual({ command: 'doctor', doctorFix: false });
+  });
+
   it('formats MCP client auto-start setup instructions', () => {
     const report = formatSetupLocalReport({
       packageName: 'easyeda-mcp-pro',
@@ -132,6 +137,87 @@ describe('local setup CLI helpers', () => {
     expect(formatDoctorReport(report)).toContain(
       'LCSC: enabled / configured / optional-missing / public-jlcsearch',
     );
+    expect(formatDoctorReport(report)).not.toContain('Suggested fixes:');
+  });
+
+  it('doctor --fix prints suggested fixes for each detected failure', () => {
+    const report: DoctorReport = {
+      setup: {
+        packageName: 'easyeda-mcp-pro',
+        packageVersion: '0.3.2',
+        packageRoot: '/repo',
+        serverEntryPath: '/repo/dist/index.js',
+        extensionPackagePath: '/repo/easyeda-bridge-extension.eext',
+        serverEntryExists: false,
+        extensionPackageExists: false,
+      },
+      nodeVersion: '18.19.0',
+      nodeSupported: false,
+      pnpmVersion: null,
+      envValid: false,
+      envIssues: ['BRIDGE_PORT: Expected number, received string'],
+      bridgeHost: '127.0.0.1',
+      bridgePorts: [
+        { port: 49620, reachable: false },
+        { port: 49621, reachable: false },
+      ],
+      toolCounts: { profile: 'core', enabled: 10, total: 20 },
+      vendorsConfigured: { MOUSER: false },
+      vendorDiagnostics: {
+        MOUSER: { enabled: true, configured: false, mode: 'api', credentialStatus: 'missing' },
+      },
+    };
+
+    const output = formatDoctorReport(report, { fix: true });
+
+    expect(output).toContain('Suggested fixes:');
+    expect(output).toContain('nvm install 24 && nvm use 24');
+    expect(output).toContain('npm install -g pnpm');
+    expect(output).toContain('Fix: set/correct BRIDGE_PORT: Expected number, received string');
+    expect(output).toContain('pnpm build');
+    expect(output).toContain('pnpm build:extension');
+    expect(output).toContain('Extension Manager and confirm the bridge extension is imported');
+    expect(output).toContain('MOUSER is enabled but missing required credentials');
+  });
+
+  it('doctor --fix reports a fallback port and no issues when everything is healthy', () => {
+    const healthyReport: DoctorReport = {
+      setup: {
+        packageName: 'easyeda-mcp-pro',
+        packageVersion: '0.3.2',
+        packageRoot: '/repo',
+        serverEntryPath: '/repo/dist/index.js',
+        extensionPackagePath: '/repo/easyeda-bridge-extension.eext',
+        serverEntryExists: true,
+        extensionPackageExists: true,
+      },
+      nodeVersion: '24.16.0',
+      nodeSupported: true,
+      pnpmVersion: '11.0.0',
+      envValid: true,
+      envIssues: [],
+      bridgeHost: '127.0.0.1',
+      bridgePorts: [{ port: 49620, reachable: true }],
+      toolCounts: { profile: 'core', enabled: 10, total: 20 },
+      vendorsConfigured: {},
+      vendorDiagnostics: {},
+    };
+
+    expect(formatDoctorReport(healthyReport, { fix: true })).toContain(
+      'No issues detected — nothing to fix.',
+    );
+
+    const fallbackReport: DoctorReport = {
+      ...healthyReport,
+      bridgePorts: [
+        { port: 49620, reachable: false },
+        { port: 49621, reachable: true },
+      ],
+    };
+
+    const fallbackOutput = formatDoctorReport(fallbackReport, { fix: true });
+    expect(fallbackOutput).toContain('reachable on a fallback port (49621)');
+    expect(fallbackOutput).toContain('BRIDGE_PORT=49621');
   });
 
   it('prints concise help', () => {

--- a/tests/unit/server/factory.test.ts
+++ b/tests/unit/server/factory.test.ts
@@ -45,6 +45,13 @@ vi.mock('../../../src/bridge/manager.js', () => ({
     connect = mocks.connect;
     disconnect = mocks.disconnect;
     call = mocks.call;
+    uptimeMs = 12345;
+    activePort = 49620;
+    lastHeartbeatMs = 999;
+    methodRegistryHash = 'test-hash';
+    easyedaVersion = '2.0.0';
+    extensionVersion = '0.20.0';
+    extensionVersionMismatch = true;
   },
 }));
 vi.mock('../../../src/tools/registry.js', () => ({
@@ -114,6 +121,23 @@ describe('createServer', () => {
 
     expect(mocks.logger.debug).toHaveBeenCalledWith({ method: 'ping' }, 'bridge call');
     expect(mocks.call).toHaveBeenCalledWith('ping', { value: 1 }, undefined);
+  });
+
+  it('exposes bridge diagnostics and version fields through the tool context', async () => {
+    const instance = await createServer(config());
+
+    expect(instance.context.bridge.uptimeMs).toBe(12345);
+    expect(instance.context.bridge.activePort).toBe(49620);
+    expect(instance.context.bridge.lastHeartbeatMs).toBe(999);
+    expect(instance.context.bridge.methodRegistryHash).toBe('test-hash');
+    expect(instance.context.bridge.easyedaVersion).toBe('2.0.0');
+    expect(instance.context.bridge.extensionVersion).toBe('0.20.0');
+    expect(instance.context.bridge.extensionVersionMismatch).toBe(true);
+  });
+
+  it('exposes keylessSourcingEnabled through the tool context config', async () => {
+    const instance = await createServer(config({ KEYLESS_SOURCING_ENABLED: false }));
+    expect(instance.context.config.keylessSourcingEnabled).toBe(false);
   });
 
   it('creates vendor clients when enabled', async () => {

--- a/tests/unit/tools/diagnostics.test.ts
+++ b/tests/unit/tools/diagnostics.test.ts
@@ -53,6 +53,9 @@ describe('Diagnostics Tools', () => {
     expect(result?.node_version).toBeDefined();
     expect(result?.transport).toBe('stdio');
     expect(result?.ups).toBeGreaterThanOrEqual(0);
+    expect(result?.keyless_sourcing_enabled).toBe(true);
+    expect(result?.catalog_device_count).toBeGreaterThan(0);
+    expect(result?.extension_version_mismatch).toBe(false);
   });
 
   it('easyeda_health_check returns degraded when bridge not connected', async () => {
@@ -71,6 +74,40 @@ describe('Diagnostics Tools', () => {
 
     expect(result?.status).toBe('degraded');
     expect(result?.bridge_connected).toBe(false);
+  });
+
+  it('easyeda_health_check surfaces EasyEDA version and extension version mismatch', async () => {
+    const tool = registry.get('easyeda_health_check');
+
+    const mismatchContext: ToolContext = {
+      ...context,
+      bridge: {
+        connected: true,
+        call: bridgeCall,
+        easyedaVersion: '2.1.0',
+        extensionVersion: '0.0.1',
+        extensionVersionMismatch: true,
+      },
+    };
+
+    const result = await tool?.handler(mismatchContext, {});
+
+    expect(result?.status).toBe('degraded');
+    expect(result?.easyeda_version).toBe('2.1.0');
+    expect(result?.extension_version).toBe('0.0.1');
+    expect(result?.extension_version_mismatch).toBe(true);
+  });
+
+  it('easyeda_health_check reflects keylessSourcingEnabled=false from ctx.config', async () => {
+    const tool = registry.get('easyeda_health_check');
+
+    const disabledContext: ToolContext = {
+      ...context,
+      config: { ...context.config, keylessSourcingEnabled: false },
+    };
+
+    const result = await tool?.handler(disabledContext, {});
+    expect(result?.keyless_sourcing_enabled).toBe(false);
   });
 
   it('easyeda_bridge_status returns connected status with bridge details', async () => {
@@ -228,5 +265,42 @@ describe('Diagnostics Tools', () => {
     const bridgeCheck = result?.checks.find((c) => c.name === 'bridge_connected');
     expect(bridgeCheck?.status).toBe('warn');
     expect(bridgeCheck?.message).toBe('Bridge not connected');
+
+    const versionCheck = result?.checks.find((c) => c.name === 'easyeda_version_detected');
+    expect(versionCheck?.status).toBe('skipped');
+  });
+
+  it('easyeda_run_self_test passes easyeda_version_detected when the version is known', async () => {
+    const tool = registry.get('easyeda_run_self_test');
+
+    const versionedContext: ToolContext = {
+      ...context,
+      bridge: { connected: true, call: bridgeCall, easyedaVersion: '2.1.0' },
+    };
+
+    const result = await tool?.handler(versionedContext, {});
+    const versionCheck = result?.checks.find((c) => c.name === 'easyeda_version_detected');
+    expect(versionCheck?.status).toBe('pass');
+    expect(versionCheck?.message).toContain('2.1.0');
+    expect(result?.passed).toBe(true);
+  });
+
+  it('easyeda_run_self_test warns on extension_version_match when versions differ', async () => {
+    const tool = registry.get('easyeda_run_self_test');
+
+    const mismatchContext: ToolContext = {
+      ...context,
+      bridge: {
+        connected: true,
+        call: bridgeCall,
+        extensionVersion: '0.0.1',
+        extensionVersionMismatch: true,
+      },
+    };
+
+    const result = await tool?.handler(mismatchContext, {});
+    const extCheck = result?.checks.find((c) => c.name === 'extension_version_match');
+    expect(extCheck?.status).toBe('warn');
+    expect(result?.passed).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

WS-02 (Zero-Friction Onboarding & First-Run UX), scoped to CLI/diagnostics
improvements only (the `.mcpb` bundle + release workflow changes are deferred to a
separate PR since they touch CI/CD infrastructure).

- `easyeda_health_check` was a thin snapshot (`bridge_connected`/`profile`/`transport`
  only). It now reports `easyeda_version`, `extension_version`,
  `extension_version_mismatch`, `keyless_sourcing_enabled`, and `catalog_device_count`
  in one call, and degrades `status` on a version mismatch — the single actionable
  status check WS-02 asks for.
- `easyeda_run_self_test` gains `easyeda_version_detected` and
  `extension_version_match` checks.
- `BridgeManager` already computed an extension-version-mismatch warning at handshake
  time but only ever logged it. It now tracks `extensionVersion` and exposes
  `easyedaVersion` / `extensionVersion` / `extensionVersionMismatch` as public getters
  (reset on disconnect), wired into `ToolContext.bridge` via `server/factory.ts`.
- Found and fixed a pre-existing gap while wiring this: `uptimeMs`, `activePort`,
  `lastHeartbeatMs`, and `methodRegistryHash` were declared on `ToolContext.bridge` and
  read by `easyeda_bridge_status`'s diagnostics block, but never actually assigned in
  `factory.ts` — they were always `undefined` in production. Now wired.
- `doctor --fix` prints a suggested-fixes section with the exact command or setting
  for each detected failure (unsupported Node version, missing pnpm, invalid env,
  missing build artifacts, unreachable bridge port, missing vendor credentials). It
  only prints guidance — it never modifies files or system state.
- `setup <client>` now detects when an existing MCP client config entry differs from
  the one being written and reports "Stale entry detected and replaced" with a compact
  diff, instead of silently overwriting with no explanation.
- `docs/TROUBLESHOOTING.md` documents extension-version-mismatch, `doctor --fix`, and
  stale-config detection.

No new runtime dependencies were added.

## Test plan

- [x] `pnpm verify` (format, typecheck incl. extension, lint, tool-metadata lint,
      tool-coverage, full test suite, build incl. extension, metadata check, docs
      build) — all green, 855/855 tests passing.
- [x] New/updated unit tests: `BridgeManager` extension-version tracking/mismatch/reset
      on disconnect, `factory.ts` bridge-getter wiring, `easyeda_health_check` /
      `easyeda_run_self_test` enrichment (including the keyless-sourcing-disabled and
      version-mismatch cases), `doctor --fix` output across multiple failure
      permutations and the healthy/fallback-port cases, and stale-vs-up-to-date
      config detection in `setup`.