### PR TITLE
feat(extension): harden Remote Relay reconnects

### DIFF
--- a/docs/EXTENSION_RELAY_PROTOCOL.md
+++ b/docs/EXTENSION_RELAY_PROTOCOL.md
@@ -5,8 +5,9 @@
 tested. `RemoteRelayClient` genuinely connects and can execute real EasyEDA API calls
 when driven directly. What is missing is upstream of this protocol: no real MCP tool
 call (`/mcp`) currently produces a `tool_request` on this relay — see
-`docs/REMOTE_RELEASE_READINESS.md` for the tracked gap. `RemoteRelayClient` also has no
-reconnect/backoff logic yet, unlike the local bridge connection in the same file.
+`docs/REMOTE_RELEASE_READINESS.md` for the tracked gap. `RemoteRelayClient` now includes
+client-side reconnect/backoff, heartbeat liveness tracking, and status diagnostics, but
+that resilience only helps once a relay URL is actually driving the extension.
 
 The relay protocol carries authenticated gateway requests to an opted-in EasyEDA bridge extension session. The extension uses an outbound connection and does not expose a local listener to the public internet.
 

--- a/easyeda-bridge-extension/src/index.ts
+++ b/easyeda-bridge-extension/src/index.ts
@@ -569,7 +569,18 @@ function disconnectRemoteRelay(): void {
 function showRemoteRelayStatus(): void {
   const status = getRemoteRelayClient().getStatus();
   const project = status.activeProject?.projectName ?? 'no active project detected';
-  showToast(`Remote Relay: ${status.mode}/${status.state} | project: ${project}`);
+  const retry =
+    status.nextReconnectDelayMs !== undefined
+      ? ` | retry: ${Math.ceil(status.nextReconnectDelayMs / 1000)}s`
+      : '';
+  const attempts =
+    status.reconnectAttempts && status.reconnectAttempts > 0
+      ? ` | attempts: ${status.reconnectAttempts}`
+      : '';
+  const error = status.lastError ? ` | last error: ${status.lastError}` : '';
+  showToast(
+    `Remote Relay: ${status.mode}/${status.state} | project: ${project}${attempts}${retry}${error}`,
+  );
 }
 
 // ── Socket lifecycle ─────────────────────────────────────────────────────────

--- a/easyeda-bridge-extension/src/remote-client.ts
+++ b/easyeda-bridge-extension/src/remote-client.ts
@@ -16,6 +16,10 @@ export interface RemoteRelayStatus {
   pairingCode?: string;
   activeProject?: RemoteActiveProject;
   lastError?: string;
+  lastConnectedAt?: string;
+  lastHeartbeatAt?: string;
+  reconnectAttempts?: number;
+  nextReconnectDelayMs?: number;
 }
 
 interface RemoteRelayClientOptions {
@@ -24,6 +28,12 @@ interface RemoteRelayClientOptions {
   showToast: (message: string) => void;
   readActiveProject: () => RemoteActiveProject | undefined;
   executeToolRequest?: (toolName: string, input: unknown) => Promise<unknown>;
+}
+
+interface RemoteRelayConnectInput {
+  mode: Exclude<RemoteRelayMode, 'disabled'>;
+  relayUrl?: string;
+  pairingCode?: string;
 }
 
 interface RemoteEnvelope {
@@ -37,6 +47,10 @@ interface RemoteEnvelope {
 
 const PROTOCOL_VERSION = '2026-07-remote-relay-v1';
 const DEFAULT_HOSTED_RELAY_URL = 'wss://relay.easyeda-mcp-pro.local/session';
+const RECONNECT_BASE_MS = 1_000;
+const RECONNECT_MAX_MS = 30_000;
+const HEARTBEAT_LIVENESS_MS = 45_000;
+const HEARTBEAT_SWEEP_MS = 15_000;
 
 function makeMessageId(): string {
   if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID();
@@ -64,51 +78,56 @@ function errorToRelayError(error: unknown): { code: string; message: string; sug
   };
 }
 
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
 export class RemoteRelayClient {
   private socket: WebSocket | null = null;
   private status: RemoteRelayStatus = { mode: 'disabled', state: 'disconnected' };
+  private desiredConnection: RemoteRelayConnectInput | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
   constructor(private readonly options: RemoteRelayClientOptions) {}
 
-  connect(input: {
-    mode: Exclude<RemoteRelayMode, 'disabled'>;
-    relayUrl?: string;
-    pairingCode?: string;
-  }): void {
+  connect(input: RemoteRelayConnectInput): void {
     this.disconnect('replaced');
     const relayUrl = input.relayUrl ?? DEFAULT_HOSTED_RELAY_URL;
+    this.desiredConnection = { ...input, relayUrl };
     this.status = {
       mode: input.mode,
       state: 'connecting',
       relayUrl,
       pairingCode: input.pairingCode,
       activeProject: this.options.readActiveProject(),
+      reconnectAttempts: 0,
     };
     this.options.showToast(`Remote Relay connecting: ${input.mode}`);
-
-    try {
-      const socket = new WebSocket(relayUrl);
-      this.socket = socket;
-      socket.onopen = () => this.handleOpen(input.pairingCode);
-      socket.onmessage = (event) => this.handleMessage(event.data);
-      socket.onerror = () => this.handleError('Remote Relay socket error');
-      socket.onclose = () => this.handleClose();
-    } catch (error) {
-      this.handleError(`Remote Relay failed to start: ${String(error)}`);
-    }
+    this.openSocket(this.desiredConnection);
   }
 
   disconnect(reason: 'user_disabled' | 'replaced' | 'disconnected' = 'user_disabled'): void {
-    if (this.socket) {
+    this.desiredConnection = null;
+    this.clearReconnectTimer();
+    this.clearHeartbeatTimer();
+
+    const socket = this.socket;
+    this.socket = null;
+    if (socket) {
       try {
-        this.send({ type: 'session_closed', reason });
-        this.socket.close();
+        this.sendOnSocket(socket, { type: 'session_closed', reason });
+        socket.close();
       } catch (error) {
         this.options.log('Remote Relay close failed', error);
       }
     }
-    this.socket = null;
-    this.status = { ...this.status, state: 'disconnected', sessionId: undefined };
+    this.status = {
+      ...this.status,
+      state: 'disconnected',
+      sessionId: undefined,
+      nextReconnectDelayMs: undefined,
+    };
   }
 
   getStatus(): RemoteRelayStatus {
@@ -118,8 +137,35 @@ export class RemoteRelayClient {
     };
   }
 
-  private handleOpen(pairingCode?: string): void {
-    this.status = { ...this.status, state: pairingCode ? 'paired' : 'connected' };
+  private openSocket(input: RemoteRelayConnectInput): void {
+    if (!input.relayUrl) return;
+    this.clearReconnectTimer();
+
+    try {
+      const socket = new WebSocket(input.relayUrl);
+      this.socket = socket;
+      socket.onopen = () => this.handleOpen(socket, input.pairingCode);
+      socket.onmessage = (event) => this.handleMessage(socket, event.data);
+      socket.onerror = () => this.handleSocketError(socket, 'Remote Relay socket error');
+      socket.onclose = () => this.handleClose(socket);
+    } catch (error) {
+      this.socket = null;
+      this.scheduleReconnect(`Remote Relay failed to start: ${String(error)}`);
+    }
+  }
+
+  private handleOpen(socket: WebSocket, pairingCode?: string): void {
+    if (socket !== this.socket) return;
+    const timestamp = nowIso();
+    this.status = {
+      ...this.status,
+      state: pairingCode ? 'paired' : 'connected',
+      lastConnectedAt: timestamp,
+      lastHeartbeatAt: timestamp,
+      nextReconnectDelayMs: undefined,
+      lastError: undefined,
+    };
+    this.startHeartbeatTimer();
     this.send({
       type: 'register_session',
       extensionVersion: this.options.extensionVersion,
@@ -133,7 +179,8 @@ export class RemoteRelayClient {
     );
   }
 
-  private handleMessage(data: unknown): void {
+  private handleMessage(socket: WebSocket, data: unknown): void {
+    if (socket !== this.socket) return;
     const text = typeof data === 'string' ? data : '';
     let message: RemoteEnvelope | undefined;
     try {
@@ -160,6 +207,7 @@ export class RemoteRelayClient {
       return;
     }
     if (message.type === 'heartbeat') {
+      this.status = { ...this.status, lastHeartbeatAt: nowIso() };
       this.send({ type: 'heartbeat' });
       return;
     }
@@ -226,22 +274,88 @@ export class RemoteRelayClient {
     }
   }
 
-  private handleError(message: string): void {
-    this.status = { ...this.status, state: 'disconnected', lastError: message };
+  private handleSocketError(socket: WebSocket, message: string): void {
+    if (socket !== this.socket) return;
+    this.status = { ...this.status, lastError: message };
     this.options.log(message);
-    this.options.showToast(message);
   }
 
-  private handleClose(): void {
+  private handleClose(socket: WebSocket): void {
+    if (socket !== this.socket) return;
     this.socket = null;
-    if (this.status.state !== 'disconnected') {
-      this.status = { ...this.status, state: 'disconnected' };
-      this.options.showToast('Remote Relay disconnected');
+    this.clearHeartbeatTimer();
+    if (!this.desiredConnection) {
+      if (this.status.state !== 'disconnected') {
+        this.status = { ...this.status, state: 'disconnected', sessionId: undefined };
+        this.options.showToast('Remote Relay disconnected');
+      }
+      return;
+    }
+    this.scheduleReconnect('Remote Relay disconnected');
+  }
+
+  private scheduleReconnect(message: string): void {
+    const desired = this.desiredConnection;
+    if (!desired) return;
+    this.clearHeartbeatTimer();
+    this.clearReconnectTimer();
+    const nextAttempt = (this.status.reconnectAttempts ?? 0) + 1;
+    const delay = Math.min(RECONNECT_BASE_MS * 2 ** (nextAttempt - 1), RECONNECT_MAX_MS);
+    this.status = {
+      ...this.status,
+      state: 'connecting',
+      sessionId: undefined,
+      lastError: message,
+      reconnectAttempts: nextAttempt,
+      nextReconnectDelayMs: delay,
+    };
+    this.options.log('Remote Relay reconnect scheduled', { attempt: nextAttempt, delayMs: delay });
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null;
+      if (this.desiredConnection) this.openSocket(desired);
+    }, delay);
+  }
+
+  private startHeartbeatTimer(): void {
+    this.clearHeartbeatTimer();
+    this.heartbeatTimer = setInterval(() => this.checkHeartbeatLiveness(), HEARTBEAT_SWEEP_MS);
+  }
+
+  private checkHeartbeatLiveness(): void {
+    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+    const lastHeartbeat = this.status.lastHeartbeatAt
+      ? Date.parse(this.status.lastHeartbeatAt)
+      : undefined;
+    if (lastHeartbeat === undefined || Number.isNaN(lastHeartbeat)) return;
+    if (Date.now() - lastHeartbeat <= HEARTBEAT_LIVENESS_MS) return;
+    this.options.log('Remote Relay heartbeat stale; closing socket to reconnect');
+    try {
+      this.socket.close();
+    } catch (error) {
+      this.options.log('Remote Relay stale socket close failed', error);
+      this.scheduleReconnect('Remote Relay heartbeat stale');
     }
   }
 
+  private clearReconnectTimer(): void {
+    if (!this.reconnectTimer) return;
+    clearTimeout(this.reconnectTimer);
+    this.reconnectTimer = null;
+  }
+
+  private clearHeartbeatTimer(): void {
+    if (!this.heartbeatTimer) return;
+    clearInterval(this.heartbeatTimer);
+    this.heartbeatTimer = null;
+  }
+
   private send(payload: Record<string, unknown>): void {
-    if (!this.socket || this.socket.readyState !== WebSocket.OPEN) return;
+    if (!this.socket) return;
+    this.sendOnSocket(this.socket, payload);
+  }
+
+  private sendOnSocket(socket: WebSocket, payload: Record<string, unknown>): void {
+    if (socket.readyState !== WebSocket.OPEN) return;
     const envelope = {
       protocolVersion: PROTOCOL_VERSION,
       messageId: makeMessageId(),
@@ -249,6 +363,6 @@ export class RemoteRelayClient {
       timestamp: new Date().toISOString(),
       ...payload,
     } as RemoteEnvelope;
-    this.socket.send(JSON.stringify(envelope));
+    socket.send(JSON.stringify(envelope));
   }
 }

--- a/easyeda-bridge-extension/tests/remote-client.test.ts
+++ b/easyeda-bridge-extension/tests/remote-client.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RemoteRelayClient } from '../src/remote-client.js';
+
+const OPEN = 1;
+const CLOSED = 3;
+
+type Listener = (() => void) | ((event: { data: unknown }) => void);
+
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  static OPEN = OPEN;
+  static CLOSED = CLOSED;
+
+  readonly sent: string[] = [];
+  readyState = 0;
+  onopen: Listener | null = null;
+  onmessage: Listener | null = null;
+  onerror: Listener | null = null;
+  onclose: Listener | null = null;
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  open(): void {
+    this.readyState = OPEN;
+    this.onopen?.();
+  }
+
+  receive(payload: Record<string, unknown>): void {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+
+  fail(): void {
+    this.onerror?.();
+  }
+
+  close(): void {
+    this.readyState = CLOSED;
+    this.onclose?.();
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+}
+
+function makeClient() {
+  const log = vi.fn();
+  const showToast = vi.fn();
+  const executeToolRequest = vi.fn(async () => ({ ok: true }));
+  const client = new RemoteRelayClient({
+    extensionVersion: '0.24.2',
+    log,
+    showToast,
+    readActiveProject: () => ({ projectName: 'Fixture', documentType: 'schematic' }),
+    executeToolRequest,
+  });
+  return { client, log, showToast, executeToolRequest };
+}
+
+function relayMessage(type: string, extra: Record<string, unknown> = {}) {
+  return {
+    protocolVersion: '2026-07-remote-relay-v1',
+    messageId: `msg_${type}`,
+    timestamp: new Date().toISOString(),
+    type,
+    ...extra,
+  };
+}
+
+describe('RemoteRelayClient resilience', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('schedules and performs reconnect after a transient close', async () => {
+    const { client } = makeClient();
+
+    client.connect({ mode: 'self_hosted', relayUrl: 'wss://relay.example/session' });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    FakeWebSocket.instances[0].open();
+
+    FakeWebSocket.instances[0].close();
+
+    expect(client.getStatus()).toMatchObject({
+      state: 'connecting',
+      reconnectAttempts: 1,
+      nextReconnectDelayMs: 1000,
+      lastError: 'Remote Relay disconnected',
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    expect(FakeWebSocket.instances[1].url).toBe('wss://relay.example/session');
+  });
+
+  it('does not reconnect after explicit user disconnect', async () => {
+    const { client } = makeClient();
+
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    FakeWebSocket.instances[0].open();
+    client.disconnect('user_disabled');
+
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(client.getStatus()).toMatchObject({ state: 'disconnected', sessionId: undefined });
+  });
+
+  it('updates heartbeat liveness and echoes heartbeat messages', () => {
+    const { client } = makeClient();
+
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+    socket.receive(relayMessage('heartbeat'));
+
+    expect(client.getStatus().lastHeartbeatAt).toBeDefined();
+    const sentTypes = socket.sent.map((data) => JSON.parse(data).type);
+    expect(sentTypes).toContain('register_session');
+    expect(sentTypes).toContain('heartbeat');
+  });
+
+  it('closes stale heartbeat sockets so the normal close path reconnects', async () => {
+    const { client, log } = makeClient();
+
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+
+    await vi.advanceTimersByTimeAsync(60_001);
+
+    expect(socket.readyState).toBe(CLOSED);
+    expect(client.getStatus()).toMatchObject({
+      state: 'connecting',
+      reconnectAttempts: 1,
+      nextReconnectDelayMs: 1000,
+    });
+    expect(log).toHaveBeenCalledWith('Remote Relay heartbeat stale; closing socket to reconnect');
+  });
+
+  it('records the paired session id from the relay registration response', () => {
+    const { client } = makeClient();
+
+    client.connect({
+      mode: 'hosted',
+      relayUrl: 'wss://relay.example/session',
+      pairingCode: '123456',
+    });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+    socket.receive(relayMessage('session_registered', { paired: true, sessionId: 'sess_1' }));
+
+    expect(client.getStatus()).toMatchObject({
+      state: 'paired',
+      sessionId: 'sess_1',
+      pairingCode: '123456',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #233.

- add bounded exponential reconnect/backoff for `RemoteRelayClient`
- track last connected time, last heartbeat time, reconnect attempts, retry delay, and last error in relay status
- add heartbeat liveness detection that closes stale sockets and re-enters the normal reconnect path
- make explicit user disconnect/replaced connection paths cancel reconnect timers
- expand `showRemoteRelayStatus()` with useful diagnostics
- update relay protocol docs to reflect that extension-side reconnect/backoff now exists while real `/mcp -> relay` routing remains tracked separately in #234

## Verification

- `pnpm format:check`
- `pnpm typecheck:extension`
- `pnpm test:extension` — 4 files / 61 tests
- `pnpm build:extension`
- `pnpm verify:extension`
- `pnpm docs:build`

Note: `pnpm docs:build` still emits the pre-existing VitePress `env` syntax-highlighter fallback warnings; build succeeds.