### PR TITLE
docs(remote): correct status claims for the pairing/relay gateway

### DIFF
--- a/docs/CHATGPT_APP_INTEGRATION.md
+++ b/docs/CHATGPT_APP_INTEGRATION.md
@@ -1,5 +1,14 @@
 # ChatGPT app integration plan
 
+**Current status: Planned.** Nothing in this document is implemented yet. The hosted
+gateway has no live deployment, and the pairing/session-router/relay subsystem it would
+depend on (`src/remote/`) is not wired to real MCP tool calls — see
+`docs/REMOTE_RELEASE_READINESS.md` for the tracked gap. This remains a target
+architecture and requirements list, not a usable integration path today. The self-hosted
+tunnel path in `docs/SELF_HOSTED_REMOTE_MCP.md` works with any MCP client that supports
+an arbitrary remote MCP URL, including ChatGPT's developer/custom-connector paths, and
+does not require anything described below.
+
 ChatGPT integration should use the hosted Remote MCP architecture as the primary app path. Self-hosted endpoints remain an advanced/developer path for clients that can connect to arbitrary remote MCP URLs.
 
 ## Target architecture

--- a/docs/CLAUDE_WEB_CONNECTOR.md
+++ b/docs/CLAUDE_WEB_CONNECTOR.md
@@ -1,8 +1,44 @@
 # Claude Web Remote MCP connector setup
 
-Claude Web can use EasyEDA MCP Pro through a public Remote MCP endpoint. The endpoint can be the hosted gateway or a user-managed self-hosted endpoint.
+Claude Web can use EasyEDA MCP Pro through a public Remote MCP endpoint.
 
-## Hosted mode
+**Current status:** there is no hosted gateway deployment today, and the pairing/relay
+flow described below as "target design" is not yet wired to real MCP tool calls — see
+`docs/REMOTE_RELEASE_READINESS.md` for the tracked gap. The setup that works today is
+the self-hosted tunnel path: run the MCP server and EasyEDA Pro on the same always-on
+machine, expose only the OAuth-protected HTTP transport through a tunnel/reverse proxy,
+and add that URL as a Claude Web connector. The bridge extension always talks to the MCP
+server over local loopback, so it does not need "pairing" in that setup — it just needs
+to be connected to the same EasyEDA Pro instance the server's bridge is listening for.
+
+## Self-hosted mode (works today)
+
+```text
+Claude Web
+  ↓
+https://mcp.user-domain.example/mcp   (OAuth-protected, tunneled/reverse-proxied)
+  ↓
+Your MCP server (TRANSPORT=http, OAUTH_ENABLED=true)
+  ↓
+Local bridge extension (same machine, loopback WebSocket)
+  ↓
+Open EasyEDA Pro project
+```
+
+User flow:
+
+1. Start the MCP server with `TRANSPORT=http`, `OAUTH_ENABLED=true`, and the other
+   settings in `docs/SELF_HOSTED_REMOTE_MCP.md`'s "Minimum safe configuration".
+2. Expose it through a safe domain, tunnel, reverse proxy, or VPS — see
+   `docs/SELF_HOSTED_REMOTE_MCP.md` for a Cloudflare Tunnel example.
+3. Install and activate the EasyEDA bridge extension on that same machine, open the
+   target project, and connect it to the local server (MCP Bridge → Connect).
+4. Add the public MCP URL as a Remote MCP connector in Claude Web.
+5. Use read tools first; the extension's browser process is on the same machine, so
+   there is no separate "active project" pairing step — whatever project is open in
+   EasyEDA Pro on that machine is what tools operate on.
+
+## Hosted mode (target design, not usable yet)
 
 ```text
 Claude Web
@@ -11,10 +47,13 @@ https://mcp.example.com/mcp
   ↓
 Hosted Remote MCP Gateway
   ↓
-Paired EasyEDA extension session
+Paired EasyEDA extension session   ← not wired to real tool calls yet
 ```
 
-User flow:
+There is no hosted gateway deployment to connect to today. The pairing/session-router/
+approval-policy subsystem this diagram depends on exists in `src/remote/` and is
+unit/HTTP-tested in isolation, but no code path routes an actual `/mcp` tool call
+through it yet. Once that integration lands, the intended user flow is:
 
 1. Install and activate the EasyEDA bridge extension.
 2. Open EasyEDA Web and the target project.
@@ -24,45 +63,15 @@ User flow:
 6. Confirm the extension shows connected status and the active project.
 7. Use read tools first; approve write/export actions in the extension.
 
-## Self-hosted mode
+## Troubleshooting (self-hosted mode)
 
-```text
-Claude Web
-  ↓
-https://mcp.user-domain.example/mcp
-  ↓
-User-managed Remote MCP endpoint
-  ↓
-Paired EasyEDA extension session
-```
-
-User flow:
-
-1. Start the self-hosted EasyEDA MCP server with auth and pairing enabled.
-2. Expose it through a safe domain, tunnel, reverse proxy, or VPS.
-3. Add that public MCP URL in Claude Web.
-4. Pair the extension session.
-5. Confirm active project visibility before approving changes.
-
-## Expected extension status
-
-Before project-changing requests, the extension should show:
-
-- mode: Hosted Remote or Self-hosted Remote,
-- connection: connected,
-- pairing: paired,
-- active project: detected,
-- approval policy: enabled for write/export actions.
-
-## Troubleshooting
-
-| Problem               | Check                                                              |
-| --------------------- | ------------------------------------------------------------------ |
-| Claude cannot connect | Public URL, TLS, auth config, and allowed endpoint path.           |
-| No active project     | EasyEDA tab/project is not open or extension cannot detect it.     |
-| Tool call rejected    | Missing auth, missing pairing, missing scope, or approval timeout. |
-| Wrong project risk    | Stop and re-pair after selecting the intended EasyEDA project.     |
+| Problem               | Check                                                                                              |
+| --------------------- | -------------------------------------------------------------------------------------------------- |
+| Claude cannot connect | Public URL, TLS, auth config, and allowed endpoint path.                                           |
+| Tool call rejected    | Missing/expired auth token, or missing required scope.                                             |
+| No active project     | EasyEDA Pro on the server's machine has no project open, or the bridge extension is not connected. |
 
 ## Safety note
 
-Remote tools can affect the active design. Review approval prompts carefully, especially for write, export, overwrite, or delete operations.
+Remote tools can affect the active design. Review any confirmation prompts your MCP
+client shows carefully, especially for write, export, overwrite, or delete operations.

--- a/docs/EXTENSION_RELAY_PROTOCOL.md
+++ b/docs/EXTENSION_RELAY_PROTOCOL.md
@@ -1,5 +1,13 @@
 # Extension relay protocol
 
+**Current status:** the wire protocol and envelope shapes below are implemented
+(`src/remote/protocol.ts`, `easyeda-bridge-extension/src/remote-client.ts`) and unit
+tested. `RemoteRelayClient` genuinely connects and can execute real EasyEDA API calls
+when driven directly. What is missing is upstream of this protocol: no real MCP tool
+call (`/mcp`) currently produces a `tool_request` on this relay — see
+`docs/REMOTE_RELEASE_READINESS.md` for the tracked gap. `RemoteRelayClient` also has no
+reconnect/backoff logic yet, unlike the local bridge connection in the same file.
+
 The relay protocol carries authenticated gateway requests to an opted-in EasyEDA bridge extension session. The extension uses an outbound connection and does not expose a local listener to the public internet.
 
 ## Goals

--- a/docs/PAIRING_AND_SESSION_ROUTING.md
+++ b/docs/PAIRING_AND_SESSION_ROUTING.md
@@ -1,5 +1,13 @@
 # Pairing and session routing
 
+**Current status:** the pairing/session-router mechanics below are implemented in
+`src/remote/session-router.ts` and covered by thorough unit tests, and are reachable
+today via the `/remote/*` REST/WebSocket surface. What's described here as "remote
+tools can route to that session" does not yet happen for real MCP tool calls (`/mcp`) —
+see `docs/REMOTE_RELEASE_READINESS.md` for the tracked integration gap. This document
+accurately describes the session router's own behavior; it does not describe what
+currently happens when an MCP client calls a tool.
+
 Pairing binds a remote MCP identity to an active EasyEDA bridge extension session. Session routing ensures every tool call reaches only the intended user's EasyEDA project.
 
 ## Pairing lifecycle

--- a/docs/REMOTE_GATEWAY_DESIGN.md
+++ b/docs/REMOTE_GATEWAY_DESIGN.md
@@ -24,6 +24,15 @@ document.
 
 ## Request flow
 
+> **Status: target design, not yet wired.** The steps below describe the intended flow
+> once tool execution is bridged to the relay. Today, a real `POST /mcp` tool call never
+> reaches the session router, policy/approval gate, or relay dispatch — it always
+> dispatches through the local-loopback `BridgeManager` WebSocket instead (see
+> `docs/REMOTE_RELEASE_READINESS.md` for the current-status writeup). The session
+> router, approval policy, and relay dispatch steps below exist and are tested only via
+> the separate `/remote/*` REST/WebSocket surface, which nothing in the `/mcp` tool-call
+> path currently calls.
+
 ```text
 remote MCP request
   ↓

--- a/docs/REMOTE_MCP_TEST_PLAN.md
+++ b/docs/REMOTE_MCP_TEST_PLAN.md
@@ -28,6 +28,11 @@ Recommended scenarios:
 
 ## Manual validation
 
+**Not yet achievable:** every scenario below assumes a real MCP tool call can be routed
+through the pairing/session-router/relay subsystem. That integration does not exist yet
+(see `docs/REMOTE_RELEASE_READINESS.md`), so none of these can currently be executed
+end-to-end. Keep this section as the target validation checklist for when that lands.
+
 Before public beta:
 
 - hosted endpoint deployed under a test domain,

--- a/docs/REMOTE_RELEASE_READINESS.md
+++ b/docs/REMOTE_RELEASE_READINESS.md
@@ -11,6 +11,44 @@ Use the following status terms consistently.
 - **Beta**: users can test it with documented limits.
 - **Production-ready**: CI, validation, security review, and runbooks are complete.
 
+## Current status: Planned (pairing/relay/approval routing is not wired to real tool calls)
+
+As of this writing, the pairing/session-router/approval-policy/relay subsystem in
+`src/remote/` (`RemoteGateway`, `RemoteSessionRouter`, `ApprovalStore`) is implemented and
+unit/HTTP-tested in isolation, and its REST/WebSocket surface (`/remote/pairing-codes`,
+`/remote/pairings`, `/remote/tool-requests`, `/remote/audit`, `/remote/relay`) is mounted
+and reachable whenever `TRANSPORT=http` — no separate flag gates it. However, **no code
+path routes an actual MCP tool call (`POST /mcp`) through this subsystem.** Every real
+tool invocation, on every transport, always dispatches through the local-loopback
+`BridgeManager` WebSocket to whatever EasyEDA bridge extension is connected on the same
+host. This means:
+
+- A user can pair an extension session, create pairing codes, and drive
+  `RemoteGateway.routeToolRequest()` directly against the `/remote/*` REST surface, but
+  that has no effect on and no connection to what any MCP client sees when it calls a
+  real tool via `/mcp`.
+- The extension's `RemoteRelayClient` (Remote Relay Mode) genuinely connects to a relay
+  URL and can execute real EasyEDA API calls when driven directly, but nothing on the
+  server side feeds it MCP tool calls from `/mcp`.
+- There is also no name mapping between the MCP tool ids used elsewhere in this repo
+  (e.g. `easyeda_pcb_place_component`) and the extension's internal dispatch method ids
+  (e.g. `schematic.placeComponent`) — a prerequisite for the two paths to ever line up.
+
+Given the status vocabulary above, the pairing/relay/approval-routing feature described
+in `REMOTE_GATEWAY_DESIGN.md`, `SELF_HOSTED_REMOTE_MCP.md`'s "Planned relay controls",
+`docs/CLAUDE_WEB_CONNECTOR.md`, and `docs/CHATGPT_APP_INTEGRATION.md` is **Planned**, not
+Experimental or Beta — closing this gap requires an explicit architecture decision (how
+tool execution selects a backend per deployment mode) before further code is written.
+
+**What already works today without this subsystem:** OAuth-protected HTTP transport
+(`TRANSPORT=http`, `OAUTH_ENABLED=true`) reachable through a tunnel/reverse proxy is
+real and production-quality — see "Current HTTP/OAuth configuration" in
+`REMOTE_GATEWAY_DESIGN.md`. A self-hosted user who runs the MCP server and EasyEDA Pro
+on the same always-on machine and tunnels only the HTTP port already has a working
+remote MCP setup; they do not need pairing/relay/approval routing for that to function,
+since the bridge extension stays local to that machine regardless of where the calling
+MCP client sits on the network.
+
 ## Gateway release gate
 
 A release candidate should verify the following items.

--- a/docs/REMOTE_SECURITY_MODEL.md
+++ b/docs/REMOTE_SECURITY_MODEL.md
@@ -1,5 +1,13 @@
 # Remote MCP security model
 
+**Current status:** this document specifies the required security model for the
+pairing/relay routing path once it is wired to real MCP tool calls. That integration
+does not exist yet — see `docs/REMOTE_RELEASE_READINESS.md`. Today, real tool calls
+never traverse the Session Router/Relay boundary shown below; they go through the local
+`BridgeManager` loopback connection instead. The controls below remain the bar that
+integration must meet before it ships, so treat this as a design/acceptance spec, not a
+description of a currently-enforced boundary.
+
 Remote MCP must not be treated as a public wrapper around local tool execution. Every remote path must enforce identity, pairing, session isolation, approval policy, and auditable routing.
 
 ## Trust boundaries

--- a/docs/SELF_HOSTED_REMOTE_MCP.md
+++ b/docs/SELF_HOSTED_REMOTE_MCP.md
@@ -4,6 +4,15 @@ Self-hosted Remote MCP lets an operator expose EasyEDA MCP Pro through their own
 VPS, or reverse proxy. This mode is for power users and private deployments that need a public MCP
 endpoint without using the hosted gateway.
 
+**Current status:** the setup below — tunneling the OAuth-protected HTTP transport out from a
+single always-on machine that also runs EasyEDA Pro and the bridge extension — works today with
+the existing HTTP/OAuth implementation. The bridge extension always connects to the MCP server
+over local loopback regardless of where the calling MCP client sits on the network, so this
+flow does not depend on the pairing/relay/approval subsystem described in "Planned relay
+controls" below. That subsystem exists and is tested in isolation but is not yet wired to real
+tool calls — see `docs/REMOTE_RELEASE_READINESS.md` for the tracked gap. Skip the "Planned relay
+controls" section and the pairing-related rows of the operator checklist until that lands.
+
 ## Architecture
 
 ```text


### PR DESCRIPTION
## Summary

WS-03 (Remote MCP Gateway GA) research turned up a significant gap before any code was
written: `src/remote/` (`RemoteGateway`, `RemoteSessionRouter`, `ApprovalStore`, the
relay protocol) is genuinely implemented and well-tested in isolation, and its
REST/WebSocket surface (`/remote/pairing-codes`, `/remote/pairings`,
`/remote/tool-requests`, `/remote/audit`, `/remote/relay`) is live whenever
`TRANSPORT=http` — but **no code path routes an actual MCP tool call (`POST /mcp`)
through it.** Every real tool call, on every transport, dispatches through the local
`BridgeManager` loopback WebSocket instead. There's also no tool-id mapping between the
MCP tool names used elsewhere (`easyeda_pcb_place_component`) and the extension's
internal dispatch method names (`schematic.placeComponent`) — a prerequisite for the two
paths to ever line up.

Bridging that gap is a real architecture decision (how tool execution selects a
local-bridge vs. remote-gateway backend per deployment mode) that affects the path every
existing local user depends on, so per direction it's deferred rather than attempted
here. This PR is docs-only: it corrects two docs that currently describe a working user
journey that isn't real, and adds honest status callouts elsewhere.

- **`docs/CLAUDE_WEB_CONNECTOR.md`**: was written entirely as "how to set up hosted/paired
  remote MCP," which doesn't work today. Rewritten to lead with what does work today — a
  self-hosted tunnel to a single always-on machine running both the MCP server and
  EasyEDA Pro, using the existing OAuth-protected HTTP transport, no pairing needed — and
  clearly labels the hosted/pairing flow as target design, not usable yet.
- **`docs/CHATGPT_APP_INTEGRATION.md`**: added an explicit "Current status: Planned" note
  up front; the rest of the doc was already framed as a plan with an "Open risks"
  section, so no further rewrite needed.
- **`docs/REMOTE_RELEASE_READINESS.md`**: added a "Current status" section using the
  doc's own Planned/Experimental/Beta/Production-ready vocabulary to state the gap
  plainly, and to note what already works today without this subsystem (the self-hosted
  tunnel path).
- **`docs/REMOTE_GATEWAY_DESIGN.md`**, **`docs/REMOTE_SECURITY_MODEL.md`**,
  **`docs/PAIRING_AND_SESSION_ROUTING.md`**, **`docs/EXTENSION_RELAY_PROTOCOL.md`**,
  **`docs/SELF_HOSTED_REMOTE_MCP.md`**, **`docs/REMOTE_MCP_TEST_PLAN.md`**: each gets a
  short status callout pointing back to `REMOTE_RELEASE_READINESS.md` rather than
  repeating the explanation at length, since each of these was otherwise accurate about
  the subsystem's own internal design — they just didn't flag that it isn't wired to
  real tool calls yet.

No code changes.

## Test plan

- [x] `pnpm verify` — full green (878 server tests, 12 extension tests, typecheck, lint,
      build, docs build) — expected, since this PR touches only markdown.
- [x] `pnpm docs:build` — VitePress renders all edited pages cleanly.