### PR TITLE
chore: add branching guidelines and close LCSC client branch-coverage gaps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,14 @@ The project target is at least 80% statement coverage where coverage tooling app
 
 ---
 
-## 9. Pull Request Review Expectations
+## 9. Branching Strategy
+
+- Create every feature/fix branch from the latest `main`, and open every pull request directly against `main`. Do not stack a branch's pull request on top of another feature branch — a chain of sequential branch-to-branch merges can silently never reach `main` if one link in the chain is merged out of order or left unmerged.
+- Keep pull requests scoped to a single unit of work (one feature, one fix, one focused refactor). Prefer several small pull requests merged in sequence over one branch that accumulates many unrelated commits before opening a pull request — small PRs are easier to review, bisect, and revert independently.
+
+---
+
+## 10. Pull Request Review Expectations
 
 A pull request should include:
 

--- a/tests/unit/vendors/lcsc.test.ts
+++ b/tests/unit/vendors/lcsc.test.ts
@@ -70,6 +70,18 @@ function mockAllCategoriesEmpty() {
   });
 }
 
+function createMemoryCache(): VendorCache {
+  const store = new Map<string, { value: unknown; storedAt: number }>();
+  return {
+    async get(key) {
+      return (store.get(key) as { value: unknown; storedAt: number } | undefined) ?? null;
+    },
+    async set(key, value) {
+      store.set(key, { value, storedAt: Date.now() });
+    },
+  };
+}
+
 describe('LcscClient', () => {
   beforeEach(() => {
     requestMock.mockReset();
@@ -150,21 +162,24 @@ describe('LcscClient', () => {
       const result = await client.searchCategory('resistors');
       expect(result.parts[0]?.classification).toBe('extended');
     });
+
+    it('falls back to empty attributes when the raw attributes string is not valid JSON', async () => {
+      requestMock.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/resistors/list.json')) {
+          return jsonResponse(200, {
+            resistors: [resistor({ attributes: 'not-valid-json{' })],
+          });
+        }
+        return jsonResponse(200, {});
+      });
+
+      const client = new LcscClient(createTestConfig());
+      const result = await client.searchCategory('resistors');
+      expect(result.parts[0]?.attributes).toEqual({});
+    });
   });
 
   describe('caching', () => {
-    function createMemoryCache(): VendorCache {
-      const store = new Map<string, { value: unknown; storedAt: number }>();
-      return {
-        async get(key) {
-          return (store.get(key) as { value: unknown; storedAt: number } | undefined) ?? null;
-        },
-        async set(key, value) {
-          store.set(key, { value, storedAt: Date.now() });
-        },
-      };
-    }
-
     it('serves a repeated category query from cache without a second HTTP call', async () => {
       requestMock.mockImplementation(async (url: string) => {
         if (typeof url === 'string' && url.includes('/resistors/list.json')) {
@@ -263,6 +278,26 @@ describe('LcscClient', () => {
       }
     });
 
+    it('computes cache age when every scanned category is served from cache', async () => {
+      requestMock.mockImplementation(async (url: string) => {
+        if (typeof url === 'string' && url.includes('/resistors/list.json')) {
+          return jsonResponse(200, { resistors: [resistor()] });
+        }
+        return jsonResponse(200, {});
+      });
+
+      const cache = createMemoryCache();
+      const client = new LcscClient(createTestConfig(), cache);
+
+      await client.searchParts('resistor');
+      const callCountAfterFirst = requestMock.mock.calls.length;
+
+      const second = await client.searchParts('resistor');
+      expect(second.fromCache).toBe(true);
+      expect(second.cacheAgeSeconds).toBeGreaterThanOrEqual(0);
+      expect(requestMock.mock.calls.length).toBe(callCountAfterFirst);
+    });
+
     it('rethrows when jlcsearch fails and no LCSC_API_KEY is configured', async () => {
       vi.useFakeTimers();
       try {
@@ -344,6 +379,23 @@ describe('LcscClient', () => {
         (call) => typeof call[0] === 'string' && call[0].includes('lcsc.com/api/part'),
       );
       expect(fallbackCall).toBeDefined();
+    });
+
+    it('returns null for a non-numeric LCSC code when no LCSC_API_KEY is configured', async () => {
+      const client = new LcscClient(createTestConfig());
+      const part = await client.getPartDetail('not-a-numeric-code');
+      expect(part).toBeNull();
+      expect(requestMock).not.toHaveBeenCalled();
+    });
+
+    it('throws when the LCSC official API returns a non-2xx status for a non-numeric code', async () => {
+      requestMock.mockResolvedValue(textResponse(503, 'unavailable'));
+
+      const client = new LcscClient(createTestConfigWithApiKey());
+      await expect(client.getPartDetail('not-a-numeric-code')).rejects.toMatchObject({
+        code: 'VENDOR_API_UNAVAILABLE',
+        message: expect.stringContaining('LCSC official API'),
+      });
     });
 
     it('surfaces cache metadata on the returned part', async () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       thresholds: {
         lines: 80,
         functions: 80,
-        branches: 70,
+        branches: 75,
         statements: 80,
       },
     },


### PR DESCRIPTION
## Summary
- Document a branching/PR-sizing rule in `CONTRIBUTING.md`: branches must be cut from and PR'd directly against `main`, not chained onto another feature branch, and PRs should stay scoped to one unit of work. This directly addresses how the WS-06..WS-13 chain (see #214) silently failed to reach `main` for several merges.
- Add tests covering four previously-uncovered branches in the LCSC vendor client (`src/vendors/lcsc/client.ts`): malformed-JSON attributes, the official API returning a non-2xx status, the non-numeric-code lookup path (with/without an API key), and the all-categories-cached path in `searchParts`.
- Raise the global branch-coverage threshold in `vitest.config.ts` from 70% to 75% to lock in the improvement and catch future regressions.

## Test plan
- [x] `pnpm verify` passes clean (1056 tests, up from 1052)
- [x] `src/vendors/lcsc/client.ts` branch coverage improved from 73.5% to 79.48%, line coverage to 100%
- [x] Overall repo branch coverage now ~76.3%, above the new 75% threshold