### PR TITLE
chore: align plugin metadata and quiet tests

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "easyeda-pro",
-  "version": "0.20.0",
+  "version": "0.24.2",
   "description": "EasyEDA MCP Pro plugin for EasyEDA Pro project workflow automation, schematic/PCB inspection, BOM and sourcing, DRC/ERC validation, and manufacturing exports.",
   "author": {
     "name": "oaslananka",

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -38,6 +38,23 @@ npm pack --dry-run
 
 The release PR and release workflow must pass the required GitHub status checks before release artifacts are considered valid.
 
+### Docker smoke check
+
+The CI `quality` job is the source of truth for Docker release readiness. It builds the Docker image, starts the container, and checks `/healthz` before the release is considered valid.
+
+Maintainers with Docker installed can repeat the same smoke locally:
+
+```bash
+docker build -t easyeda-mcp-pro:release-smoke .
+cid=$(docker run -d easyeda-mcp-pro:release-smoke)
+trap 'docker rm -f "$cid" >/dev/null 2>&1 || true' EXIT
+sleep 3
+docker logs "$cid"
+docker exec "$cid" node -e "const r = await fetch('http://127.0.0.1:3000/healthz'); if (!r.ok) process.exit(1); console.log(await r.text());"
+```
+
+If the maintainer workstation or VPS does not have Docker installed, record that the local Docker smoke was skipped and link to the passing CI `quality` job. Do not treat a Docker-less local host as a release blocker when the CI Docker smoke has passed.
+
 ## User verification steps
 
 Users can verify a release by checking:

--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -241,7 +241,10 @@ async function collectPinCoordinateNets(): Promise<Map<string, string>> {
       }
     }
   } catch (e) {
-    logRecoverableError('failed to build pin coordinate map for net-collision check', e);
+    const message = e instanceof Error ? e.message : String(e);
+    if (!message.includes('SCH_PrimitiveComponent class not found')) {
+      logRecoverableError('failed to build pin coordinate map for net-collision check', e);
+    }
   }
   return coordToNet;
 }

--- a/scripts/check-metadata.mjs
+++ b/scripts/check-metadata.mjs
@@ -42,6 +42,10 @@ const extJsonPath = path.join(root, 'easyeda-bridge-extension', 'extension.json'
 const extJson = fs.existsSync(extJsonPath)
   ? JSON.parse(fs.readFileSync(extJsonPath, 'utf8'))
   : null;
+const claudePluginJsonPath = path.join(root, '.claude-plugin', 'plugin.json');
+const claudePluginJson = fs.existsSync(claudePluginJsonPath)
+  ? JSON.parse(fs.readFileSync(claudePluginJsonPath, 'utf8'))
+  : null;
 const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
 
 // ── 2. Version consistency ──────────────────────────────────────────────────
@@ -78,6 +82,15 @@ if (extJson) {
   if (extJson.version !== expectedVersion) {
     error(
       `easyeda-bridge-extension/extension.json version "${extJson.version}" !== package.json "${expectedVersion}"`,
+    );
+  }
+}
+
+// .claude-plugin/plugin.json version (if present)
+if (claudePluginJson) {
+  if (claudePluginJson.version !== expectedVersion) {
+    error(
+      `.claude-plugin/plugin.json version "${claudePluginJson.version}" !== package.json "${expectedVersion}"`,
     );
   }
 }

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -38,7 +38,16 @@ if (fs.existsSync(extensionJsonPath)) {
   console.log(`- Synced: ${extensionJsonPath}`);
 }
 
-// 4. Update server.json
+// 4. Update .claude-plugin/plugin.json
+const claudePluginJsonPath = path.join(root, '.claude-plugin', 'plugin.json');
+if (fs.existsSync(claudePluginJsonPath)) {
+  const pluginJson = JSON.parse(fs.readFileSync(claudePluginJsonPath, 'utf8'));
+  pluginJson.version = version;
+  fs.writeFileSync(claudePluginJsonPath, JSON.stringify(pluginJson, null, 2) + '\n');
+  console.log(`- Synced: ${claudePluginJsonPath}`);
+}
+
+// 5. Update server.json
 const serverJsonPath = path.join(root, 'server.json');
 if (fs.existsSync(serverJsonPath)) {
   const serverJson = JSON.parse(fs.readFileSync(serverJsonPath, 'utf8'));
@@ -50,9 +59,11 @@ if (fs.existsSync(serverJsonPath)) {
   console.log(`- Synced: ${serverJsonPath}`);
 }
 
-// 5. Format all synced files with Prettier to ensure consistent style
+// 6. Format all synced files with Prettier to ensure consistent style
 try {
-  const prettierFiles = [extensionJsonPath, serverJsonPath].filter((f) => fs.existsSync(f));
+  const prettierFiles = [extensionJsonPath, serverJsonPath, claudePluginJsonPath].filter((f) =>
+    fs.existsSync(f),
+  );
   if (prettierFiles.length > 0) {
     execFileSync('npx', ['prettier', '--write', ...prettierFiles], {
       cwd: root,

--- a/tests/unit/vendors/base-http-client.test.ts
+++ b/tests/unit/vendors/base-http-client.test.ts
@@ -23,6 +23,10 @@ const logger = {
   info: vi.fn(),
 } as any;
 
+function okResponse() {
+  return { statusCode: 200, body: Readable.from(['{}']) };
+}
+
 describe('base http client observability', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -30,10 +34,7 @@ describe('base http client observability', () => {
   });
 
   it('records vendor request timing on success', async () => {
-    requestMock.mockResolvedValueOnce({
-      statusCode: 200,
-      body: Readable.from(['{}']),
-    });
+    requestMock.mockResolvedValueOnce(okResponse());
 
     const result = await httpRequestWithRetry('https://vendor.example/api', {}, logger, 0);
     const snapshot = getGlobalMetricsCollector().snapshot();
@@ -72,7 +73,7 @@ describe('vendor rate limiting', () => {
   });
 
   it('does not delay requests when rate limiting is disabled (default)', async () => {
-    requestMock.mockResolvedValue({ statusCode: 200, body: Readable.from(['{}']) });
+    requestMock.mockImplementation(() => Promise.resolve(okResponse()));
 
     const start = Date.now();
     await httpRequestWithRetry('https://vendor.example/a', {}, logger, 0);
@@ -84,7 +85,7 @@ describe('vendor rate limiting', () => {
     vi.useFakeTimers();
     try {
       configureVendorRateLimit(200);
-      requestMock.mockResolvedValue({ statusCode: 200, body: Readable.from(['{}']) });
+      requestMock.mockImplementation(() => Promise.resolve(okResponse()));
 
       const first = httpRequestWithRetry('https://vendor.example/a', {}, logger, 0);
       await vi.runAllTimersAsync();
@@ -112,7 +113,7 @@ describe('vendor rate limiting', () => {
     vi.useFakeTimers();
     try {
       configureVendorRateLimit(5000);
-      requestMock.mockResolvedValue({ statusCode: 200, body: Readable.from(['{}']) });
+      requestMock.mockImplementation(() => Promise.resolve(okResponse()));
 
       await httpRequestWithRetry('https://vendor-a.example/x', {}, logger, 0);
       const second = httpRequestWithRetry('https://vendor-b.example/y', {}, logger, 0);

--- a/tests/unit/vendors/lcsc.test.ts
+++ b/tests/unit/vendors/lcsc.test.ts
@@ -301,7 +301,7 @@ describe('LcscClient', () => {
     it('rethrows when jlcsearch fails and no LCSC_API_KEY is configured', async () => {
       vi.useFakeTimers();
       try {
-        requestMock.mockResolvedValue(textResponse(500, 'boom'));
+        requestMock.mockImplementation(() => Promise.resolve(textResponse(500, 'boom')));
 
         const client = new LcscClient(createTestConfig());
         const pending = client.searchParts('capacitor');
@@ -355,7 +355,7 @@ describe('LcscClient', () => {
     });
 
     it('throws when jlcsearch is entirely unreachable and no LCSC_API_KEY is configured', async () => {
-      requestMock.mockResolvedValue(textResponse(500, 'boom'));
+      requestMock.mockImplementation(() => Promise.resolve(textResponse(500, 'boom')));
 
       const client = new LcscClient(createTestConfig());
       await expect(client.getPartDetail('C1')).rejects.toMatchObject({
@@ -389,7 +389,7 @@ describe('LcscClient', () => {
     });
 
     it('throws when the LCSC official API returns a non-2xx status for a non-numeric code', async () => {
-      requestMock.mockResolvedValue(textResponse(503, 'unavailable'));
+      requestMock.mockImplementation(() => Promise.resolve(textResponse(503, 'unavailable')));
 
       const client = new LcscClient(createTestConfigWithApiKey());
       await expect(client.getPartDetail('not-a-numeric-code')).rejects.toMatchObject({


### PR DESCRIPTION
## Summary

- include `.claude-plugin/plugin.json` in version sync and metadata checks
- align plugin metadata to the package/server version
- stop vendor HTTP tests from reusing one `Readable` body across repeated mocked responses
- keep the expected EasyEDA runtime-class-missing path from logging noisy fallback errors in extension tests
- document how to handle Docker smoke verification when Docker is unavailable locally but CI Docker smoke has passed

## Local verification

- `pnpm audit --audit-level low`
- `pnpm peers check`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm typecheck:extension`
- `pnpm lint`
- `pnpm lint:tools`
- `pnpm verify:tool-coverage`
- `NODE_OPTIONS='--trace-warnings' pnpm test` — 94 files / 1129 tests, no `MaxListenersExceededWarning`
- `pnpm test:extension` — 3 files / 56 tests, no expected net-collision fallback stderr log
- `pnpm build`
- `pnpm build:extension`
- `pnpm verify:extension`
- `pnpm check:metadata`
- `pnpm docs:build`

Note: `pnpm docs:build` still emits the pre-existing VitePress `env` syntax-highlighter fallback warnings; this PR does not change those docs blocks.