### PR TITLE
fix(dispatcher): Circle/Polygon modify + Rectangle Y-sign fix

### DIFF
--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -2300,6 +2300,16 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
       // above), and that's the key that actually resolves; X/Y kept as a
       // fallback in case a future runtime version differs. Still degrades to
       // "no overlap data" (not a crash) if both guesses are wrong.
+      //
+      // Y-sign note (live-verified 2026-07-09): a rectangle created with
+      // `y: 5000` reads back TopLeftY: -5000 — an exact sign flip, also
+      // observed on SCH_PrimitiveText the same way (created y:6000 -> read
+      // back y:-6000). SCH_PrimitiveComponent (pins) and SCH_PrimitiveWire
+      // (Line) showed no such flip across multiple live checks — this
+      // appears specific to these two annotation-layer primitive types, not
+      // a general coordinate-system quirk. Negate on the way out so callers
+      // (e.g. findOverlappingRectangles, which compares against pin-derived
+      // Y coordinates) see the same sign convention as everything else.
       const schRectClass = readFirstPath<any>(['SCH_PrimitiveRectangle', 'sch_PrimitiveRectangle']);
       if (!schRectClass || typeof schRectClass.getAll !== 'function') {
         return { total: 0, items: [] };
@@ -2311,14 +2321,17 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
         logRecoverableError('failed to list rectangles', e);
         all = [];
       }
-      const items = all.map((r) => ({
-        primitiveId: extractPrimitiveId(r) || String(safeGetState(r, 'PrimitiveId') ?? ''),
-        x: safeGetState(r, 'TopLeftX') ?? safeGetState(r, 'X'),
-        y: safeGetState(r, 'TopLeftY') ?? safeGetState(r, 'Y'),
-        width: safeGetState(r, 'Width'),
-        height: safeGetState(r, 'Height'),
-        rotation: safeGetState(r, 'Rotation'),
-      }));
+      const items = all.map((r) => {
+        const rawY = safeGetState(r, 'TopLeftY') ?? safeGetState(r, 'Y');
+        return {
+          primitiveId: extractPrimitiveId(r) || String(safeGetState(r, 'PrimitiveId') ?? ''),
+          x: safeGetState(r, 'TopLeftX') ?? safeGetState(r, 'X'),
+          y: typeof rawY === 'number' ? -rawY : rawY,
+          width: safeGetState(r, 'Width'),
+          height: safeGetState(r, 'Height'),
+          rotation: safeGetState(r, 'Rotation'),
+        };
+      });
       return { total: items.length, items };
     }
     case 'schematic.deletePrimitive':
@@ -2476,6 +2489,64 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
             ...property,
           };
           return schTextClass.modify(primitiveId, merged);
+        }
+      }
+
+      // Circle/Polygon had the same fall-through-to-wrong-handler gap as Text
+      // above. Field names mirror their respective create() argument order
+      // (schematic.addCircle/addPolygon), which was itself recovered by
+      // reading .modify()'s minified source via .toString() — see the
+      // comments on those create() cases.
+      const schCircleClass = readFirstPath<any>(['SCH_PrimitiveCircle', 'sch_PrimitiveCircle']);
+      if (
+        schCircleClass &&
+        typeof schCircleClass.get === 'function' &&
+        typeof schCircleClass.modify === 'function'
+      ) {
+        let current: unknown;
+        try {
+          current = await schCircleClass.get(primitiveId);
+        } catch (e) {
+          logRecoverableError(`SCH_PrimitiveCircle.get(${primitiveId}) failed`, e);
+        }
+        if (current) {
+          const merged: Record<string, unknown> = {
+            centerX: safeGetState(current, 'CenterX'),
+            centerY: safeGetState(current, 'CenterY'),
+            radius: safeGetState(current, 'Radius'),
+            color: safeGetState(current, 'Color'),
+            fillColor: safeGetState(current, 'FillColor'),
+            lineWidth: safeGetState(current, 'LineWidth'),
+            lineType: safeGetState(current, 'LineType'),
+            fillStyle: safeGetState(current, 'FillStyle'),
+            ...property,
+          };
+          return schCircleClass.modify(primitiveId, merged);
+        }
+      }
+
+      const schPolygonClass = readFirstPath<any>(['SCH_PrimitivePolygon', 'sch_PrimitivePolygon']);
+      if (
+        schPolygonClass &&
+        typeof schPolygonClass.get === 'function' &&
+        typeof schPolygonClass.modify === 'function'
+      ) {
+        let current: unknown;
+        try {
+          current = await schPolygonClass.get(primitiveId);
+        } catch (e) {
+          logRecoverableError(`SCH_PrimitivePolygon.get(${primitiveId}) failed`, e);
+        }
+        if (current) {
+          const merged: Record<string, unknown> = {
+            line: safeGetState(current, 'Line'),
+            color: safeGetState(current, 'Color'),
+            fillColor: safeGetState(current, 'FillColor'),
+            lineWidth: safeGetState(current, 'LineWidth'),
+            lineType: safeGetState(current, 'LineType'),
+            ...property,
+          };
+          return schPolygonClass.modify(primitiveId, merged);
         }
       }
 

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -835,13 +835,69 @@ describe('createDispatcher', () => {
     });
   });
 
+  describe('schematic.modifyPrimitive on circle/polygon primitives', () => {
+    it('snapshots and merges a circle primitive instead of falling through to the wrong handler', async () => {
+      const circleModify = vi.fn(async () => true);
+      const circleGet = vi.fn(async () => ({
+        getState_CenterX: () => 300,
+        getState_CenterY: () => 700,
+        getState_Radius: () => 50,
+        getState_Color: () => '#000000',
+        getState_FillColor: () => 'none',
+        getState_LineWidth: () => 1,
+        getState_LineType: () => 0,
+        getState_FillStyle: () => 'none',
+      }));
+      const dispatcher = createDispatcher(
+        makeToolkit({ SCH_PrimitiveCircle: { get: circleGet, modify: circleModify } }),
+      );
+
+      await dispatcher.dispatch('schematic.modifyPrimitive', {
+        primitiveId: 'circle1',
+        property: { radius: 75 },
+      });
+
+      expect(circleModify).toHaveBeenCalledWith(
+        'circle1',
+        expect.objectContaining({ centerX: 300, centerY: 700, radius: 75, color: '#000000' }),
+      );
+    });
+
+    it('snapshots and merges a polygon primitive instead of falling through to the wrong handler', async () => {
+      const polygonModify = vi.fn(async () => true);
+      const polygonGet = vi.fn(async () => ({
+        getState_Line: () => [0, 0, 10, 0, 5, 10],
+        getState_Color: () => '#FF0000',
+        getState_FillColor: () => 'none',
+        getState_LineWidth: () => 1,
+        getState_LineType: () => 0,
+      }));
+      const dispatcher = createDispatcher(
+        makeToolkit({ SCH_PrimitivePolygon: { get: polygonGet, modify: polygonModify } }),
+      );
+
+      await dispatcher.dispatch('schematic.modifyPrimitive', {
+        primitiveId: 'poly1',
+        property: { color: '#00FF00' },
+      });
+
+      expect(polygonModify).toHaveBeenCalledWith(
+        'poly1',
+        expect.objectContaining({ line: [0, 0, 10, 0, 5, 10], color: '#00FF00' }),
+      );
+    });
+  });
+
   describe('schematic.listRectangles', () => {
-    it('lists rectangles with their coordinates via the live-confirmed TopLeftX/TopLeftY keys', async () => {
+    it('lists rectangles with their coordinates via the live-confirmed TopLeftX/TopLeftY keys, negating the live-verified Y sign flip', async () => {
       const getAll = vi.fn(async () => [
         {
           getState_PrimitiveId: () => 'rect1',
           getState_TopLeftX: () => 100,
-          getState_TopLeftY: () => 200,
+          // Live-verified (2026-07-09): SCH_PrimitiveRectangle reports TopLeftY
+          // sign-flipped relative to what create() was given — raw -200 here
+          // means the box was actually created at y:200.
+          getState_TopLeftY: () => -200,
           getState_Width: () => 300,
           getState_Height: () => 150,
           getState_Rotation: () => 0,
@@ -857,12 +913,12 @@ describe('createDispatcher', () => {
       });
     });
 
-    it('falls back to X/Y if TopLeftX/TopLeftY are not exposed', async () => {
+    it('falls back to X/Y if TopLeftX/TopLeftY are not exposed, still negating Y', async () => {
       const getAll = vi.fn(async () => [
         {
           getState_PrimitiveId: () => 'rect1',
           getState_X: () => 100,
-          getState_Y: () => 200,
+          getState_Y: () => -200,
           getState_Width: () => 300,
           getState_Height: () => 150,
           getState_Rotation: () => 0,


### PR DESCRIPTION
## Summary
Follow-up to #227 — two more issues found while investigating that PR's open questions.

- `schematic.modifyPrimitive` on `SCH_PrimitiveCircle`/`SCH_PrimitivePolygon` previously fell through to the wrong handler (the component/wire fallback), the same class of bug #227 fixed for `SCH_PrimitiveText`. Added dedicated snapshot+merge branches mirroring the Text fix.
- `schematic.listRectangles` (added in #227): live-verified that `SCH_PrimitiveRectangle` reports `TopLeftY` sign-flipped relative to what `create()` was given (`create(y: 5000)` → read back `-5000`), while `SCH_PrimitiveComponent` pins and `SCH_PrimitiveWire` show no such flip across multiple live checks. This meant `findOverlappingRectangles`'s overlap math (which compares against pin-derived, unflipped Y) was comparing inconsistent sign conventions. Now negates Y on the way out of the dispatcher so all callers see one consistent convention.

## Test plan
- [x] `pnpm typecheck` / `pnpm typecheck:extension`
- [x] `pnpm lint` (root, `--max-warnings 0`)
- [x] `pnpm format:check`
- [x] `pnpm test` — 1129 passing
- [x] `pnpm test:extension` — 56 passing (2 new: Circle/Polygon modify)