### PR TITLE
fix(vendors): use locale-aware cache key sorting

### DIFF
--- a/src/vendors/cache.ts
+++ b/src/vendors/cache.ts
@@ -29,7 +29,7 @@ export function cacheKey(parts: Array<string | number | Record<string, unknown>>
 }
 
 function stableStringify(obj: Record<string, unknown>): string {
-  const sortedKeys = Object.keys(obj).sort();
+  const sortedKeys = Object.keys(obj).sort((a, b) => a.localeCompare(b, 'en'));
   const sorted: Record<string, unknown> = {};
   for (const key of sortedKeys) sorted[key] = obj[key];
   return JSON.stringify(sorted);


### PR DESCRIPTION
## Summary

- fix Sonar `typescript:S2871` by replacing bare `Array.prototype.sort()` with a `String.localeCompare` comparator in `stableStringify()`
- keep vendor cache key generation deterministic while satisfying locale-aware alphabetical sorting guidance

## Verification

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test -- tests/unit/vendors/cache.test.ts` — root suite completed successfully: 94 files / 1129 tests