### PR TITLE
Add native agent runtime config for EasyEDA

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,83 +1,11 @@
 {
+  "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "easyeda-pro",
   "version": "0.20.0",
-  "description": "EasyEDA MCP Pro agent plugin for EasyEDA Pro project workflow automation, schematic/PCB inspection, BOM and sourcing, DRC/ERC validation, and manufacturing exports.",
+  "description": "EasyEDA MCP Pro plugin for EasyEDA Pro project workflow automation, schematic/PCB inspection, BOM and sourcing, DRC/ERC validation, and manufacturing exports.",
   "author": {
     "name": "oaslananka",
     "url": "https://github.com/oaslananka"
   },
-  "source": {
-    "source": "github",
-    "repo": "oaslananka/easyeda-mcp-pro"
-  },
-  "category": "engineering",
-  "tags": [
-    "easyeda",
-    "easyeda-pro",
-    "pcb",
-    "eda",
-    "mcp",
-    "hardware",
-    "electronics",
-    "jlcpcb",
-    "lcsc",
-    "bom"
-  ],
-  "mcp_servers": [
-    {
-      "name": "io.github.oaslananka/easyeda-mcp-pro",
-      "title": "EasyEDA MCP Pro",
-      "description": "MCP server for EasyEDA Pro: PCB inspection, BOM, exports, and hardware review.",
-      "package": {
-        "npm": "easyeda-mcp-pro"
-      },
-      "transports": ["stdio", "http"],
-      "launch_examples": [
-        "npx easyeda-mcp-pro",
-        "TRANSPORT=http HTTP_HOST=127.0.0.1 HTTP_PORT=3000 npx easyeda-mcp-pro",
-        "pnpm build && node dist/index.js"
-      ],
-      "registry_manifest": "server.json",
-      "minimum_requirements": [
-        "Node.js >=24 <27.",
-        "pnpm >=11 for source checkout development flows.",
-        "EasyEDA Pro plus the EasyEDA bridge extension for live project inspection and write operations.",
-        "TOOL_PROFILE set to core, pro, full, dev, or experimental according to the workflow boundary."
-      ]
-    }
-  ],
-  "skills": [
-    {
-      "name": "easyeda-workflow",
-      "path": "skills/easyeda-workflow/SKILL.md",
-      "description": "End-to-end EasyEDA Pro workflow guidance for setup, inspection, controlled writes, exports, and reporting."
-    },
-    {
-      "name": "component-search",
-      "path": "skills/component-search/SKILL.md",
-      "description": "Component discovery, BOM review, LCSC/JLCPCB sourcing, pricing, availability, and part-risk workflow."
-    },
-    {
-      "name": "design-validation",
-      "path": "skills/design-validation/SKILL.md",
-      "description": "EasyEDA DRC/ERC, semantic ERC, power-tree, PCB constraints, production QA, and release validation workflow."
-    }
-  ],
-  "documentation": {
-    "readme": "README.md",
-    "installation": "docs/INSTALLATION.md",
-    "chatgpt_app_integration": "docs/CHATGPT_APP_INTEGRATION.md",
-    "claude_web_connector": "docs/CLAUDE_WEB_CONNECTOR.md",
-    "remote_modes": "docs/REMOTE_MCP_MODES.md",
-    "agent_plugin": "README.md#agent-plugin-and-skills"
-  },
-  "safety": {
-    "human_review_required": true,
-    "notes": [
-      "EasyEDA MCP Pro is an engineering assistant, not an autonomous production sign-off authority.",
-      "Write operations require explicit workflow permission and must respect bridge capability, tool profile, and scope boundaries.",
-      "Manufacturing exports, sourcing decisions, and production QA artifacts require qualified human review before fabrication or assembly."
-    ]
-  },
-  "status": "ready-for-catalog-validation"
+  "skills": ["./skills/easyeda-workflow", "./skills/component-search", "./skills/design-validation"]
 }

--- a/.codex/config.example.toml
+++ b/.codex/config.example.toml
@@ -1,0 +1,13 @@
+# Example Codex MCP configuration for EasyEDA MCP Pro.
+# Copy this block into your Codex config.toml and adjust env values if needed.
+
+[[mcp_servers]]
+name = "easyeda-mcp-pro"
+command = "npx"
+args = ["easyeda-mcp-pro"]
+
+[mcp_servers.env]
+TRANSPORT = "stdio"
+TOOL_PROFILE = "core"
+BRIDGE_HOST = "127.0.0.1"
+BRIDGE_PORT = "49620"

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "easyeda-mcp-pro": {
+      "command": "npx",
+      "args": ["easyeda-mcp-pro"],
+      "env": {
+        "TRANSPORT": "stdio",
+        "TOOL_PROFILE": "core",
+        "BRIDGE_HOST": "127.0.0.1",
+        "BRIDGE_PORT": "49620"
+      }
+    }
+  }
+}

--- a/.vscode/mcp.example.json
+++ b/.vscode/mcp.example.json
@@ -1,0 +1,15 @@
+{
+  "servers": {
+    "easyeda-mcp-pro": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["easyeda-mcp-pro"],
+      "env": {
+        "TRANSPORT": "stdio",
+        "TOOL_PROFILE": "core",
+        "BRIDGE_HOST": "127.0.0.1",
+        "BRIDGE_PORT": "49620"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -704,7 +704,11 @@ profiles, and EasyEDA runtime behavior.
 
 | File                                                                     | Purpose                                                                                         |
 | ------------------------------------------------------------------------ | ----------------------------------------------------------------------------------------------- |
-| [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json)               | Product-level plugin manifest for compatible agent runtimes and marketplace catalogs.           |
+| [`.claude-plugin/plugin.json`](.claude-plugin/plugin.json)               | Claude Code-valid plugin manifest for compatible agent runtimes and marketplace catalogs.       |
+| [`.mcp.json`](.mcp.json)                                                 | Project-local Claude Code MCP server configuration.                                             |
+| [`.codex/config.example.toml`](.codex/config.example.toml)               | Codex CLI MCP configuration example.                                                            |
+| [`.vscode/mcp.example.json`](.vscode/mcp.example.json)                   | VS Code / GitHub Copilot workspace MCP configuration example.                                   |
+| [`docs/agent-runtime-config.md`](docs/agent-runtime-config.md)           | Agent runtime setup and validation matrix.                                                      |
 | [`skills/easyeda-workflow/SKILL.md`](skills/easyeda-workflow/SKILL.md)   | End-to-end EasyEDA setup, inspection, controlled write, export, and reporting workflow.         |
 | [`skills/component-search/SKILL.md`](skills/component-search/SKILL.md)   | Component search, BOM review, sourcing, pricing, availability, and part-risk workflow.          |
 | [`skills/design-validation/SKILL.md`](skills/design-validation/SKILL.md) | DRC/ERC, semantic ERC, PCB constraints, production QA, export, and release-validation workflow. |
@@ -727,6 +731,7 @@ For source checkouts, run the normal validation path before publishing plugin ch
 
 ```bash
 python3 -m json.tool .claude-plugin/plugin.json >/dev/null
+claude plugin validate .
 pnpm format:check
 pnpm typecheck
 pnpm test

--- a/docs/agent-runtime-config.md
+++ b/docs/agent-runtime-config.md
@@ -1,0 +1,57 @@
+# Agent Runtime Configuration
+
+This document gives copyable configuration examples for running EasyEDA MCP Pro from popular MCP-capable agent runtimes.
+
+## Claude Code
+
+The repository includes both:
+
+- `.claude-plugin/plugin.json` with a Claude Code-valid plugin manifest.
+- `.mcp.json` with the MCP server definition for project-local Claude Code usage.
+
+Validate the plugin locally:
+
+```bash
+claude plugin validate .
+```
+
+Run Claude Code with this plugin directory for one session:
+
+```bash
+claude --plugin-dir .
+```
+
+## Codex CLI
+
+Use `.codex/config.example.toml` as a starting point. Copy the `[[mcp_servers]]` block into your Codex config file and adjust bridge or profile settings if needed.
+
+## VS Code / GitHub Copilot
+
+Use `.vscode/mcp.example.json` as a workspace MCP configuration example. If your VS Code profile already has MCP servers configured globally, copy only the `easyeda-mcp-pro` server block.
+
+## Cursor and other MCP clients
+
+Most MCP-compatible clients can use the same stdio launch command:
+
+```bash
+npx easyeda-mcp-pro
+```
+
+For HTTP transport, use an explicit transport environment:
+
+```bash
+TRANSPORT=http HTTP_HOST=127.0.0.1 HTTP_PORT=3000 npx easyeda-mcp-pro
+```
+
+## Validation checklist
+
+1. Confirm the command starts: `npx easyeda-mcp-pro --help`.
+2. Validate plugin metadata: `claude plugin validate .`.
+3. Install and enable the EasyEDA bridge extension for live EasyEDA Pro project workflows.
+4. Start an MCP-capable client with the configured server.
+5. Call safe diagnostics such as `easyeda_health_check`, `easyeda_bridge_status`, or `easyeda_get_capabilities`.
+6. Use write tools only after bridge status, `TOOL_PROFILE`, and user permission are clear.
+
+## Safety
+
+EasyEDA MCP Pro is an engineering assistant, not a manufacturing sign-off authority. DRC, ERC, BOM, sourcing, export artifacts, and all generated changes require human engineering review.


### PR DESCRIPTION
## Summary

Hardens the EasyEDA agent/plugin packaging for popular MCP-capable agent runtimes.

## Changes

- Convert `.claude-plugin/plugin.json` to a Claude Code-valid plugin manifest.
- Add `.mcp.json` for project-local Claude Code MCP discovery.
- Add `.codex/config.example.toml` for Codex MCP configuration.
- Add `.vscode/mcp.example.json` for VS Code / GitHub Copilot-style workspace MCP configuration.
- Add `docs/agent-runtime-config.md` with Claude Code, Codex, VS Code/Copilot, Cursor/generic MCP setup notes and validation checklist.
- Update README agent/plugin section to reference the native runtime config files.

## Validation performed

- `python3 -m json.tool .claude-plugin/plugin.json >/dev/null`
- `python3 -m json.tool .mcp.json >/dev/null`
- `python3 -m json.tool .vscode/mcp.example.json >/dev/null`
- `claude plugin validate .`
- `pnpm check:metadata`
- `git diff --check`

## Notes

The product-specific source repository remains the source of truth for EasyEDA skills and MCP runtime configuration. Marketplace/catalog metadata stays in `oaslananka/agent-tools`.