### PR TITLE
Add OpenCode runtime config for EasyEDA

### DIFF
--- a/.opencode/skills/component-search/SKILL.md
+++ b/.opencode/skills/component-search/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: component-search
+description: EasyEDA component discovery, BOM review, LCSC/JLCPCB sourcing, pricing, availability, and part-risk workflow through EasyEDA MCP Pro.
+---
+
+# Component Search Skill
+
+Use this skill when an AI agent is asked to find, review, source, compare, or validate components for an EasyEDA Pro project through EasyEDA MCP Pro.
+
+This skill is specific to `oaslananka/easyeda-mcp-pro` and must stay aligned with the registered MCP tools in `src/tools/` and the tool list in `README.md`.
+
+## When to use
+
+Use this skill for:
+
+- EasyEDA schematic device search
+- BOM generation and review
+- LCSC/JLCPCB-oriented sourcing checks
+- Supplier pricing and availability review
+- BOM export preparation
+- Component-quality and production-risk reporting
+
+Do not use this skill to promise live inventory, price, lifecycle, or compliance facts unless the relevant tool result actually provides them.
+
+## Required context
+
+Collect:
+
+- Target component requirements: value, tolerance, package, voltage, current, temperature, lifecycle, and manufacturer constraints
+- Preferred supplier or marketplace: LCSC, JLCPCB, DigiKey, Mouser, or project default
+- Assembly target: prototype, JLCPCB assembly, manual assembly, or production
+- Active schematic and BOM state
+- Whether component placement or property updates are allowed
+- API credentials or supplier integration status when supplier tools require them
+
+## Primary MCP tools
+
+### Schematic and component discovery
+
+- `easyeda_schematic_components`
+- `easyeda_schematic_search_device`
+- `easyeda_schematic_component_pins`
+- `easyeda_schematic_net_detail`
+- `easyeda_schematic_nets`
+
+### BOM generation and validation
+
+- `easyeda_bom_generate`
+- `easyeda_bom_validate`
+- `easyeda_bom_export`
+- `easyeda_bom_sourcing`
+- `easyeda_bom_quality_report`
+
+### Supplier and production workflow
+
+- `easyeda_jlcpcb_quote_workflow`
+- `easyeda_production_qa_artifacts`
+- `easyeda_export_pick_place`
+- `easyeda_export_netlist`
+
+### Controlled component write workflow
+
+Use only after explicit permission and runtime capability confirmation.
+
+- `easyeda_schematic_place_component`
+- `easyeda_schematic_modify_primitive`
+- `easyeda_schematic_connect_pin_to_net`
+- `easyeda_schematic_connect_pins_by_net`
+- `easyeda_project_save`
+
+## Workflow
+
+1. Confirm health and bridge state with `easyeda_health_check` and `easyeda_bridge_status` if no recent status exists.
+2. Inspect current components with `easyeda_schematic_components`.
+3. Generate or refresh BOM with `easyeda_bom_generate`.
+4. Validate BOM structure and basic sourcing data with `easyeda_bom_validate`.
+5. Use `easyeda_schematic_search_device` when searching for new EasyEDA library devices.
+6. Use `easyeda_bom_sourcing` and `easyeda_bom_quality_report` for supplier, price, stock, and risk review when available.
+7. For JLCPCB workflows, use `easyeda_jlcpcb_quote_workflow` and report all assumptions.
+8. If the user requests component insertion or property updates, explain the mutation and use controlled schematic write tools only after approval.
+9. Export BOM or pick-and-place only when the project state and assembly target are clear.
+10. Report recommended parts with evidence, constraints, and unresolved risks.
+
+## Quality checks
+
+A useful component-search response must include:
+
+- Search criteria used
+- Current BOM state
+- Candidate components and source evidence
+- Package and footprint compatibility notes
+- Electrical derating risks
+- Stock, pricing, and supplier caveats
+- Assembly suitability
+- Required human review
+
+## Failure modes
+
+Stop and report clearly when:
+
+- Supplier tools are unavailable or credentials are missing
+- The user asks for guaranteed current stock or price without live tool evidence
+- The component requirements are under-specified
+- The EasyEDA library search returns ambiguous candidates
+- Footprint compatibility cannot be verified
+- A write operation is requested without permission
+
+## Output format
+
+Return:
+
+- Requirement summary
+- Tools used
+- Candidate table or BOM findings
+- Recommended choice and rationale
+- Risks and missing data
+- Required verification steps
+- Optional write/export actions
+
+## Safety rule
+
+Component recommendations are engineering suggestions. A qualified human must verify datasheets, footprint, availability, lifecycle, compliance, and assembly constraints before purchase or production.

--- a/.opencode/skills/design-validation/SKILL.md
+++ b/.opencode/skills/design-validation/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: design-validation
+description: EasyEDA DRC/ERC, semantic ERC, power-tree, PCB constraints, production QA, export, and release-validation workflow through EasyEDA MCP Pro.
+---
+
+# Design Validation Skill
+
+Use this skill when an AI agent is asked to validate an EasyEDA Pro schematic, PCB, BOM, export, or production handoff through EasyEDA MCP Pro.
+
+This skill is specific to `oaslananka/easyeda-mcp-pro` and must stay aligned with the registered MCP tools in `src/tools/` and the tool list in `README.md`.
+
+## When to use
+
+Use this skill for:
+
+- ERC review
+- DRC review
+- Semantic ERC and netlist checks
+- PCB constraint review
+- Power-tree analysis
+- BOM and sourcing validation
+- Production QA and export readiness review
+- Manufacturing handoff risk reporting
+
+Do not use this skill to approve a project for fabrication or assembly without qualified human review.
+
+## Required context
+
+Collect:
+
+- Active EasyEDA project and bridge status
+- Validation target: schematic, PCB, BOM, export, quote, or production package
+- Manufacturer or assembly constraints
+- Power rails, currents, connector requirements, and critical nets
+- Expected board stackup and mechanical constraints
+- Export directory and artifact requirements
+- Existing waivers or accepted risks
+
+## Primary MCP tools
+
+### Health and capability checks
+
+- `easyeda_health_check`
+- `easyeda_bridge_status`
+- `easyeda_get_capabilities`
+- `easyeda_get_tool_profiles`
+- `easyeda_run_self_test`
+
+### Schematic validation
+
+- `easyeda_erc_run`
+- `easyeda_semantic_erc_validate`
+- `easyeda_schematic_validate_netlist`
+- `easyeda_schematic_verify_write`
+- `easyeda_schematic_components`
+- `easyeda_schematic_nets`
+- `easyeda_schematic_net_detail`
+- `easyeda_power_tree_analyze`
+
+### PCB validation
+
+- `easyeda_drc_run`
+- `easyeda_rule_check_summary`
+- `easyeda_board_layers`
+- `easyeda_board_stackup`
+- `easyeda_board_dimensions`
+- `easyeda_board_features`
+- `easyeda_pcb_constraint_check`
+- `easyeda_pcb_constraint_report`
+- `easyeda_pcb_production_review`
+
+### BOM and sourcing validation
+
+- `easyeda_bom_generate`
+- `easyeda_bom_validate`
+- `easyeda_bom_sourcing`
+- `easyeda_bom_quality_report`
+
+### Export and production checks
+
+- `easyeda_export_gerbers`
+- `easyeda_export_pick_place`
+- `easyeda_export_pdf`
+- `easyeda_export_netlist`
+- `easyeda_production_qa_artifacts`
+- `easyeda_jlcpcb_quote_workflow`
+- `easyeda_canvas_capture`
+- `easyeda_canvas_capture_region`
+
+## Workflow
+
+1. Confirm server and bridge state with `easyeda_health_check` and `easyeda_bridge_status`.
+2. Confirm that the active profile exposes the needed validation tools.
+3. Run schematic validation with `easyeda_erc_run`, `easyeda_semantic_erc_validate`, and `easyeda_schematic_validate_netlist` when schematic scope is included.
+4. Run PCB validation with `easyeda_drc_run`, `easyeda_rule_check_summary`, and board inspection tools when PCB scope is included.
+5. Run power-tree and critical-net validation when the design has named rails, current constraints, or safety-sensitive nets.
+6. Run PCB constraint and production review tools against the provided manufacturer constraints.
+7. Validate BOM and sourcing if assembly or procurement is in scope.
+8. Generate export and production QA artifacts only when validation blockers are known and reported.
+9. Capture visual evidence when layout or schematic readability matters.
+10. Produce a final report that separates blocking issues, warnings, unknowns, waivers, and human-review items.
+
+## Quality checks
+
+A complete validation response must include:
+
+- Health and bridge status
+- Active tool profile
+- ERC result summary
+- DRC result summary
+- Semantic/netlist result summary
+- PCB constraints and production review
+- BOM and sourcing status when relevant
+- Export artifact status when relevant
+- Blockers, warnings, unknowns, and waivers
+- Human-review checklist
+
+## Failure modes
+
+Stop and report clearly when:
+
+- EasyEDA bridge is disconnected
+- Required validation tools are hidden by the active tool profile
+- ERC/DRC tools cannot obtain project data
+- Manufacturer constraints are missing for production review
+- BOM/sourcing data is incomplete
+- Export tools fail or artifact paths are ambiguous
+- The user asks to ignore unresolved critical issues
+
+## Output format
+
+Return:
+
+- Validation scope
+- Tools used
+- Results by domain
+- Findings by severity
+- Waivers and assumptions
+- Export/production artifact status
+- Final verdict: `blocked`, `needs fixes`, `needs human review`, or `candidate after human review`
+
+## Safety rule
+
+A clean automated validation result is not production approval. Production release requires human review of EasyEDA files, exports, BOM, assembly data, and manufacturer constraints.

--- a/.opencode/skills/easyeda-workflow/SKILL.md
+++ b/.opencode/skills/easyeda-workflow/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: easyeda-workflow
+description: End-to-end EasyEDA Pro workflow guidance for setup, inspection, controlled writes, exports, and reporting through EasyEDA MCP Pro.
+---
+
+# EasyEDA Workflow Skill
+
+Use this skill when an AI agent is asked to work with an EasyEDA Pro project through EasyEDA MCP Pro.
+
+This skill is specific to `oaslananka/easyeda-mcp-pro` and must stay aligned with the registered MCP tools in `src/tools/` and the tool list in `README.md`.
+
+## When to use
+
+Use this skill for:
+
+- EasyEDA MCP server setup and health checks
+- Bridge extension connectivity checks
+- Project inspection
+- Schematic and PCB read-only review
+- Controlled schematic or PCB write workflows
+- BOM, DRC/ERC, board, export, and production review orchestration
+- Producing a structured status report for a human engineer
+
+Do not use this skill to bypass EasyEDA Pro, bridge-extension, tool-profile, or scope restrictions.
+
+## Required context
+
+Collect:
+
+- Whether the server is running in `stdio` or `http` transport mode
+- Active `TOOL_PROFILE`: `core`, `pro`, `full`, `dev`, or `experimental`
+- EasyEDA Pro bridge status
+- Whether the task is read-only or write-enabled
+- Project type: schematic, PCB, BOM, export, sourcing, or production review
+- User approval for any write operation
+- Output directory requirements for exports
+
+## Primary MCP tools
+
+### Diagnostics and capability discovery
+
+- `easyeda_health_check`
+- `easyeda_bridge_status`
+- `easyeda_get_capabilities`
+- `easyeda_get_server_config`
+- `easyeda_get_tool_profiles`
+- `easyeda_get_feature_flags`
+- `easyeda_observability_report`
+- `easyeda_run_self_test`
+- `easyeda_api_inventory`
+
+### Schematic read workflow
+
+- `easyeda_schematic_nets`
+- `easyeda_schematic_components`
+- `easyeda_schematic_net_detail`
+- `easyeda_schematic_sheet_info`
+- `easyeda_schematic_component_pins`
+- `easyeda_schematic_validate_netlist`
+- `easyeda_schematic_verify_write`
+
+### Controlled schematic write workflow
+
+Use only after explicit permission and bridge capability confirmation.
+
+- `easyeda_schematic_place_component`
+- `easyeda_schematic_add_wire`
+- `easyeda_schematic_create_net_flag`
+- `easyeda_schematic_create_net_port`
+- `easyeda_schematic_connect_pin_to_net`
+- `easyeda_schematic_connect_pins_by_net`
+- `easyeda_schematic_modify_primitive`
+- `easyeda_schematic_delete_primitive`
+- `easyeda_project_save`
+
+### PCB and board workflow
+
+- `easyeda_board_layers`
+- `easyeda_board_stackup`
+- `easyeda_board_dimensions`
+- `easyeda_board_features`
+- `easyeda_pcb_constraint_check`
+- `easyeda_pcb_constraint_report`
+- `easyeda_pcb_production_review`
+
+### Controlled PCB write workflow
+
+Use only after explicit permission and bridge capability confirmation.
+
+- `easyeda_pcb_place_component_group`
+- `easyeda_pcb_route_path_plan`
+- `easyeda_pcb_place_component`
+- `easyeda_pcb_add_track`
+- `easyeda_pcb_add_via`
+- `easyeda_pcb_add_zone`
+- `easyeda_pcb_modify_component`
+- `easyeda_pcb_delete_component`
+- `easyeda_project_save`
+
+### Export and visual workflow
+
+- `easyeda_canvas_capture`
+- `easyeda_canvas_capture_region`
+- `easyeda_canvas_locate`
+- `easyeda_export_gerbers`
+- `easyeda_export_pick_place`
+- `easyeda_export_pdf`
+- `easyeda_export_netlist`
+- `easyeda_production_qa_artifacts`
+- `easyeda_jlcpcb_quote_workflow`
+
+## Workflow
+
+1. Start with `easyeda_health_check`, `easyeda_bridge_status`, and `easyeda_get_capabilities`.
+2. Confirm the active tool profile and scope boundary with `easyeda_get_tool_profiles` and `easyeda_get_feature_flags`.
+3. Determine whether the task is read-only, controlled write, export, sourcing, or validation.
+4. For read-only review, inspect schematic, board, BOM, DRC/ERC, and export readiness with the relevant L1 tools.
+5. For write workflows, state the exact intended mutations before tool use and require explicit approval.
+6. Apply the smallest safe write set. Prefer semantic tools over `easyeda_api_call`.
+7. Save only when appropriate with `easyeda_project_save`.
+8. Validate after mutation with schematic netlist, DRC/ERC, board constraint, and production checks.
+9. Report verified tool output separately from assumptions and user-supplied requirements.
+
+## Quality checks
+
+A complete EasyEDA workflow response must include:
+
+- Server and bridge health
+- Active profile and scope assumptions
+- Tools used
+- Project observations
+- Changes made or proposed
+- Validation evidence
+- Unsupported or unavailable capabilities
+- Required human-review items
+
+## Failure modes
+
+Stop and report clearly when:
+
+- EasyEDA Pro is not connected through the bridge
+- The active tool profile does not expose the required tool
+- Required write permission is missing
+- A bridge API returns unsupported-method or unavailable-runtime errors
+- A project cannot be saved or exported
+- The user requests raw execution or unsafe full-control behavior without explicit enabled gates
+
+## Output format
+
+Return:
+
+- Context
+- Health/capability state
+- Workflow performed
+- Tool evidence
+- Changes or proposed changes
+- Validation result
+- Blockers and next actions
+
+## Safety rule
+
+Do not claim an EasyEDA project is manufacturing-ready based only on write success. Manufacturing readiness requires validation, export review, and qualified human approval.

--- a/README.md
+++ b/README.md
@@ -708,6 +708,8 @@ profiles, and EasyEDA runtime behavior.
 | [`.mcp.json`](.mcp.json)                                                 | Project-local Claude Code MCP server configuration.                                             |
 | [`.codex/config.example.toml`](.codex/config.example.toml)               | Codex CLI MCP configuration example.                                                            |
 | [`.vscode/mcp.example.json`](.vscode/mcp.example.json)                   | VS Code / GitHub Copilot workspace MCP configuration example.                                   |
+| [`opencode.example.jsonc`](opencode.example.jsonc)                       | OpenCode project MCP configuration example.                                                     |
+| [`.opencode/skills/`](.opencode/skills)                                  | OpenCode-native mirrored skill definitions.                                                     |
 | [`docs/agent-runtime-config.md`](docs/agent-runtime-config.md)           | Agent runtime setup and validation matrix.                                                      |
 | [`skills/easyeda-workflow/SKILL.md`](skills/easyeda-workflow/SKILL.md)   | End-to-end EasyEDA setup, inspection, controlled write, export, and reporting workflow.         |
 | [`skills/component-search/SKILL.md`](skills/component-search/SKILL.md)   | Component search, BOM review, sourcing, pricing, availability, and part-risk workflow.          |

--- a/docs/agent-runtime-config.md
+++ b/docs/agent-runtime-config.md
@@ -29,6 +29,24 @@ Use `.codex/config.example.toml` as a starting point. Copy the `[[mcp_servers]]`
 
 Use `.vscode/mcp.example.json` as a workspace MCP configuration example. If your VS Code profile already has MCP servers configured globally, copy only the `easyeda-mcp-pro` server block.
 
+## OpenCode
+
+Use `opencode.example.jsonc` as a project-level OpenCode MCP configuration example. Copy it to `opencode.json` in a working project, or merge the `mcp` block into an existing OpenCode config.
+
+OpenCode discovers project-local skills from `.opencode/skills/<name>/SKILL.md`, so this repository mirrors the EasyEDA skills there for OpenCode-native loading.
+
+Local MCP server command:
+
+```bash
+npx easyeda-mcp-pro
+```
+
+Typical prompt hint:
+
+```text
+Use the easyeda-mcp-pro MCP tools and the design-validation skill to validate this EasyEDA project.
+```
+
 ## Cursor and other MCP clients
 
 Most MCP-compatible clients can use the same stdio launch command:

--- a/opencode.example.jsonc
+++ b/opencode.example.jsonc
@@ -9,16 +9,16 @@
         "TRANSPORT": "stdio",
         "TOOL_PROFILE": "core",
         "BRIDGE_HOST": "127.0.0.1",
-        "BRIDGE_PORT": "49620"
+        "BRIDGE_PORT": "49620",
       },
-      "timeout": 15000
-    }
+      "timeout": 15000,
+    },
   },
   "permission": {
     "skill": {
       "easyeda-workflow": "allow",
       "component-search": "allow",
-      "design-validation": "allow"
-    }
-  }
+      "design-validation": "allow",
+    },
+  },
 }

--- a/opencode.example.jsonc
+++ b/opencode.example.jsonc
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "easyeda-mcp-pro": {
+      "type": "local",
+      "command": ["npx", "easyeda-mcp-pro"],
+      "enabled": true,
+      "environment": {
+        "TRANSPORT": "stdio",
+        "TOOL_PROFILE": "core",
+        "BRIDGE_HOST": "127.0.0.1",
+        "BRIDGE_PORT": "49620"
+      },
+      "timeout": 15000
+    }
+  },
+  "permission": {
+    "skill": {
+      "easyeda-workflow": "allow",
+      "component-search": "allow",
+      "design-validation": "allow"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds OpenCode runtime support for EasyEDA MCP Pro based on the current OpenCode config and Agent Skills conventions.

## Changes

- Add `opencode.example.jsonc` with a local MCP server definition for `easyeda-mcp-pro`.
- Mirror EasyEDA skills into `.opencode/skills/<name>/SKILL.md` for OpenCode-native skill discovery.
- Update `docs/agent-runtime-config.md` with an OpenCode section.
- Update README agent/plugin table with OpenCode config and skill paths.

## Validation performed

- Parsed `opencode.example.jsonc` as JSON-compatible JSONC.
- Verified every `.opencode/skills/<name>/SKILL.md` has frontmatter and `name` matches the directory name.
- `claude plugin validate .`
- `python3 -m json.tool .claude-plugin/plugin.json >/dev/null`
- `python3 -m json.tool .mcp.json >/dev/null`
- `python3 -m json.tool .vscode/mcp.example.json >/dev/null`
- `pnpm check:metadata`
- `git diff --check`

## Notes

OpenCode CLI is not available through the connected exec target, so this PR uses static validation against the documented OpenCode config and skill conventions.