### PR TITLE
feat(visual): add canvas capture tools and fix Blob export serialization

### DIFF
--- a/docs/SAFETY_MODEL.md
+++ b/docs/SAFETY_MODEL.md
@@ -8,11 +8,11 @@ This document explains the security posture, permission checks, data privacy con
 
 Our tools are categorized into three risk tiers based on their potential impact on project data and external services:
 
-| Risk Level | Tool Type                            | Description                                                                                                           | Confirmation Required         |
-| :--------- | :----------------------------------- | :-------------------------------------------------------------------------------------------------------------------- | :---------------------------- |
-| **Low**    | `Read-only` / `Diagnostics`          | Queries project metadata, diagnostics status, layers, stackups, and BOM. Cannot mutate project state.                 | **No**                        |
-| **Medium** | `Schematic Write`                    | Mutates schematic sheets (placing components, drawing wires, deleting or modifying primitives).                       | **Yes (`confirmWrite=true`)** |
-| **High**   | `PCB Write` / `Exports` / `API Call` | Mutates PCB layouts (tracks, vias, zones, components), exports fabrication files, or makes direct class-method calls. | **Yes (`confirmWrite=true`)** |
+| Risk Level | Tool Type                              | Description                                                                                                                                                                                                                                                                                                                  | Confirmation Required         |
+| :--------- | :------------------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :---------------------------- |
+| **Low**    | `Read-only` / `Diagnostics` / `Visual` | Queries project metadata, diagnostics status, layers, stackups, BOM, and canvas captures (`easyeda_canvas_capture`, `easyeda_canvas_capture_region`, `easyeda_canvas_locate`). Cannot mutate project state, though a capture/locate call does move the user's visible viewport (EasyEDA Pro has no offscreen rendering API). | **No**                        |
+| **Medium** | `Schematic Write`                      | Mutates schematic sheets (placing components, drawing wires, deleting or modifying primitives).                                                                                                                                                                                                                              | **Yes (`confirmWrite=true`)** |
+| **High**   | `PCB Write` / `Exports` / `API Call`   | Mutates PCB layouts (tracks, vias, zones, components), exports fabrication files, or makes direct class-method calls.                                                                                                                                                                                                        | **Yes (`confirmWrite=true`)** |
 
 ---
 
@@ -45,6 +45,10 @@ Only explicitly initiated queries to third-party suppliers are sent over the net
 3. **Mouser / DigiKey**: Retrieves market pricing and stock data if Mouser/DigiKey credentials are provided in `.env`.
 
 _No design geometry or netlist data is ever uploaded to these suppliers._
+
+Canvas captures (`easyeda_canvas_capture*`) are returned directly as MCP image content in
+the tool response — they are not written to `ARTIFACT_DIR` or persisted anywhere on the
+server by default. The image only goes as far as the MCP client that requested it.
 
 ---
 

--- a/docs/TOOL_APPROVAL_POLICY.md
+++ b/docs/TOOL_APPROVAL_POLICY.md
@@ -4,12 +4,12 @@ Remote tool approval protects the user from unintended project changes when a cl
 
 ## Risk levels
 
-| Risk level  | Examples                                                     | Default behavior                                          |
-| ----------- | ------------------------------------------------------------ | --------------------------------------------------------- |
-| Read        | list project, inspect netlist, read BOM, read DRC/ERC report | Allowed after auth and pairing.                           |
-| Write       | add component, create net, edit wire, update PCB primitive   | Requires explicit approval.                               |
-| Export      | generate Gerber, BOM, pick-and-place, manufacturing package  | Requires explicit approval.                               |
-| Destructive | delete, overwrite, bulk replace, publish/share, place order  | Requires stronger confirmation or is disabled by default. |
+| Risk level  | Examples                                                                           | Default behavior                                          |
+| ----------- | ---------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| Read        | list project, inspect netlist, read BOM, read DRC/ERC report, capture canvas image | Allowed after auth and pairing.                           |
+| Write       | add component, create net, edit wire, update PCB primitive                         | Requires explicit approval.                               |
+| Export      | generate Gerber, BOM, pick-and-place, manufacturing package                        | Requires explicit approval.                               |
+| Destructive | delete, overwrite, bulk replace, publish/share, place order                        | Requires stronger confirmation or is disabled by default. |
 
 ## Approval prompt requirements
 

--- a/docs/examples/cookbook.md
+++ b/docs/examples/cookbook.md
@@ -97,3 +97,32 @@ Run a manufacturing preflight for the active project. Check export package readi
 - Quote/order actions require explicit user confirmation and audit.
 - Export packages must include hashes and clear generation metadata.
 - Any missing board outline, drill, placement, or BOM artifact should block handoff until reviewed.
+
+## 6. Visual verification after a schematic edit
+
+**Goal:** After placing a component or drawing a wire, visually confirm the change looks
+right before continuing — catch overlaps, dangling wires, or misplacements a structural
+diff alone would miss.
+
+**Prompt:**
+
+```text
+Place a 0603 decoupling capacitor near U1's VCC pin and wire it to VCC and GND. After placing it, capture the area and check the result looks correct before doing anything else.
+```
+
+**Tool sequence:**
+
+1. `easyeda_schematic_place_component` / `easyeda_schematic_add_wire` (with `confirmWrite: true`)
+2. `easyeda_canvas_capture_region` framed around the edited area (or `easyeda_canvas_capture`
+   for the whole visible viewport)
+3. Visually inspect the returned PNG for overlaps, dangling wire ends, or misplacement
+4. If something looks wrong, use `easyeda_schematic_verify_write` or a follow-up
+   read-only inspection tool to confirm the structural state, then correct it
+
+**Safety checkpoints:**
+
+- `easyeda_canvas_capture_region` moves the user's visible viewport (EasyEDA Pro has no
+  offscreen rendering API) — mention this to the user before use in an interactive session.
+- Treat the captured image as a visual sanity check, not a substitute for DRC/ERC.
+- A capture that fails with `not_available` (e.g. `PAYLOAD_TOO_LARGE`) should fall back to
+  structural inspection tools rather than blocking the whole review.

--- a/docs/reference/bridge-contract.md
+++ b/docs/reference/bridge-contract.md
@@ -45,11 +45,17 @@ After accepting the handshake, the server replies:
   "easyedaVersion": "<runtime version>",
   "capabilities": ["schematic.listNets"],
   "methodRegistryHash": "<16-char sha256 prefix>",
-  "devMode": false
+  "devMode": false,
+  "maxPayloadSize": 1048576
 }
 ```
 
 `methodRegistryHash` is computed from the sorted bridge method registry. A changed hash means the server and extension should be rechecked against the live compatibility smoke harness.
+
+`maxPayloadSize` mirrors the server's configured `BRIDGE_MAX_PAYLOAD_SIZE` (bytes). The
+extension uses it to self-limit binary (Blob/File) results — e.g. `canvas.capture` and
+the `export.*` methods — before sending, since a response frame that exceeds this limit
+closes the whole WS connection (code 4009), not just the offending call.
 
 ## Compatibility rules
 
@@ -59,6 +65,8 @@ After accepting the handshake, the server replies:
 - Warn when extension and server package versions differ.
 - Include `methodRegistryHash` in every hello.
 - Extension logs a warning when the hello contract version differs or does not list its protocol version.
+- Extension self-limits binary (Blob/File) results to a safety margin under `maxPayloadSize`
+  before sending, returning a structured `PAYLOAD_TOO_LARGE` error instead of an oversized frame.
 
 ## Release checklist
 

--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -20,6 +20,9 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_bom_validate`                  | `core`  | `medium` | Validate the project BOM against LCSC inventory to identify missing, obsolete, or alternate parts.                                                                                                                                                                                                            |
 | `easyeda_bridge_probe_methods`          | `dev`   | `medium` | Query the EasyEDA Pro bridge for available API methods. Requires bridge connection. (dev/pro only)                                                                                                                                                                                                            |
 | `easyeda_bridge_status`                 | `core`  | `low`    | Check EasyEDA Pro bridge connection status, version, and capabilities.                                                                                                                                                                                                                                        |
+| `easyeda_canvas_capture`                | `core`  | `low`    | Capture the currently visible EasyEDA schematic/PCB canvas as a PNG image, so the caller can visually verify the result of a draw/place/route action. Captures the given tab (or the last-focused one) as-is; use easyeda_canvas_capture_region first to frame a specific area.                               |
+| `easyeda_canvas_capture_region`         | `core`  | `low`    | Zoom the EasyEDA canvas to a rectangular region (document/canvas coordinates) and capture it as a PNG, so the caller can visually verify a specific area. This moves the user's visible viewport — EasyEDA Pro has no offscreen rendering API.                                                                |
+| `easyeda_canvas_locate`                 | `core`  | `low`    | Zoom the EasyEDA canvas to a coordinate/scale (document/canvas coordinates), returning the resulting viewport rectangle. Useful to frame a location before calling easyeda_canvas_capture, or standalone to navigate the user's view to a point of interest.                                                  |
 | `easyeda_component_probe`               | `dev`   | `low`    | Inspect live schematic component objects, including available methods and state getter values, to validate EasyEDA runtime mappings.                                                                                                                                                                          |
 | `easyeda_drc_run`                       | `core`  | `medium` | Run design rule check (DRC) on the project to identify rule violations, clearance issues, and manufacturing constraints.                                                                                                                                                                                      |
 | `easyeda_erc_run`                       | `core`  | `medium` | Run electrical rule check (ERC) on the schematic to detect unconnected nets, short circuits, and electrical conflicts.                                                                                                                                                                                        |
@@ -457,6 +460,103 @@ Returns a JSON object matching the schema:
 
 ---
 
+## `easyeda_canvas_capture`
+
+**Profile:** `core` | **Risk Level:** `low`
+
+> Capture the currently visible EasyEDA schematic/PCB canvas as a PNG image, so the caller can visually verify the result of a draw/place/route action. Captures the given tab (or the last-focused one) as-is; use easyeda_canvas_capture_region first to frame a specific area.
+
+### Input Parameters
+
+| Parameter | Type  | Required | Description |
+| --------- | ----- | -------- | ----------- |
+| `tabId`   | `any` | No       |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  captured: any;
+  mime_type: any;
+  file_name: any;
+  byte_length: any;
+  image_base64: any;
+  not_available: any;
+  error: any;
+}
+```
+
+---
+
+## `easyeda_canvas_capture_region`
+
+**Profile:** `core` | **Risk Level:** `low`
+
+> Zoom the EasyEDA canvas to a rectangular region (document/canvas coordinates) and capture it as a PNG, so the caller can visually verify a specific area. This moves the user's visible viewport — EasyEDA Pro has no offscreen rendering API.
+
+### Input Parameters
+
+| Parameter | Type  | Required | Description |
+| --------- | ----- | -------- | ----------- |
+| `left`    | `any` | Yes      |             |
+| `right`   | `any` | Yes      |             |
+| `top`     | `any` | Yes      |             |
+| `bottom`  | `any` | Yes      |             |
+| `tabId`   | `any` | No       |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  captured: any;
+  mime_type: any;
+  file_name: any;
+  byte_length: any;
+  image_base64: any;
+  not_available: any;
+  error: any;
+}
+```
+
+---
+
+## `easyeda_canvas_locate`
+
+**Profile:** `core` | **Risk Level:** `low`
+
+> Zoom the EasyEDA canvas to a coordinate/scale (document/canvas coordinates), returning the resulting viewport rectangle. Useful to frame a location before calling easyeda_canvas_capture, or standalone to navigate the user's view to a point of interest.
+
+### Input Parameters
+
+| Parameter    | Type  | Required | Description |
+| ------------ | ----- | -------- | ----------- |
+| `x`          | `any` | No       |             |
+| `y`          | `any` | No       |             |
+| `scaleRatio` | `any` | No       |             |
+| `tabId`      | `any` | No       |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  located: any;
+  left: any;
+  right: any;
+  top: any;
+  bottom: any;
+  not_available: any;
+  error: any;
+}
+```
+
+---
+
 ## `easyeda_component_probe`
 
 **Profile:** `dev` | **Risk Level:** `low`
@@ -557,6 +657,7 @@ Returns a JSON object matching the schema:
 | Parameter          | Type  | Required | Description |
 | ------------------ | ----- | -------- | ----------- |
 | `projectId`        | `any` | Yes      |             |
+| `filePath`         | `any` | No       |             |
 | `drillFormat`      | `any` | No       |             |
 | `excludeLayer`     | `any` | No       |             |
 | `ledPanel`         | `any` | No       |             |
@@ -570,11 +671,13 @@ Returns a JSON object matching the schema:
 {
   project_id: any;
   artifact_path: any;
+  byte_length: any;
   file_count: any;
   exported: any;
   blocked_by_production_review: any;
   production_review: any;
   not_available: any;
+  error: any;
 }
 ```
 
@@ -592,6 +695,7 @@ Returns a JSON object matching the schema:
 | ----------- | ----- | -------- | ----------- |
 | `projectId` | `any` | Yes      |             |
 | `format`    | `any` | Yes      |             |
+| `filePath`  | `any` | No       |             |
 
 ### Output Format
 
@@ -602,9 +706,11 @@ Returns a JSON object matching the schema:
   project_id: any;
   format: any;
   file_path: any;
+  byte_length: any;
   net_count: any;
   exported: any;
   not_available: any;
+  error: any;
 }
 ```
 
@@ -623,6 +729,7 @@ Returns a JSON object matching the schema:
 | `projectId`   | `any` | Yes      |             |
 | `scope`       | `any` | Yes      |             |
 | `orientation` | `any` | Yes      |             |
+| `filePath`    | `any` | No       |             |
 
 ### Output Format
 
@@ -634,9 +741,11 @@ Returns a JSON object matching the schema:
   scope: any;
   orientation: any;
   file_path: any;
+  byte_length: any;
   pages: any;
   exported: any;
   not_available: any;
+  error: any;
 }
 ```
 
@@ -654,6 +763,7 @@ Returns a JSON object matching the schema:
 | ----------- | ----- | -------- | ----------- |
 | `projectId` | `any` | Yes      |             |
 | `format`    | `any` | Yes      |             |
+| `filePath`  | `any` | No       |             |
 
 ### Output Format
 
@@ -664,9 +774,11 @@ Returns a JSON object matching the schema:
   project_id: any;
   format: any;
   file_path: any;
+  byte_length: any;
   component_count: any;
   exported: any;
   not_available: any;
+  error: any;
 }
 ```
 

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -107,10 +107,10 @@ Tools are organized into hierarchical profiles: `core` < `pro` < `full` < `dev` 
 - The `TOOL_PROFILE` environment variable selects which tools are enabled.
 - Each tool definition declares a minimum `profile` level.
 - Only tools at or below the active profile are registered on the MCP server.
-- `core` is the default and exposes 44 tools.
-- `pro` exposes 49 tools and adds manufacturing export tools (pick-and-place, PDF, netlist).
-- `full` exposes 58 tools and adds the controlled `easyeda_api_call` tool for direct EasyEDA API access.
-- `dev` exposes 62 tools and adds runtime probes for debugging (bridge method probing, component inspection).
+- `core` is the default and exposes 47 tools.
+- `pro` exposes 52 tools and adds manufacturing export tools (pick-and-place, PDF, netlist).
+- `full` exposes 61 tools and adds the controlled `easyeda_api_call` tool for direct EasyEDA API access.
+- `dev` exposes 65 tools and adds runtime probes for debugging (bridge method probing, component inspection).
 - `experimental` is reserved for future MCP Apps, Tasks, simulation, autorouter, and AI action plan capabilities; it currently does not add registered tools beyond `dev`.
 
 **Security principle:** Privilege escalation is prevented because tool registration happens at startup. Changing the active profile requires a server restart.

--- a/easyeda-bridge-extension/package.json
+++ b/easyeda-bridge-extension/package.json
@@ -6,11 +6,13 @@
     "build": "esbuild src/index.ts --bundle --format=iife --platform=browser --target=es2020 --outfile=dist/index.js && node scripts/package.mjs",
     "build:watch": "esbuild src/index.ts --bundle --format=iife --platform=browser --target=es2020 --outfile=dist/index.js --watch",
     "typecheck": "tsc --noEmit -p tsconfig.json",
+    "test": "vitest run",
     "verify": "node scripts/verify-dist.mjs"
   },
   "devDependencies": {
     "archiver": "^8.0.0",
     "esbuild": "^0.28.1",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
   }
 }

--- a/easyeda-bridge-extension/src/binary-result.ts
+++ b/easyeda-bridge-extension/src/binary-result.ts
@@ -1,0 +1,82 @@
+/**
+ * Binary result handling (Blob/File → base64).
+ *
+ * EasyEDA Pro's manufacturing-data and canvas-capture APIs return in-memory
+ * Blob/File objects (e.g. `PCB_ManufactureData.getGerberFile`,
+ * `DMT_EditorControl.getCurrentRenderedAreaImage`). The bridge transport is
+ * JSON-only (see `send()` in index.ts), and `JSON.stringify` on a Blob/File
+ * produces `{}` — no own enumerable properties — silently dropping the
+ * payload. Every dispatch case that can return a Blob/File must route its
+ * result through {@link normalizeBinaryResult} before returning.
+ *
+ * Kept in its own module (rather than inline in index.ts) so it can be unit
+ * tested without triggering index.ts's module-load side effects (WebSocket
+ * bootstrap, auto-connect).
+ */
+
+const MIME_TYPES_BY_EXTENSION: Record<string, string> = {
+  pdf: 'application/pdf',
+  zip: 'application/zip',
+  csv: 'text/csv',
+  txt: 'text/plain',
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  json: 'application/json',
+};
+
+export function guessMimeType(fileName: string): string {
+  const ext = fileName.split('.').pop()?.toLowerCase();
+  return (ext && MIME_TYPES_BY_EXTENSION[ext]) || 'application/octet-stream';
+}
+
+/** True for anything duck-typed as a Blob/File (has an `arrayBuffer()` method). */
+export function isBlobLike(value: unknown): value is Blob {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as { arrayBuffer?: unknown }).arrayBuffer === 'function'
+  );
+}
+
+/**
+ * Convert a Blob/File to a base64 string. Chunked to avoid a call-stack
+ * overflow from `String.fromCharCode(...bytes)` on large payloads (multi-MB
+ * PDFs/gerbers/canvas captures).
+ */
+export async function blobToBase64(blob: Blob): Promise<string> {
+  const buffer = await blob.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  return btoa(binary);
+}
+
+export interface BinaryResultPayload {
+  base64: string;
+  mimeType: string;
+  fileName: string;
+  byteLength: number;
+}
+
+/**
+ * Convert any Blob/File dispatch result into a JSON-safe base64 payload; pass
+ * through anything else (e.g. a plain netlist object) unchanged.
+ */
+export async function normalizeBinaryResult(
+  value: unknown,
+  fallbackFileName: string,
+): Promise<BinaryResultPayload | unknown> {
+  if (!isBlobLike(value)) return value;
+  const fileName = (value as File).name || fallbackFileName;
+  const base64 = await blobToBase64(value);
+  return {
+    base64,
+    mimeType: value.type || guessMimeType(fileName),
+    fileName,
+    byteLength: value.size,
+  };
+}

--- a/easyeda-bridge-extension/src/index.ts
+++ b/easyeda-bridge-extension/src/index.ts
@@ -1,4 +1,5 @@
 import { RemoteRelayClient, type RemoteRelayMode } from './remote-client.js';
+import { normalizeBinaryResult, type BinaryResultPayload } from './binary-result.js';
 
 declare const eda: EasyedaGlobal | undefined;
 declare const EDA: unknown | undefined;
@@ -124,6 +125,11 @@ const RECONNECT_MAX_MS = 30000;
 const STORAGE_KEY = 'easyeda-mcp-pro:autoConnect';
 const HEARTBEAT_MS = 15000;
 const SOCKET_ID = 'easyeda-mcp-pro-bridge';
+// Fraction of the server's advertised BRIDGE_MAX_PAYLOAD_SIZE we allow a single
+// binary (Blob/File) result to use, leaving headroom for base64 (~1.33x raw
+// bytes) plus JSON envelope overhead. Exceeding the server's actual limit closes
+// the whole WS connection, not just the offending call — so we self-limit first.
+const PAYLOAD_SAFETY_MARGIN = 0.6;
 const API_CLASS_PREFIXES = ['DMT_', 'SCH_', 'PCB_', 'LIB_'] as const;
 const DENIED_API_METHODS = new Set([
   'constructor',
@@ -142,6 +148,9 @@ let manualDisconnectRequested = false;
 let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 let externalInteractionWarningShown = false;
+// Updated from the server's `hello` message; matches BRIDGE_MAX_PAYLOAD_SIZE default
+// until the handshake completes.
+let bridgeMaxPayloadSize = 1_048_576;
 
 let remoteRelayClient: RemoteRelayClient | null = null;
 
@@ -338,6 +347,41 @@ function extractPrimitiveId(result: unknown): string {
     /* ignore */
   }
   return '';
+}
+
+function isBinaryResultPayload(value: unknown): value is BinaryResultPayload {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as { base64?: unknown }).base64 === 'string' &&
+    typeof (value as { byteLength?: unknown }).byteLength === 'number'
+  );
+}
+
+/**
+ * Wraps `normalizeBinaryResult`, additionally rejecting a payload that would
+ * exceed the server's advertised BRIDGE_MAX_PAYLOAD_SIZE (see
+ * `bridgeMaxPayloadSize`) before it is ever handed to `send()`. Sending an
+ * oversized WS frame closes the whole connection (code 4009) rather than just
+ * failing this one call, so we throw a normal, small, structured error
+ * instead — handleRequest() turns it into an ok:false response.
+ */
+async function normalizeBinaryResultSafely(
+  value: unknown,
+  fallbackFileName: string,
+): Promise<unknown> {
+  const normalized = await normalizeBinaryResult(value, fallbackFileName);
+  if (isBinaryResultPayload(normalized)) {
+    const budget = Math.floor(bridgeMaxPayloadSize * PAYLOAD_SAFETY_MARGIN);
+    if (normalized.byteLength > budget) {
+      throw newBridgeError(
+        'PAYLOAD_TOO_LARGE',
+        `"${normalized.fileName}" is ${normalized.byteLength} bytes, which exceeds the safe transport budget (${budget} bytes, derived from the server's BRIDGE_MAX_PAYLOAD_SIZE=${bridgeMaxPayloadSize}).`,
+        'Increase BRIDGE_MAX_PAYLOAD_SIZE in the MCP server environment, or (for canvas captures) zoom to a smaller region.',
+      );
+    }
+  }
+  return normalized;
 }
 
 function getApiCandidates(): Array<{ name: string; root: unknown }> {
@@ -1681,7 +1725,10 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
     case 'board.getFeatures':
       return getFeaturesApi();
     case 'board.exportGerbers':
-      return callFirst(['PCB_ManufactureData.getGerberFile'], params);
+      return normalizeBinaryResultSafely(
+        await callFirst(['PCB_ManufactureData.getGerberFile'], params),
+        'gerbers.zip',
+      );
     case 'system.getStatus': {
       const globals: Record<string, unknown> = {};
       try {
@@ -1899,6 +1946,9 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
           'pcb.addZone',
           'pcb.deleteComponent',
           'pcb.modifyComponent',
+          'canvas.capture',
+          'canvas.captureRegion',
+          'canvas.locate',
         ],
         devMode: false,
         globals: globals,
@@ -1923,21 +1973,56 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
     case 'design.drc':
       return callFirst(['PCB_Drc.check', 'SCH_Drc.check'], params);
     case 'export.pickPlace':
-      return callFirst(['PCB_ManufactureData.getPickAndPlaceFile'], params);
+      return normalizeBinaryResultSafely(
+        await callFirst(['PCB_ManufactureData.getPickAndPlaceFile'], params),
+        `pick-place.${typeof params.format === 'string' ? params.format : 'csv'}`,
+      );
     case 'export.pdf':
-      return callFirst(
-        ['PCB_ManufactureData.getPdfFile', 'SCH_ManufactureData.getExportDocumentFile'],
-        params.what === 'board' ? params : { ...params, type: 'schematic' },
+      return normalizeBinaryResultSafely(
+        await callFirst(
+          ['PCB_ManufactureData.getPdfFile', 'SCH_ManufactureData.getExportDocumentFile'],
+          params.what === 'board' ? params : { ...params, type: 'schematic' },
+        ),
+        'export.pdf',
       );
     case 'export.netlist':
-      return callFirst(
-        [
-          'SCH_Netlist.getNetlist',
-          'SCH_ManufactureData.getNetlistFile',
-          'PCB_ManufactureData.getNetlistFile',
-        ],
-        params,
+      return normalizeBinaryResultSafely(
+        await callFirst(
+          [
+            'SCH_Netlist.getNetlist',
+            'SCH_ManufactureData.getNetlistFile',
+            'PCB_ManufactureData.getNetlistFile',
+          ],
+          params,
+        ),
+        `netlist.${typeof params.format === 'string' ? params.format : 'txt'}`,
       );
+    case 'canvas.capture': {
+      const tabId = typeof params.tabId === 'string' ? params.tabId : undefined;
+      const blob = await callFirst(['DMT_EditorControl.getCurrentRenderedAreaImage'], tabId);
+      return normalizeBinaryResultSafely(blob, 'capture.png');
+    }
+    case 'canvas.captureRegion': {
+      const { left, right, top, bottom, tabId } = params as {
+        left: number;
+        right: number;
+        top: number;
+        bottom: number;
+        tabId?: string;
+      };
+      await callFirst(['DMT_EditorControl.zoomToRegion'], left, right, top, bottom, tabId);
+      const blob = await callFirst(['DMT_EditorControl.getCurrentRenderedAreaImage'], tabId);
+      return normalizeBinaryResultSafely(blob, 'capture-region.png');
+    }
+    case 'canvas.locate': {
+      const { x, y, scaleRatio, tabId } = params as {
+        x?: number;
+        y?: number;
+        scaleRatio?: number;
+        tabId?: string;
+      };
+      return callFirst(['DMT_EditorControl.zoomTo'], x, y, scaleRatio, tabId);
+    }
     case 'pcb.placeComponent':
       return callFirst(
         ['PCB_PrimitiveComponent.create', 'pcb_PrimitiveComponent.create'],
@@ -2210,6 +2295,9 @@ function handleMessage(raw: string): InboundMessageType {
         protocolVersion: BRIDGE_VERSION,
         supportedProtocolVersions: supportedVersions,
       });
+    }
+    if (typeof record.maxPayloadSize === 'number' && record.maxPayloadSize > 0) {
+      bridgeMaxPayloadSize = record.maxPayloadSize;
     }
     log('Bridge handshake accepted');
     return 'hello';

--- a/easyeda-bridge-extension/tests/binary-result.test.ts
+++ b/easyeda-bridge-extension/tests/binary-result.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import {
+  guessMimeType,
+  isBlobLike,
+  blobToBase64,
+  normalizeBinaryResult,
+} from '../src/binary-result.js';
+
+describe('guessMimeType', () => {
+  it('maps known extensions to their MIME type', () => {
+    expect(guessMimeType('gerbers.zip')).toBe('application/zip');
+    expect(guessMimeType('export.pdf')).toBe('application/pdf');
+    expect(guessMimeType('netlist.csv')).toBe('text/csv');
+    expect(guessMimeType('netlist.txt')).toBe('text/plain');
+    expect(guessMimeType('capture.png')).toBe('image/png');
+    expect(guessMimeType('data.json')).toBe('application/json');
+  });
+
+  it('falls back to application/octet-stream for unknown extensions', () => {
+    expect(guessMimeType('weird.xyz')).toBe('application/octet-stream');
+    expect(guessMimeType('no-extension')).toBe('application/octet-stream');
+  });
+});
+
+describe('isBlobLike', () => {
+  it('returns true for a real Blob', () => {
+    expect(isBlobLike(new Blob(['hello']))).toBe(true);
+  });
+
+  it('returns true for a real File (Blob subclass)', () => {
+    expect(isBlobLike(new File(['hello'], 'test.txt'))).toBe(true);
+  });
+
+  it('returns false for plain objects, arrays, and primitives', () => {
+    expect(isBlobLike({ foo: 'bar' })).toBe(false);
+    expect(isBlobLike([1, 2, 3])).toBe(false);
+    expect(isBlobLike('a string')).toBe(false);
+    expect(isBlobLike(null)).toBe(false);
+    expect(isBlobLike(undefined)).toBe(false);
+    expect(isBlobLike(42)).toBe(false);
+  });
+});
+
+describe('blobToBase64', () => {
+  it('round-trips a small blob to valid base64', async () => {
+    const original = 'hello world';
+    const blob = new Blob([original], { type: 'text/plain' });
+    const base64 = await blobToBase64(blob);
+    expect(Buffer.from(base64, 'base64').toString('utf-8')).toBe(original);
+  });
+
+  it('round-trips a large payload spanning multiple chunk boundaries', async () => {
+    // 0x8000 (32768) is the chunk size in blobToBase64; exceed several chunks.
+    const bytes = new Uint8Array(0x8000 * 3 + 123);
+    for (let i = 0; i < bytes.length; i++) bytes[i] = i % 256;
+    const blob = new Blob([bytes]);
+
+    const base64 = await blobToBase64(blob);
+    const decoded = Buffer.from(base64, 'base64');
+    expect(decoded.length).toBe(bytes.length);
+    expect(new Uint8Array(decoded)).toEqual(bytes);
+  });
+});
+
+describe('normalizeBinaryResult', () => {
+  it('converts a Blob into a base64 payload using the fallback file name', async () => {
+    const blob = new Blob(['%PDF-1.4 fake pdf bytes'], { type: 'application/pdf' });
+    const result = await normalizeBinaryResult(blob, 'export.pdf');
+
+    expect(result).toMatchObject({
+      mimeType: 'application/pdf',
+      fileName: 'export.pdf',
+      byteLength: blob.size,
+    });
+    expect(typeof (result as { base64: string }).base64).toBe('string');
+    expect(Buffer.from((result as { base64: string }).base64, 'base64').toString()).toBe(
+      '%PDF-1.4 fake pdf bytes',
+    );
+  });
+
+  it("prefers a File object's own name over the fallback", async () => {
+    const file = new File(['csv,data'], 'pick-place.csv', { type: 'text/csv' });
+    const result = await normalizeBinaryResult(file, 'fallback.csv');
+    expect(result).toMatchObject({ fileName: 'pick-place.csv', mimeType: 'text/csv' });
+  });
+
+  it('guesses a MIME type from the file name when blob.type is empty', async () => {
+    const blob = new Blob(['zip bytes']);
+    const result = await normalizeBinaryResult(blob, 'gerbers.zip');
+    expect(result).toMatchObject({ mimeType: 'application/zip', fileName: 'gerbers.zip' });
+  });
+
+  it('passes through non-Blob values unchanged', async () => {
+    const plainNetlist = { nets: ['GND', 'VCC'], format: 'pads' };
+    const result = await normalizeBinaryResult(plainNetlist, 'netlist.txt');
+    expect(result).toBe(plainNetlist);
+  });
+
+  it('passes through undefined unchanged', async () => {
+    const result = await normalizeBinaryResult(undefined, 'capture.png');
+    expect(result).toBeUndefined();
+  });
+});

--- a/easyeda-bridge-extension/vitest.config.ts
+++ b/easyeda-bridge-extension/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+});

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "test:extension": "pnpm --filter @easyeda-mcp-pro/bridge-extension test",
     "smoke:easyeda": "tsx scripts/live-easyeda-smoke.mts",
     "verify:extension": "pnpm --filter @easyeda-mcp-pro/bridge-extension verify",
     "inspector": "pnpm build && npx @modelcontextprotocol/inspector node dist/index.js",
@@ -74,7 +75,7 @@
     "inventory:diff": "tsx scripts/diff-runtime-inventory.mts",
     "eval:golden": "tsx scripts/run-evals.mts",
     "eval:golden:update": "tsx scripts/run-evals.mts --update-baseline",
-    "verify": "pnpm format:check && pnpm typecheck && pnpm typecheck:extension && pnpm lint && pnpm lint:tools && pnpm verify:tool-coverage && pnpm test && pnpm build && pnpm build:extension && pnpm check:metadata && pnpm docs:build"
+    "verify": "pnpm format:check && pnpm typecheck && pnpm typecheck:extension && pnpm lint && pnpm lint:tools && pnpm verify:tool-coverage && pnpm test && pnpm test:extension && pnpm build && pnpm build:extension && pnpm check:metadata && pnpm docs:build"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(vite@7.3.5(@types/node@24.13.2)(lightningcss@1.32.0)(tsx@4.22.4))
 
 packages:
 

--- a/src/bridge/manager.ts
+++ b/src/bridge/manager.ts
@@ -369,6 +369,7 @@ export class BridgeManager extends EventEmitter {
       easyedaVersion: parsed.data.easyedaVersion,
       capabilities: EasyedaApiMethodSchema.options,
       methodRegistryHash: this._methodRegistryHash,
+      maxPayloadSize: this.config.BRIDGE_MAX_PAYLOAD_SIZE,
       devMode: parsed.data.devMode ?? false,
     };
 

--- a/src/bridge/protocol.ts
+++ b/src/bridge/protocol.ts
@@ -58,6 +58,10 @@ export const BridgeHelloSchema = z.object({
   capabilities: z.array(z.string()),
   methodRegistryHash: z.string(),
   devMode: z.boolean(),
+  /** The server's configured BRIDGE_MAX_PAYLOAD_SIZE, so the extension can self-limit
+   *  binary (Blob/File) results before sending — avoiding a payload-too-large close
+   *  of the whole connection over one oversized response. */
+  maxPayloadSize: z.number().int().positive().optional(),
 });
 
 /**

--- a/src/bridge/types.ts
+++ b/src/bridge/types.ts
@@ -44,4 +44,7 @@ export const EasyedaApiMethodSchema = z.enum([
   'pcb.deleteComponent',
   'pcb.modifyComponent',
   'api.execute',
+  'canvas.capture',
+  'canvas.captureRegion',
+  'canvas.locate',
 ]);

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -14,14 +14,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Core',
     description:
       'High-confidence tools: diagnostics, EasyEDA API inventory, schematic, BOM, DRC/ERC, board layers/stackup, Gerber export',
-    approxToolCount: '44',
+    approxToolCount: '47',
     isDefault: true,
   },
   pro: {
     name: 'pro',
     label: 'Pro',
     description: 'Adds pick-and-place, PDF, netlist export for manufacturing workflows',
-    approxToolCount: '49',
+    approxToolCount: '52',
     isDefault: false,
   },
   full: {
@@ -29,7 +29,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls for full runtime control without raw JavaScript execution',
-    approxToolCount: '58',
+    approxToolCount: '61',
     isDefault: false,
   },
   dev: {
@@ -37,14 +37,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '62',
+    approxToolCount: '65',
     isDefault: false,
   },
   experimental: {
     name: 'experimental',
     label: 'Experimental',
     description: 'MCP Apps, Tasks, simulation, autorouter, AI action plans',
-    approxToolCount: '58',
+    approxToolCount: '65',
     isDefault: false,
   },
 };

--- a/src/tools/L1_export.ts
+++ b/src/tools/L1_export.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { z } from 'zod';
 import { type ToolDefinition, type ToolContext } from './types.js';
 import { type EnvConfig } from '../config/env.js';
@@ -5,6 +7,72 @@ import { validatePcbConstraints } from '../pcb-constraints/index.js';
 import type { PcbConstraintInput } from '../pcb-constraints/types.js';
 import { generateProductionQaArtifacts } from '../production-qa/index.js';
 import { evaluateQuoteWorkflow } from '../quote-gating/index.js';
+
+interface BinaryBridgeResult {
+  base64?: string;
+  fileName?: string;
+}
+
+interface WriteExportResult {
+  ok: boolean;
+  filePath?: string;
+  byteLength?: number;
+  error?: string;
+}
+
+/**
+ * Write a bridge export result to disk under `ctx.config.artifactDir`.
+ *
+ * The EasyEDA manufacturing-data APIs (Gerbers/PDF/netlist/pick-place) return
+ * in-memory Blob/File objects. The bridge extension converts these to a
+ * `{base64, fileName, ...}` JSON payload (see
+ * `easyeda-bridge-extension/src/binary-result.ts`) since Blob/File cannot
+ * cross the JSON-only WS transport directly. Some paths (e.g. a netlist
+ * method that returns plain structured data instead of a file) may return
+ * non-binary JSON instead — that is written as formatted JSON so the tool's
+ * `exported`/`file_path` contract stays meaningful either way.
+ */
+function writeExportPayload(
+  ctx: ToolContext,
+  data: unknown,
+  requestedPath: string | undefined,
+  defaultFileName: string,
+): WriteExportResult {
+  if (
+    data === undefined ||
+    data === null ||
+    (typeof data === 'object' && Object.keys(data).length === 0)
+  ) {
+    // An empty object is what a stale/un-upgraded bridge extension produces when it
+    // tries to JSON-serialize a Blob/File directly (JSON.stringify(blob) === '{}'),
+    // so treat it the same as "no data" rather than writing a useless `{}` file.
+    return { ok: false, error: 'Bridge did not return export data.' };
+  }
+
+  const binary = data as BinaryBridgeResult;
+  let buffer: Buffer;
+  let fileName = defaultFileName;
+  if (typeof binary.base64 === 'string') {
+    buffer = Buffer.from(binary.base64, 'base64');
+    fileName = binary.fileName || defaultFileName;
+  } else {
+    buffer = Buffer.from(JSON.stringify(data, null, 2), 'utf-8');
+  }
+
+  const artifactDir = path.resolve(ctx.config.artifactDir);
+  const target = requestedPath ? path.resolve(requestedPath) : path.resolve(artifactDir, fileName);
+  const relative = path.relative(artifactDir, target);
+  if (relative.startsWith('..') || path.isAbsolute(relative)) {
+    return { ok: false, error: 'File path must be inside the artifact directory.' };
+  }
+
+  const parentDir = path.dirname(target);
+  if (!fs.existsSync(parentDir)) {
+    fs.mkdirSync(parentDir, { recursive: true });
+  }
+  fs.writeFileSync(target, buffer);
+  return { ok: true, filePath: target, byteLength: buffer.byteLength };
+}
 
 const quoteBoardSchema = z.object({
   boardCount: z.number().int().positive(),
@@ -337,6 +405,7 @@ function registerExportTools(
     },
     inputSchema: z.object({
       projectId: z.string(),
+      filePath: z.string().optional(),
       drillFormat: z.enum(['excellon', 'millimeter', 'inch']).optional(),
       excludeLayer: z.array(z.string()).optional(),
       ledPanel: z.boolean().optional(),
@@ -350,6 +419,7 @@ function registerExportTools(
     outputSchema: z.object({
       project_id: z.string(),
       artifact_path: z.string().optional(),
+      byte_length: z.number().int().nonnegative().optional(),
       file_count: z.number().int().nonnegative().optional(),
       exported: z.boolean(),
       blocked_by_production_review: z.boolean().optional(),
@@ -365,18 +435,21 @@ function registerExportTools(
         })
         .optional(),
       not_available: z.boolean().optional(),
+      error: z.string().optional(),
     }),
     handler: async (ctx: ToolContext, params: unknown) => {
-      const { projectId, drillFormat, excludeLayer, ledPanel, productionReview } = params as {
-        projectId: string;
-        drillFormat?: string;
-        excludeLayer?: string[];
-        ledPanel?: boolean;
-        productionReview?: {
-          mode?: 'off' | 'warn' | 'block';
-          boardData?: Partial<PcbConstraintInput>;
+      const { projectId, filePath, drillFormat, excludeLayer, ledPanel, productionReview } =
+        params as {
+          projectId: string;
+          filePath?: string;
+          drillFormat?: string;
+          excludeLayer?: string[];
+          ledPanel?: boolean;
+          productionReview?: {
+            mode?: 'off' | 'warn' | 'block';
+            boardData?: Partial<PcbConstraintInput>;
+          };
         };
-      };
       try {
         const productionReviewResult = runProductionReview(
           productionReview?.boardData,
@@ -398,11 +471,20 @@ function registerExportTools(
           excludeLayer,
           ledPanel,
         });
-        const data = result as { artifactPath?: string; fileCount?: number };
+        const written = writeExportPayload(ctx, result, filePath, `${projectId}-gerbers.zip`);
+        if (!written.ok) {
+          return {
+            project_id: projectId,
+            exported: false,
+            not_available: true,
+            error: written.error,
+            production_review: productionReviewResult,
+          };
+        }
         return {
           project_id: projectId,
-          artifact_path: data.artifactPath,
-          file_count: data.fileCount,
+          artifact_path: written.filePath,
+          byte_length: written.byteLength,
           exported: true,
           production_review: productionReviewResult,
         };
@@ -440,28 +522,49 @@ function registerExportTools(
     inputSchema: z.object({
       projectId: z.string(),
       format: z.enum(['csv', 'txt']).default('csv'),
+      filePath: z.string().optional(),
     }),
     outputSchema: z.object({
       project_id: z.string(),
       format: z.string(),
       file_path: z.string().optional(),
+      byte_length: z.number().int().nonnegative().optional(),
       component_count: z.number().int().nonnegative().optional(),
       exported: z.boolean(),
       not_available: z.boolean().optional(),
+      error: z.string().optional(),
     }),
     handler: async (ctx: ToolContext, params: unknown) => {
-      const { projectId, format } = params as { projectId: string; format: string };
+      const { projectId, format, filePath } = params as {
+        projectId: string;
+        format: string;
+        filePath?: string;
+      };
       try {
         const result = await ctx.bridge.call('export.pickPlace', {
           projectId,
           format,
         });
-        const data = result as { filePath?: string; componentCount?: number };
+        const written = writeExportPayload(
+          ctx,
+          result,
+          filePath,
+          `${projectId}-pick-place.${format}`,
+        );
+        if (!written.ok) {
+          return {
+            project_id: projectId,
+            format,
+            exported: false,
+            not_available: true,
+            error: written.error,
+          };
+        }
         return {
           project_id: projectId,
           format,
-          file_path: data.filePath,
-          component_count: data.componentCount,
+          file_path: written.filePath,
+          byte_length: written.byteLength,
           exported: true,
         };
       } catch (err) {
@@ -495,21 +598,25 @@ function registerExportTools(
       projectId: z.string(),
       scope: z.enum(['schematic', 'board', 'both']).default('both'),
       orientation: z.enum(['portrait', 'landscape']).default('landscape'),
+      filePath: z.string().optional(),
     }),
     outputSchema: z.object({
       project_id: z.string(),
       scope: z.string(),
       orientation: z.string(),
       file_path: z.string().optional(),
+      byte_length: z.number().int().nonnegative().optional(),
       pages: z.number().int().nonnegative().optional(),
       exported: z.boolean(),
       not_available: z.boolean().optional(),
+      error: z.string().optional(),
     }),
     handler: async (ctx: ToolContext, params: unknown) => {
-      const { projectId, scope, orientation } = params as {
+      const { projectId, scope, orientation, filePath } = params as {
         projectId: string;
         scope: string;
         orientation: string;
+        filePath?: string;
       };
       try {
         const result = await ctx.bridge.call('export.pdf', {
@@ -518,13 +625,23 @@ function registerExportTools(
           orientation,
           what: scope,
         });
-        const data = result as { filePath?: string; pages?: number };
+        const written = writeExportPayload(ctx, result, filePath, `${projectId}-${scope}.pdf`);
+        if (!written.ok) {
+          return {
+            project_id: projectId,
+            scope,
+            orientation,
+            exported: false,
+            not_available: true,
+            error: written.error,
+          };
+        }
         return {
           project_id: projectId,
           scope,
           orientation,
-          file_path: data.filePath,
-          pages: data.pages,
+          file_path: written.filePath,
+          byte_length: written.byteLength,
           exported: true,
         };
       } catch (err) {
@@ -559,28 +676,51 @@ function registerExportTools(
     inputSchema: z.object({
       projectId: z.string(),
       format: z.enum(['pads', 'allegro', 'altium']).default('pads'),
+      filePath: z.string().optional(),
     }),
     outputSchema: z.object({
       project_id: z.string(),
       format: z.string(),
       file_path: z.string().optional(),
+      byte_length: z.number().int().nonnegative().optional(),
       net_count: z.number().int().nonnegative().optional(),
       exported: z.boolean(),
       not_available: z.boolean().optional(),
+      error: z.string().optional(),
     }),
     handler: async (ctx: ToolContext, params: unknown) => {
-      const { projectId, format } = params as { projectId: string; format: string };
+      const { projectId, format, filePath } = params as {
+        projectId: string;
+        format: string;
+        filePath?: string;
+      };
       try {
         const result = await ctx.bridge.call('export.netlist', {
           projectId,
           format,
         });
-        const data = result as { filePath?: string; netCount?: number };
+        const written = writeExportPayload(ctx, result, filePath, `${projectId}-netlist.${format}`);
+        if (!written.ok) {
+          return {
+            project_id: projectId,
+            format,
+            exported: false,
+            not_available: true,
+            error: written.error,
+          };
+        }
+        const netCount =
+          result &&
+          typeof result === 'object' &&
+          typeof (result as { netCount?: unknown }).netCount === 'number'
+            ? (result as { netCount: number }).netCount
+            : undefined;
         return {
           project_id: projectId,
           format,
-          file_path: data.filePath,
-          net_count: data.netCount,
+          file_path: written.filePath,
+          byte_length: written.byteLength,
+          net_count: netCount,
           exported: true,
         };
       } catch (err) {

--- a/src/tools/L1_visual.ts
+++ b/src/tools/L1_visual.ts
@@ -1,0 +1,215 @@
+import { z } from 'zod';
+import { type ToolDefinition, type ToolContext } from './types.js';
+import { type EnvConfig } from '../config/env.js';
+
+interface CanvasBinaryResult {
+  base64?: string;
+  mimeType?: string;
+  fileName?: string;
+  byteLength?: number;
+}
+
+const captureOutputSchema = z.object({
+  captured: z.boolean(),
+  mime_type: z.string().optional(),
+  file_name: z.string().optional(),
+  byte_length: z.number().int().nonnegative().optional(),
+  image_base64: z.string().optional(),
+  not_available: z.boolean().optional(),
+  error: z.string().optional(),
+});
+
+type CaptureOutput = z.infer<typeof captureOutputSchema>;
+
+function imageContentFromCapture(output: unknown): Array<{ data: string; mimeType: string }> {
+  const data = output as CaptureOutput;
+  if (!data.captured || !data.image_base64) return [];
+  return [{ data: data.image_base64, mimeType: data.mime_type ?? 'image/png' }];
+}
+
+/**
+ * Build the tool's output from a raw `canvas.capture`/`canvas.captureRegion`
+ * bridge result. A successful bridge call already respects the wire's
+ * payload-size limit (the extension self-limits before sending — see
+ * `easyeda-bridge-extension/src/binary-result.ts` and
+ * `normalizeBinaryResultSafely` in the extension), so no size is re-checked
+ * here; a too-large capture surfaces as a bridge error caught by the caller.
+ */
+function buildCaptureOutput(result: unknown): CaptureOutput {
+  const data = result as CanvasBinaryResult | undefined;
+  if (!data?.base64) {
+    return { captured: false, not_available: true, error: 'Bridge did not return image data.' };
+  }
+  return {
+    captured: true,
+    mime_type: data.mimeType ?? 'image/png',
+    file_name: data.fileName,
+    byte_length: data.byteLength,
+    image_base64: data.base64,
+  };
+}
+
+function registerVisualTools(
+  registry: { register: (def: ToolDefinition) => void },
+  _config: EnvConfig,
+) {
+  registry.register({
+    name: 'easyeda_canvas_capture',
+    title: 'Capture canvas image',
+    description:
+      'Capture the currently visible EasyEDA schematic/PCB canvas as a PNG image, so the ' +
+      'caller can visually verify the result of a draw/place/route action. Captures the ' +
+      'given tab (or the last-focused one) as-is; use easyeda_canvas_capture_region first ' +
+      'to frame a specific area.',
+    profile: 'core',
+    evidence: ['pro-api-types'],
+    risk: 'low',
+    confirmWrite: false,
+    group: 'visual',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: false,
+    },
+    inputSchema: z.object({
+      tabId: z.string().optional(),
+    }),
+    outputSchema: captureOutputSchema,
+    imageContent: imageContentFromCapture,
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const { tabId } = params as { tabId?: string };
+      try {
+        const result = await ctx.bridge.call('canvas.capture', { tabId });
+        return buildCaptureOutput(result);
+      } catch (err) {
+        return {
+          captured: false,
+          not_available: true,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+  });
+
+  registry.register({
+    name: 'easyeda_canvas_capture_region',
+    title: 'Capture canvas region image',
+    description:
+      'Zoom the EasyEDA canvas to a rectangular region (document/canvas coordinates) and ' +
+      'capture it as a PNG, so the caller can visually verify a specific area. This moves ' +
+      "the user's visible viewport — EasyEDA Pro has no offscreen rendering API.",
+    profile: 'core',
+    evidence: ['pro-api-types'],
+    risk: 'low',
+    confirmWrite: false,
+    group: 'visual',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: false,
+    },
+    inputSchema: z.object({
+      left: z.number(),
+      right: z.number(),
+      top: z.number(),
+      bottom: z.number(),
+      tabId: z.string().optional(),
+    }),
+    outputSchema: captureOutputSchema,
+    imageContent: imageContentFromCapture,
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const { left, right, top, bottom, tabId } = params as {
+        left: number;
+        right: number;
+        top: number;
+        bottom: number;
+        tabId?: string;
+      };
+      try {
+        const result = await ctx.bridge.call('canvas.captureRegion', {
+          left,
+          right,
+          top,
+          bottom,
+          tabId,
+        });
+        return buildCaptureOutput(result);
+      } catch (err) {
+        return {
+          captured: false,
+          not_available: true,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+  });
+
+  registry.register({
+    name: 'easyeda_canvas_locate',
+    title: 'Zoom canvas to coordinate',
+    description:
+      'Zoom the EasyEDA canvas to a coordinate/scale (document/canvas coordinates), returning ' +
+      'the resulting viewport rectangle. Useful to frame a location before calling ' +
+      "easyeda_canvas_capture, or standalone to navigate the user's view to a point of interest.",
+    profile: 'core',
+    evidence: ['pro-api-types'],
+    risk: 'low',
+    confirmWrite: false,
+    group: 'visual',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: false,
+    },
+    inputSchema: z.object({
+      x: z.number().optional(),
+      y: z.number().optional(),
+      scaleRatio: z.number().positive().optional(),
+      tabId: z.string().optional(),
+    }),
+    outputSchema: z.object({
+      located: z.boolean(),
+      left: z.number().optional(),
+      right: z.number().optional(),
+      top: z.number().optional(),
+      bottom: z.number().optional(),
+      not_available: z.boolean().optional(),
+      error: z.string().optional(),
+    }),
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const { x, y, scaleRatio, tabId } = params as {
+        x?: number;
+        y?: number;
+        scaleRatio?: number;
+        tabId?: string;
+      };
+      try {
+        const result = await ctx.bridge.call('canvas.locate', { x, y, scaleRatio, tabId });
+        const rect = result as
+          { left?: number; right?: number; top?: number; bottom?: number } | false;
+        if (!rect) {
+          return {
+            located: false,
+            not_available: true,
+            error: 'EasyEDA could not zoom to the requested coordinate.',
+          };
+        }
+        return {
+          located: true,
+          left: rect.left,
+          right: rect.right,
+          top: rect.top,
+          bottom: rect.bottom,
+        };
+      } catch (err) {
+        return {
+          located: false,
+          not_available: true,
+          error: err instanceof Error ? err.message : String(err),
+        };
+      }
+    },
+  });
+}
+
+export { registerVisualTools };

--- a/src/tools/register.ts
+++ b/src/tools/register.ts
@@ -10,6 +10,7 @@ import { registerPcbConstraintTools } from './L1_pcb_constraints.js';
 import { registerPcbWriteTools } from './L1_pcb_write.js';
 import { registerSchematicReadTools } from './L1_schematic_read.js';
 import { registerSchematicWriteTools } from './L1_schematic_write.js';
+import { registerVisualTools } from './L1_visual.js';
 import { type ToolRegistry } from './registry.js';
 
 export function registerBuiltinTools(registry: ToolRegistry, config: EnvConfig): void {
@@ -24,4 +25,5 @@ export function registerBuiltinTools(registry: ToolRegistry, config: EnvConfig):
   registerPcbConstraintTools(registry, config);
   registerPcbWriteTools(registry, config);
   registerExportTools(registry, config);
+  registerVisualTools(registry, config);
 }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -82,6 +82,8 @@ export function getRequiredToolScopes(tool: ToolDefinition): string[] {
       return ['pcb:write'];
     case 'export':
       return ['export:write'];
+    case 'visual':
+      return ['schematic:read', 'pcb:read'];
     default:
       return [tool.confirmWrite ? WRITE_ALL_SCOPE : READ_ALL_SCOPE];
   }
@@ -296,9 +298,17 @@ export class ToolRegistry {
               typeof output.data === 'object' && output.data !== null
                 ? (output.data as Record<string, unknown>)
                 : { value: output.data };
+            const images = tool.imageContent?.(output.data) ?? [];
             return {
               structuredContent,
-              content: [{ type: 'text' as const, text: JSON.stringify(output.data, null, 2) }],
+              content: [
+                { type: 'text' as const, text: JSON.stringify(output.data, null, 2) },
+                ...images.map((image) => ({
+                  type: 'image' as const,
+                  data: image.data,
+                  mimeType: image.mimeType,
+                })),
+              ],
             };
           } catch (err) {
             // ── Zod validation errors ─────────────────────────────────

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -47,6 +47,13 @@ export interface ToolDefinition<
   inputSchema: TInput;
   outputSchema: TOutput;
   handler: (context: ToolContext, input: z.infer<TInput>) => Promise<z.infer<TOutput>>;
+  /**
+   * Optional: extract MCP image content blocks (e.g. a PNG canvas capture)
+   * from a successful, schema-validated tool result. Returned images are
+   * appended to the response's `content` array alongside the usual JSON/text
+   * block. Most tools omit this.
+   */
+  imageContent?: (output: z.infer<TOutput>) => Array<{ data: string; mimeType: string }>;
 }
 
 export interface BridgeDiagnosticsSnapshot {

--- a/tests/unit/bridge/manager.test.ts
+++ b/tests/unit/bridge/manager.test.ts
@@ -392,6 +392,26 @@ describe('BridgeManager - method registry hash', () => {
     socket.close();
     manager.disconnect('test complete');
   });
+
+  it('includes the configured BRIDGE_MAX_PAYLOAD_SIZE in hello', async () => {
+    const port = await getFreePort();
+    const config = createTestConfig({
+      BRIDGE_HOST: '127.0.0.1',
+      BRIDGE_PORT_SCAN: String(port),
+      BRIDGE_MAX_PAYLOAD_SIZE: 2_097_152,
+    });
+    const manager = new BridgeManager(config);
+    await manager.connect();
+
+    const socket = await openSocket(port);
+    sendHandshake(socket);
+
+    const msg = (await waitForMessage(socket)) as Record<string, unknown>;
+    expect(msg.maxPayloadSize).toBe(2_097_152);
+
+    socket.close();
+    manager.disconnect('test complete');
+  });
 });
 
 describe('BridgeManager - payload size limit', () => {
@@ -578,6 +598,71 @@ describe('BridgeManager - call() round trip', () => {
     const { manager, socket } = await setupSecureConnection();
 
     await expect(manager.call('project.save', {}, { timeoutMs: 20 })).rejects.toThrow(/timed out/);
+
+    socket.close();
+    manager.disconnect('test complete');
+  });
+
+  it('round-trips a canvas.capture request/response without a live EasyEDA process', async () => {
+    // Simulates the bridge extension's response shape after it has already
+    // converted a Blob to base64 (see easyeda-bridge-extension/src/binary-result.ts) —
+    // no real EasyEDA Pro process is needed to exercise the server-side contract.
+    const { manager, socket } = await setupSecureConnection();
+
+    socket.on('message', (raw) => {
+      const msg = JSON.parse(raw.toString()) as { id: string; type: string; method: string };
+      if (msg.type === 'request' && msg.method === 'canvas.capture') {
+        socket.send(
+          JSON.stringify({
+            id: msg.id,
+            type: 'response',
+            ok: true,
+            result: {
+              base64: 'ZmFrZS1wbmctYnl0ZXM=',
+              mimeType: 'image/png',
+              fileName: 'capture.png',
+              byteLength: 14,
+            },
+          }),
+        );
+      }
+    });
+
+    const result = await manager.call('canvas.capture', { tabId: 'tab-1' });
+    expect(result).toMatchObject({
+      base64: 'ZmFrZS1wbmctYnl0ZXM=',
+      mimeType: 'image/png',
+      fileName: 'capture.png',
+    });
+
+    socket.close();
+    manager.disconnect('test complete');
+  });
+
+  it('surfaces a payload-too-large error from canvas.capture as a normal rejected call', async () => {
+    // The extension self-limits before sending (normalizeBinaryResultSafely) rather
+    // than sending an oversized frame that would close the whole connection — this
+    // is what that error looks like from the server's perspective.
+    const { manager, socket } = await setupSecureConnection();
+
+    socket.on('message', (raw) => {
+      const msg = JSON.parse(raw.toString()) as { id: string; type: string; method: string };
+      if (msg.type === 'request' && msg.method === 'canvas.capture') {
+        socket.send(
+          JSON.stringify({
+            id: msg.id,
+            type: 'response',
+            ok: false,
+            error: {
+              code: 'PAYLOAD_TOO_LARGE',
+              message: '"capture.png" is 5000000 bytes, which exceeds the safe transport budget',
+            },
+          }),
+        );
+      }
+    });
+
+    await expect(manager.call('canvas.capture', {})).rejects.toThrow(/exceeds the safe transport/);
 
     socket.close();
     manager.disconnect('test complete');

--- a/tests/unit/bridge/protocol.test.ts
+++ b/tests/unit/bridge/protocol.test.ts
@@ -82,6 +82,21 @@ describe('BridgeProtocol schemas', () => {
         devMode: false,
       });
       expect(result.easyedaVersion).toBeUndefined();
+      expect(result.maxPayloadSize).toBeUndefined();
+    });
+
+    it('should accept maxPayloadSize when present', () => {
+      const result = BridgeHelloSchema.parse({
+        type: 'hello',
+        bridgeVersion: '1.0.0',
+        contractVersion: BRIDGE_CONTRACT_VERSION,
+        supportedProtocolVersions: [...SUPPORTED_PROTOCOL_VERSIONS],
+        capabilities: [],
+        methodRegistryHash: 'abc',
+        devMode: false,
+        maxPayloadSize: 1_048_576,
+      });
+      expect(result.maxPayloadSize).toBe(1_048_576);
     });
   });
 

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -39,14 +39,14 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for core', () => {
-    expect(PROFILE_DEFINITIONS.core.approxToolCount).toBe('44');
+    expect(PROFILE_DEFINITIONS.core.approxToolCount).toBe('47');
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('49');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('52');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('58');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('61');
   });
 });

--- a/tests/unit/tools/export.test.ts
+++ b/tests/unit/tools/export.test.ts
@@ -1,4 +1,7 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ToolRegistry } from '../../../src/tools/registry.js';
 import { type ToolContext } from '../../../src/tools/types.js';
 import { registerExportTools } from '../../../src/tools/L1_export.js';
@@ -8,6 +11,7 @@ describe('Export Tools', () => {
   let registry: ToolRegistry;
   let context: ToolContext;
   let bridgeCall: any;
+  let tmpArtifactDir: string;
 
   beforeEach(() => {
     registry = new ToolRegistry();
@@ -15,6 +19,7 @@ describe('Export Tools', () => {
     registerExportTools(registry, config);
 
     bridgeCall = vi.fn();
+    tmpArtifactDir = fs.mkdtempSync(path.join(os.tmpdir(), 'export-tools-'));
 
     context = {
       profile: 'pro',
@@ -24,7 +29,7 @@ describe('Export Tools', () => {
       },
       config: {
         bridgeTimeoutMs: 1000,
-        artifactDir: '.easyeda-mcp-pro/artifacts',
+        artifactDir: tmpArtifactDir,
       },
       vendors: {
         lcsc: null,
@@ -32,14 +37,21 @@ describe('Export Tools', () => {
         mouser: null,
         digikey: null,
       },
-    };
+    } as unknown as ToolContext;
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpArtifactDir, { recursive: true, force: true });
   });
 
   it('easyeda_export_gerbers warns with production review findings but still exports in warn mode', async () => {
     const tool = registry.get('easyeda_export_gerbers');
     expect(tool).toBeDefined();
 
-    bridgeCall.mockResolvedValue({ artifactPath: 'artifacts/gerbers.zip', fileCount: 12 });
+    bridgeCall.mockResolvedValue({
+      base64: Buffer.from('fake gerber zip bytes').toString('base64'),
+      fileName: 'gerbers.zip',
+    });
 
     const result = await tool?.handler(context, {
       projectId: 'proj-123',
@@ -70,6 +82,8 @@ describe('Export Tools', () => {
     expect(result?.exported).toBe(true);
     expect(result?.production_review?.passed).toBe(false);
     expect(result?.production_review?.errors[0].code).toBe('PCB_DRILL_FILE_MISSING');
+    expect(result?.artifact_path).toBeTruthy();
+    expect(fs.readFileSync(result!.artifact_path!, 'utf-8')).toBe('fake gerber zip bytes');
   });
 
   it('easyeda_export_gerbers blocks before bridge export when production review is in block mode', async () => {
@@ -102,13 +116,24 @@ describe('Export Tools', () => {
     expect(result?.production_review?.blocked).toBe(true);
   });
 
-  it('easyeda_export_pick_place should call correct bridge method and return result', async () => {
+  it('easyeda_export_gerbers reports not_available when the bridge does not return file data', async () => {
+    const tool = registry.get('easyeda_export_gerbers');
+    bridgeCall.mockResolvedValue({});
+
+    const result = await tool?.handler(context, { projectId: 'proj-123' });
+
+    expect(result?.exported).toBe(false);
+    expect(result?.not_available).toBe(true);
+    expect(result?.error).toBeTruthy();
+  });
+
+  it('easyeda_export_pick_place decodes the bridge payload and writes it to the artifact directory', async () => {
     const tool = registry.get('easyeda_export_pick_place');
     expect(tool).toBeDefined();
 
     bridgeCall.mockResolvedValue({
-      filePath: 'artifacts/pick_place.csv',
-      componentCount: 23,
+      base64: Buffer.from('ref,x,y,rotation,layer\nR1,1,2,0,top').toString('base64'),
+      fileName: 'pick-place.csv',
     });
 
     const result = await tool?.handler(context, {
@@ -124,19 +149,52 @@ describe('Export Tools', () => {
     expect(result).toMatchObject({
       project_id: 'proj-123',
       format: 'csv',
-      file_path: 'artifacts/pick_place.csv',
-      component_count: 23,
       exported: true,
     });
+    expect(result?.file_path).toBeTruthy();
+    expect(path.dirname(result!.file_path!)).toBe(path.resolve(tmpArtifactDir));
+    expect(fs.readFileSync(result!.file_path!, 'utf-8')).toBe(
+      'ref,x,y,rotation,layer\nR1,1,2,0,top',
+    );
   });
 
-  it('easyeda_export_pdf should call correct bridge method and return result', async () => {
+  it('easyeda_export_pick_place writes to an explicit filePath within the artifact directory', async () => {
+    const tool = registry.get('easyeda_export_pick_place');
+    bridgeCall.mockResolvedValue({ base64: Buffer.from('data').toString('base64') });
+
+    const explicitPath = path.join(tmpArtifactDir, 'nested', 'custom.csv');
+    const result = await tool?.handler(context, {
+      projectId: 'proj-123',
+      format: 'csv',
+      filePath: explicitPath,
+    });
+
+    expect(result?.file_path).toBe(explicitPath);
+    expect(fs.existsSync(explicitPath)).toBe(true);
+  });
+
+  it('easyeda_export_pick_place rejects a filePath that escapes the artifact directory', async () => {
+    const tool = registry.get('easyeda_export_pick_place');
+    bridgeCall.mockResolvedValue({ base64: Buffer.from('data').toString('base64') });
+
+    const outsidePath = path.join(os.tmpdir(), 'outside-pick-place.csv');
+    const result = await tool?.handler(context, {
+      projectId: 'proj-123',
+      format: 'csv',
+      filePath: outsidePath,
+    });
+
+    expect(result?.exported).toBe(false);
+    expect(result?.not_available).toBe(true);
+  });
+
+  it('easyeda_export_pdf decodes the bridge payload and writes it to the artifact directory', async () => {
     const tool = registry.get('easyeda_export_pdf');
     expect(tool).toBeDefined();
 
     bridgeCall.mockResolvedValue({
-      filePath: 'artifacts/schematic.pdf',
-      pages: 3,
+      base64: Buffer.from('%PDF-1.4 fake pdf bytes').toString('base64'),
+      fileName: 'schematic.pdf',
     });
 
     const result = await tool?.handler(context, {
@@ -156,19 +214,18 @@ describe('Export Tools', () => {
       project_id: 'proj-123',
       scope: 'schematic',
       orientation: 'landscape',
-      file_path: 'artifacts/schematic.pdf',
-      pages: 3,
       exported: true,
     });
+    expect(fs.readFileSync(result!.file_path!, 'utf-8')).toBe('%PDF-1.4 fake pdf bytes');
   });
 
-  it('easyeda_export_netlist should call correct bridge method and return result', async () => {
+  it('easyeda_export_netlist decodes a binary bridge payload and writes it to disk', async () => {
     const tool = registry.get('easyeda_export_netlist');
     expect(tool).toBeDefined();
 
     bridgeCall.mockResolvedValue({
-      filePath: 'artifacts/netlist.net',
-      netCount: 12,
+      base64: Buffer.from('*NET GND R1-1 R2-1').toString('base64'),
+      fileName: 'netlist.net',
     });
 
     const result = await tool?.handler(context, {
@@ -184,9 +241,34 @@ describe('Export Tools', () => {
     expect(result).toMatchObject({
       project_id: 'proj-123',
       format: 'pads',
-      file_path: 'artifacts/netlist.net',
-      net_count: 12,
       exported: true,
     });
+    expect(fs.readFileSync(result!.file_path!, 'utf-8')).toBe('*NET GND R1-1 R2-1');
+  });
+
+  it('easyeda_export_netlist writes plain (non-binary) netlist data as JSON and surfaces net_count', async () => {
+    const tool = registry.get('easyeda_export_netlist');
+    bridgeCall.mockResolvedValue({ netCount: 12, nets: ['GND', 'VCC'] });
+
+    const result = await tool?.handler(context, {
+      projectId: 'proj-123',
+      format: 'pads',
+    });
+
+    expect(result?.exported).toBe(true);
+    expect(result?.net_count).toBe(12);
+    const written = JSON.parse(fs.readFileSync(result!.file_path!, 'utf-8'));
+    expect(written).toEqual({ netCount: 12, nets: ['GND', 'VCC'] });
+  });
+
+  it('easyeda_export_netlist reports not_available when the bridge call fails', async () => {
+    const tool = registry.get('easyeda_export_netlist');
+    bridgeCall.mockRejectedValue(new Error('bridge offline'));
+
+    const result = await tool?.handler(context, { projectId: 'proj-123', format: 'pads' });
+
+    expect(result?.exported).toBe(false);
+    expect(result?.not_available).toBe(true);
+    expect(result?.error).toBe('bridge offline');
   });
 });

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -330,6 +330,58 @@ describe('ToolRegistry', () => {
     });
   });
 
+  describe('image content', () => {
+    it('appends an image content block when the tool defines imageContent', async () => {
+      const tool = createMockTool('image_tool', 'core', {
+        outputSchema: z.object({ ok: z.boolean(), image_base64: z.string().optional() }),
+        handler: async () => ({ ok: true, image_base64: 'ZmFrZS1wbmctYnl0ZXM=' }),
+        imageContent: (output) =>
+          output.image_base64 ? [{ data: output.image_base64, mimeType: 'image/png' }] : [],
+      });
+      registry.register(tool);
+
+      const { server, handlers } = mockMcpServer();
+      registry.registerAllOnServer(server as any, mockContext());
+
+      const response = await handlers.get('image_tool')!({});
+
+      expect(response.isError).toBeFalsy();
+      expect(response.content).toHaveLength(2);
+      expect(response.content[0]).toMatchObject({ type: 'text' });
+      expect(response.content[1]).toEqual({
+        type: 'image',
+        data: 'ZmFrZS1wbmctYnl0ZXM=',
+        mimeType: 'image/png',
+      });
+    });
+
+    it('does not add an image block when imageContent returns an empty array', async () => {
+      const tool = createMockTool('no_image_tool', 'core', {
+        outputSchema: z.object({ ok: z.boolean() }),
+        handler: async () => ({ ok: true }),
+        imageContent: () => [],
+      });
+      registry.register(tool);
+
+      const { server, handlers } = mockMcpServer();
+      registry.registerAllOnServer(server as any, mockContext());
+
+      const response = await handlers.get('no_image_tool')!({});
+      expect(response.content).toHaveLength(1);
+    });
+
+    it('does not add an image block for tools that omit imageContent entirely', async () => {
+      const tool = createMockTool('plain_tool', 'core');
+      registry.register(tool);
+
+      const { server, handlers } = mockMcpServer();
+      registry.registerAllOnServer(server as any, mockContext());
+
+      const response = await handlers.get('plain_tool')!({});
+      expect(response.content).toHaveLength(1);
+    });
+  });
+
   describe('capability scope gate', () => {
     it('should allow all tools when TOOL_SCOPES is empty', async () => {
       const tool = createMockTool('scope_default_allow', 'core');
@@ -508,6 +560,7 @@ describe('ToolRegistry', () => {
           'export',
           'pcb-constraints',
           'pcb-write',
+          'visual',
         ]).toContain(tool.group);
 
         // profile must be valid

--- a/tests/unit/tools/visual.test.ts
+++ b/tests/unit/tools/visual.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { ToolRegistry } from '../../../src/tools/registry.js';
+import { type ToolContext } from '../../../src/tools/types.js';
+import { registerVisualTools } from '../../../src/tools/L1_visual.js';
+import { EnvSchema } from '../../../src/config/env.js';
+
+describe('Visual Tools', () => {
+  let registry: ToolRegistry;
+  let context: ToolContext;
+  let bridgeCall: any;
+
+  beforeEach(() => {
+    registry = new ToolRegistry();
+    const config = EnvSchema.parse({ NODE_ENV: 'test' });
+    registerVisualTools(registry, config);
+
+    bridgeCall = vi.fn();
+
+    context = {
+      profile: 'core',
+      bridge: {
+        connected: true,
+        call: bridgeCall,
+      },
+      config: {
+        bridgeTimeoutMs: 1000,
+        artifactDir: '.easyeda-mcp-pro/artifacts',
+      },
+      vendors: {
+        lcsc: null,
+        jlcpcb: null,
+        mouser: null,
+        digikey: null,
+      },
+    };
+  });
+
+  describe('easyeda_canvas_capture', () => {
+    it('returns a captured image on success', async () => {
+      const tool = registry.get('easyeda_canvas_capture');
+      expect(tool).toBeDefined();
+
+      bridgeCall.mockResolvedValue({
+        base64: 'ZmFrZS1wbmctYnl0ZXM=',
+        mimeType: 'image/png',
+        fileName: 'capture.png',
+        byteLength: 14,
+      });
+
+      const result = await tool?.handler(context, {});
+
+      expect(bridgeCall).toHaveBeenCalledWith('canvas.capture', { tabId: undefined });
+      expect(result).toMatchObject({
+        captured: true,
+        mime_type: 'image/png',
+        file_name: 'capture.png',
+        byte_length: 14,
+        image_base64: 'ZmFrZS1wbmctYnl0ZXM=',
+      });
+    });
+
+    it('passes tabId through to the bridge call', async () => {
+      const tool = registry.get('easyeda_canvas_capture');
+      bridgeCall.mockResolvedValue({ base64: 'YQ==', mimeType: 'image/png' });
+
+      await tool?.handler(context, { tabId: 'tab-1' });
+
+      expect(bridgeCall).toHaveBeenCalledWith('canvas.capture', { tabId: 'tab-1' });
+    });
+
+    it('reports not_available when the bridge returns no image data', async () => {
+      const tool = registry.get('easyeda_canvas_capture');
+      bridgeCall.mockResolvedValue({});
+
+      const result = await tool?.handler(context, {});
+
+      expect(result?.captured).toBe(false);
+      expect(result?.not_available).toBe(true);
+    });
+
+    it('reports not_available when the bridge call throws (e.g. payload too large)', async () => {
+      const tool = registry.get('easyeda_canvas_capture');
+      bridgeCall.mockRejectedValue(new Error('PAYLOAD_TOO_LARGE'));
+
+      const result = await tool?.handler(context, {});
+
+      expect(result?.captured).toBe(false);
+      expect(result?.not_available).toBe(true);
+      expect(result?.error).toBe('PAYLOAD_TOO_LARGE');
+    });
+
+    it('produces an MCP image content block via imageContent', () => {
+      const tool = registry.get('easyeda_canvas_capture');
+      expect(tool?.imageContent).toBeDefined();
+
+      const images = tool!.imageContent!({
+        captured: true,
+        image_base64: 'ZmFrZS1wbmctYnl0ZXM=',
+        mime_type: 'image/png',
+      });
+      expect(images).toEqual([{ data: 'ZmFrZS1wbmctYnl0ZXM=', mimeType: 'image/png' }]);
+    });
+
+    it('produces no image content when capture failed', () => {
+      const tool = registry.get('easyeda_canvas_capture');
+      const images = tool!.imageContent!({ captured: false });
+      expect(images).toEqual([]);
+    });
+  });
+
+  describe('easyeda_canvas_capture_region', () => {
+    it('zooms to the region and returns the captured image', async () => {
+      const tool = registry.get('easyeda_canvas_capture_region');
+      expect(tool).toBeDefined();
+
+      bridgeCall.mockResolvedValue({
+        base64: 'cmVnaW9uLWJ5dGVz',
+        mimeType: 'image/png',
+        fileName: 'capture-region.png',
+      });
+
+      const result = await tool?.handler(context, {
+        left: 0,
+        right: 100,
+        top: 0,
+        bottom: 50,
+        tabId: 'tab-1',
+      });
+
+      expect(bridgeCall).toHaveBeenCalledWith('canvas.captureRegion', {
+        left: 0,
+        right: 100,
+        top: 0,
+        bottom: 50,
+        tabId: 'tab-1',
+      });
+      expect(result).toMatchObject({ captured: true, image_base64: 'cmVnaW9uLWJ5dGVz' });
+    });
+
+    it('reports not_available on bridge error', async () => {
+      const tool = registry.get('easyeda_canvas_capture_region');
+      bridgeCall.mockRejectedValue(new Error('bridge offline'));
+
+      const result = await tool?.handler(context, { left: 0, right: 1, top: 0, bottom: 1 });
+
+      expect(result?.captured).toBe(false);
+      expect(result?.not_available).toBe(true);
+      expect(result?.error).toBe('bridge offline');
+    });
+  });
+
+  describe('easyeda_canvas_locate', () => {
+    it('returns the resulting viewport rectangle', async () => {
+      const tool = registry.get('easyeda_canvas_locate');
+      expect(tool).toBeDefined();
+
+      bridgeCall.mockResolvedValue({ left: 0, right: 10, top: 0, bottom: 10 });
+
+      const result = await tool?.handler(context, { x: 5, y: 5, scaleRatio: 2 });
+
+      expect(bridgeCall).toHaveBeenCalledWith('canvas.locate', {
+        x: 5,
+        y: 5,
+        scaleRatio: 2,
+        tabId: undefined,
+      });
+      expect(result).toMatchObject({ located: true, left: 0, right: 10, top: 0, bottom: 10 });
+    });
+
+    it('reports not_available when EasyEDA cannot zoom to the coordinate (returns false)', async () => {
+      const tool = registry.get('easyeda_canvas_locate');
+      bridgeCall.mockResolvedValue(false);
+
+      const result = await tool?.handler(context, {});
+
+      expect(result?.located).toBe(false);
+      expect(result?.not_available).toBe(true);
+    });
+
+    it('reports not_available on bridge error', async () => {
+      const tool = registry.get('easyeda_canvas_locate');
+      bridgeCall.mockRejectedValue(new Error('bridge offline'));
+
+      const result = await tool?.handler(context, {});
+
+      expect(result?.located).toBe(false);
+      expect(result?.not_available).toBe(true);
+      expect(result?.error).toBe('bridge offline');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

WS-04 (Visual Verification Loop), combined with a related bug fix per explicit scoping
decision: canvas capture requires real Blob→base64 transport handling that didn't
exist, and the same gap already silently broke the shipped export tools.

**Bug fix (pre-existing, found while implementing capture):**
- The bridge extension's `board.exportGerbers`, `export.pickPlace`, `export.pdf`, and
  `export.netlist` dispatch cases call EasyEDA manufacturing-data APIs that return
  in-memory `File`/`Blob` objects (confirmed against `@jlceda/pro-api-types`). The bridge
  transport is JSON-only, and `JSON.stringify(blob)` produces `{}` — the real file bytes
  were silently dropped on every call. This was never caught because the existing tests
  mocked the bridge response directly (`{filePath: '...', ...}`) rather than exercising
  real Blob serialization.
- Fix: `easyeda-bridge-extension/src/binary-result.ts` converts any Blob/File dispatch
  result to `{base64, mimeType, fileName, byteLength}`; `src/tools/L1_export.ts`'s four
  export tools decode that payload and write the real file to `ARTIFACT_DIR` themselves,
  keeping their existing `artifact_path`/`file_path` output contract unchanged (plus a
  new optional `filePath` input, matching the sandboxing pattern already used by
  `easyeda_bom_export`).

**New capability (WS-04):**
- Three new bridge methods — `canvas.capture`, `canvas.captureRegion`, `canvas.locate`
  — backed by `DMT_EditorControl.getCurrentRenderedAreaImage`/`zoomToRegion`/`zoomTo`
  (real, typed, `@beta` EasyEDA Pro APIs; there is no offscreen-rendering API, so a
  region capture moves the user's visible viewport).
- New tools `easyeda_canvas_capture`, `easyeda_canvas_capture_region`,
  `easyeda_canvas_locate` in `src/tools/L1_visual.ts` (profile `core`, scopes
  `schematic:read`/`pcb:read`), so an agent can visually verify a draw/place/route action.
- New `ToolDefinition.imageContent` hook + registry plumbing so a tool result can include
  an MCP `image` content block alongside its JSON — this didn't exist anywhere in the
  codebase before (every tool response was text/JSON-only).
- Since a single oversized WS response frame closes the *whole* bridge connection
  (code 4009), not just the offending call, the server now advertises its configured
  `BRIDGE_MAX_PAYLOAD_SIZE` in the `hello` handshake (`maxPayloadSize`), and the
  extension self-limits binary results to a safety margin under it before sending,
  returning a structured `PAYLOAD_TOO_LARGE` error instead of an oversized frame.
- Added a vitest setup to the `easyeda-bridge-extension` package (previously had no
  test runner, only typecheck) to directly unit-test the new Blob-conversion helpers.

Tool profile counts moved from 44/49/58/62 to 47/52/61/65 (core/pro/full/dev) — 3 new
`core`-profile tools. Updated everywhere those counts are asserted or documented.

No new runtime dependencies (vitest added as a devDependency to the extension package
only, matching the version already used at the repo root).

## Test plan

- [x] `pnpm verify` (format, typecheck incl. extension, lint, tool-metadata lint,
      tool-coverage, full test suite, **new** extension test suite, build incl.
      extension, metadata check, docs build) — all green, 878 server-side tests +
      12 extension tests passing.
- [x] New/updated unit tests: Blob/File→base64 conversion and MIME-guessing helpers
      (including large multi-chunk payloads), the four export tools decoding a base64
      payload and writing real files to a temp artifact dir (including the
      path-escape guard and the "stale extension still returns `{}`" regression case),
      the three new canvas tools, MCP image-content registry plumbing, a
      `canvas.capture` round-trip against a fake WS client (no live EasyEDA needed,
      following the existing `manager.test.ts` pattern) including a
      `PAYLOAD_TOO_LARGE` scenario, and the new `maxPayloadSize` hello field.
- [ ] Live verification against a real EasyEDA Pro install is out of scope for this
      sandboxed session — flagged as the natural next step before relying on this in
      production, per the existing live-test policy (`pnpm smoke:easyeda`).