### PR TITLE
feat(remote): add MCP relay backend foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@ TOOL_PROFILE=core
 # Optional comma/space separated allowlist, e.g. schematic:read,bom:read
 TOOL_SCOPES=
 MCP_PROTOCOL_VERSION=2025-11-25
+# local_bridge keeps the existing localhost extension bridge. remote_relay routes bridge calls through a paired Remote Relay session.
+MCP_BRIDGE_BACKEND=local_bridge
+# Optional fixed Remote Relay session id for remote_relay backend; otherwise use remoteSessionId per request.
+MCP_REMOTE_SESSION_ID=
 
 # ── Transport ──────────────────────────────────────────────
 TRANSPORT=stdio

--- a/README.md
+++ b/README.md
@@ -436,14 +436,16 @@ Copy `.env.example` to `.env` and edit. All variables have safe defaults — onl
 
 ### Essential
 
-| Variable               | Default       | Description                                                                  |
-| ---------------------- | ------------- | ---------------------------------------------------------------------------- |
-| `NODE_ENV`             | `development` | Set to `production` in production                                            |
-| `LOG_LEVEL`            | `info`        | Pino log level: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `silent` |
-| `TOOL_PROFILE`         | `core`        | Tool set: `core`, `pro`, `full`, `dev`, `experimental`                       |
-| `TOOL_SCOPES`          | empty         | Optional capability allowlist such as `schematic:read,bom:read`              |
-| `MCP_PROTOCOL_VERSION` | `2025-11-25`  | MCP protocol version string                                                  |
-| `TRANSPORT`            | `stdio`       | Server transport: `stdio` (default) or `http`                                |
+| Variable                | Default        | Description                                                                  |
+| ----------------------- | -------------- | ---------------------------------------------------------------------------- |
+| `NODE_ENV`              | `development`  | Set to `production` in production                                            |
+| `LOG_LEVEL`             | `info`         | Pino log level: `trace`, `debug`, `info`, `warn`, `error`, `fatal`, `silent` |
+| `TOOL_PROFILE`          | `core`         | Tool set: `core`, `pro`, `full`, `dev`, `experimental`                       |
+| `TOOL_SCOPES`           | empty          | Optional capability allowlist such as `schematic:read,bom:read`              |
+| `MCP_PROTOCOL_VERSION`  | `2025-11-25`   | MCP protocol version string                                                  |
+| `MCP_BRIDGE_BACKEND`    | `local_bridge` | Bridge backend: `local_bridge` or experimental `remote_relay`                |
+| `MCP_REMOTE_SESSION_ID` | empty          | Optional fixed Remote Relay session id for `remote_relay` backend            |
+| `TRANSPORT`             | `stdio`        | Server transport: `stdio` (default) or `http`                                |
 
 ### Bridge (EasyEDA Pro connection)
 

--- a/docs/REMOTE_RELEASE_READINESS.md
+++ b/docs/REMOTE_RELEASE_READINESS.md
@@ -11,34 +11,38 @@ Use the following status terms consistently.
 - **Beta**: users can test it with documented limits.
 - **Production-ready**: CI, validation, security review, and runbooks are complete.
 
-## Current status: Planned (pairing/relay/approval routing is not wired to real tool calls)
+## Current status: Experimental foundation (explicit `MCP_BRIDGE_BACKEND=remote_relay` flag)
 
 As of this writing, the pairing/session-router/approval-policy/relay subsystem in
 `src/remote/` (`RemoteGateway`, `RemoteSessionRouter`, `ApprovalStore`) is implemented and
 unit/HTTP-tested in isolation, and its REST/WebSocket surface (`/remote/pairing-codes`,
 `/remote/pairings`, `/remote/tool-requests`, `/remote/audit`, `/remote/relay`) is mounted
-and reachable whenever `TRANSPORT=http` — no separate flag gates it. However, **no code
-path routes an actual MCP tool call (`POST /mcp`) through this subsystem.** Every real
-tool invocation, on every transport, always dispatches through the local-loopback
-`BridgeManager` WebSocket to whatever EasyEDA bridge extension is connected on the same
-host. This means:
+and reachable whenever `TRANSPORT=http` — no separate flag gates it.
 
-- A user can pair an extension session, create pairing codes, and drive
-  `RemoteGateway.routeToolRequest()` directly against the `/remote/*` REST surface, but
-  that has no effect on and no connection to what any MCP client sees when it calls a
-  real tool via `/mcp`.
+The MCP tool path now has an explicit backend selector. With the default
+`MCP_BRIDGE_BACKEND=local_bridge`, every real tool invocation keeps using the existing
+local-loopback `BridgeManager` WebSocket. With `MCP_BRIDGE_BACKEND=remote_relay`, the
+ToolRegistry creates a per-request bridge context that routes `ctx.bridge.call(...)`
+through `RemoteGateway.routeToolRequest(...)`, preserving the existing tool handlers
+without rewriting every tool. This is an integration foundation, not beta-ready remote
+support yet. This means:
+
+- A read-only tool whose handler calls `ctx.bridge.call(...)` can route through a paired
+  Remote Relay session when the MCP request carries a remote identity and either
+  `remoteSessionId` or `MCP_REMOTE_SESSION_ID` identifies the session.
+- Write/export calls can pass `remoteApprovalId` into the gateway and fail closed if the
+  approval is absent, rejected, expired, or mismatched.
 - The extension's `RemoteRelayClient` (Remote Relay Mode) genuinely connects to a relay
-  URL and can execute real EasyEDA API calls when driven directly, but nothing on the
-  server side feeds it MCP tool calls from `/mcp`.
-- There is also no name mapping between the MCP tool ids used elsewhere in this repo
-  (e.g. `easyeda_pcb_place_component`) and the extension's internal dispatch method ids
-  (e.g. `schematic.placeComponent`) — a prerequisite for the two paths to ever line up.
+  URL, includes reconnect/backoff and heartbeat liveness, and can execute real EasyEDA
+  API calls when driven directly.
+- Remaining gap: production identity propagation, UX/session selection, approval request
+  creation from MCP clients, and live EasyEDA relay dogfood still need end-to-end
+  validation before this should be described as Beta.
 
 Given the status vocabulary above, the pairing/relay/approval-routing feature described
 in `REMOTE_GATEWAY_DESIGN.md`, `SELF_HOSTED_REMOTE_MCP.md`'s "Planned relay controls",
-`docs/CLAUDE_WEB_CONNECTOR.md`, and `docs/CHATGPT_APP_INTEGRATION.md` is **Planned**, not
-Experimental or Beta — closing this gap requires an explicit architecture decision (how
-tool execution selects a backend per deployment mode) before further code is written.
+`docs/CLAUDE_WEB_CONNECTOR.md`, and `docs/CHATGPT_APP_INTEGRATION.md` is **Experimental**
+behind explicit configuration, not Beta.
 
 **What already works today without this subsystem:** OAuth-protected HTTP transport
 (`TRANSPORT=http`, `OAUTH_ENABLED=true`) reachable through a tunnel/reverse proxy is

--- a/server.json
+++ b/server.json
@@ -41,6 +41,18 @@
           "default": "2025-11-25"
         },
         {
+          "name": "MCP_BRIDGE_BACKEND",
+          "description": "Bridge backend: local_bridge or experimental remote_relay",
+          "isRequired": false,
+          "default": "local_bridge"
+        },
+        {
+          "name": "MCP_REMOTE_SESSION_ID",
+          "description": "Optional fixed Remote Relay session id for the remote_relay backend",
+          "isRequired": false,
+          "default": ""
+        },
+        {
           "name": "TRANSPORT",
           "description": "Server transport mode (stdio or http)",
           "isRequired": false,

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -17,6 +17,8 @@ export const EnvSchema = z.object({
   TOOL_PROFILE: z.enum(['core', 'pro', 'full', 'dev', 'experimental']).default('core'),
   TOOL_SCOPES: z.string().default(''),
   MCP_PROTOCOL_VERSION: z.string().default('2025-11-25'),
+  MCP_BRIDGE_BACKEND: z.enum(['local_bridge', 'remote_relay']).default('local_bridge'),
+  MCP_REMOTE_SESSION_ID: z.string().default(''),
 
   TRANSPORT: z.enum(['stdio', 'http']).default('stdio'),
   HTTP_HOST: z.string().default('127.0.0.1'),

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import type { SetupOptions } from './cli/client-definitions.js';
 import { loadEnvConfig } from './config/env.js';
 import { createServer } from './server/factory.js';
 import { createHttpTransport } from './server/transports/http.js';
+import { RemoteGateway } from './remote/gateway.js';
 
 async function main() {
   const cli = parseCliArgs(process.argv.slice(2));
@@ -57,10 +58,12 @@ async function main() {
   }
 
   const config = loadEnvConfig();
-  const instance = await createServer(config);
+  const remoteGateway =
+    config.MCP_BRIDGE_BACKEND === 'remote_relay' ? new RemoteGateway() : undefined;
+  const instance = await createServer(config, { remoteGateway });
 
   if (config.TRANSPORT === 'http') {
-    const httpTransport = createHttpTransport(config);
+    const httpTransport = createHttpTransport(config, { gateway: remoteGateway });
     instance.httpTransport = httpTransport;
     instance.transport = httpTransport.transport;
     await instance.server.connect(httpTransport.transport);

--- a/src/server/factory.ts
+++ b/src/server/factory.ts
@@ -16,6 +16,7 @@ import { CdpBridgeManager } from '../bridge/cdp-manager.js';
 import { startHotSwapWatcher } from '../bridge/hotswap-watcher.js';
 import { registerBuiltinTools } from '../tools/register.js';
 import { registerProjectResourcesAndPrompts } from './resources-prompts.js';
+import { RemoteGateway } from '../remote/gateway.js';
 
 import { LcscClient } from '../vendors/lcsc/client.js';
 import { JlcpcbClient } from '../vendors/jlcpcb/client.js';
@@ -23,6 +24,10 @@ import { MouserClient } from '../vendors/mouser/client.js';
 import { DigiKeyClient } from '../vendors/digikey/client.js';
 import { createFileVendorCache } from '../vendors/cache.js';
 import { configureVendorRateLimit } from '../vendors/base-http-client.js';
+
+export interface CreateServerOptions {
+  remoteGateway?: RemoteGateway;
+}
 
 export interface McpServerInstance {
   server: McpServer;
@@ -35,9 +40,15 @@ export interface McpServerInstance {
   shutdown: () => Promise<void>;
 }
 
-export async function createServer(config: EnvConfig): Promise<McpServerInstance> {
+export async function createServer(
+  config: EnvConfig,
+  options: CreateServerOptions = {},
+): Promise<McpServerInstance> {
   const logger = createLogger(config);
   const flags = loadFeatureFlags(config);
+  const remoteGateway =
+    options.remoteGateway ??
+    (config.MCP_BRIDGE_BACKEND === 'remote_relay' ? new RemoteGateway() : undefined);
 
   logger.info(
     {
@@ -133,7 +144,11 @@ export async function createServer(config: EnvConfig): Promise<McpServerInstance
       bridgeHost: config.BRIDGE_HOST,
       bridgePort: bridge.activePort || config.BRIDGE_PORT,
       keylessSourcingEnabled: config.KEYLESS_SOURCING_ENABLED,
+      TOOL_SCOPES: config.TOOL_SCOPES,
+      MCP_BRIDGE_BACKEND: config.MCP_BRIDGE_BACKEND,
+      MCP_REMOTE_SESSION_ID: config.MCP_REMOTE_SESSION_ID,
     },
+    remote: remoteGateway ? { gateway: remoteGateway } : undefined,
     vendors: {
       lcsc: lcscClient,
       jlcpcb: jlcClient,

--- a/src/server/transports/http.ts
+++ b/src/server/transports/http.ts
@@ -3,6 +3,7 @@ import { type Express, type Request, type Response, type NextFunction } from 'ex
 import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
+import { type AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { type EnvConfig } from '../../config/env.js';
 import { SERVER_VERSION } from '../../config/version.js';
 import { getLogger } from '../../utils/logger.js';
@@ -116,6 +117,8 @@ function extractTokenScopes(payload: Record<string, unknown>): Set<string> {
   return scopes;
 }
 
+type AuthenticatedExpressRequest = Request & { auth?: AuthInfo };
+
 function validateOAuthToken(config: EnvConfig) {
   if (!config.OAUTH_ENABLED || config.HTTP_AUTH_DISABLED) {
     return (_req: Request, _res: Response, next: NextFunction): void => next();
@@ -156,8 +159,8 @@ function validateOAuthToken(config: EnvConfig) {
           return;
         }
 
+        const tokenScopes = extractTokenScopes(payload as Record<string, unknown>);
         if (requiredScopes.length > 0) {
-          const tokenScopes = extractTokenScopes(payload as Record<string, unknown>);
           const normalizedTokenScopes = new Set([...tokenScopes].map(normalizeOAuthScope));
           const missingScopes = requiredScopes.filter(
             (_scope, idx) => !normalizedTokenScopes.has(normalizedRequiredScopes[idx] ?? ''),
@@ -173,6 +176,17 @@ function validateOAuthToken(config: EnvConfig) {
           }
         }
 
+        const claims = payload as Record<string, unknown>;
+        const subject = typeof claims.sub === 'string' ? claims.sub : undefined;
+        const clientId =
+          typeof claims.client_id === 'string' ? claims.client_id : (subject ?? 'oauth-client');
+        (req as AuthenticatedExpressRequest).auth = {
+          token,
+          clientId,
+          scopes: [...tokenScopes],
+          expiresAt: typeof claims.exp === 'number' ? claims.exp : undefined,
+          extra: claims,
+        };
         res.locals.claims = payload;
         next();
       })

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -6,11 +6,14 @@ import {
   parseWriteMode,
   omitWriteControls,
   writePlanResponse,
+  type WriteMode,
 } from './transaction.js';
 import { type ToolProfile, getEnabledProfiles } from '../config/profiles.js';
 import { ZodError, type z } from 'zod';
 import { SERVER_VERSION } from '../config/version.js';
 import { getGlobalMetricsCollector, type ObservabilityCategory } from '../observability/index.js';
+import { type RemoteIdentity } from '../remote/scope.js';
+import { type RemoteRiskLevel } from '../remote/protocol.js';
 
 // ── Structured error codes ────────────────────────────────────────────────
 
@@ -22,6 +25,7 @@ export const ErrorCodes = {
   INVALID_INPUT: 'ERR_INVALID_INPUT',
   TOOL_OUTPUT_INVALID: 'ERR_TOOL_OUTPUT_INVALID',
   FORBIDDEN_SCOPE: 'ERR_FORBIDDEN_SCOPE',
+  REMOTE_RELAY: 'ERR_REMOTE_RELAY',
 } as const;
 
 export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];
@@ -167,6 +171,308 @@ function bridgeDisconnectedResponse(
   });
 }
 
+type McpHandlerExtra = {
+  authInfo?: {
+    clientId?: string;
+    scopes?: string[];
+    expiresAt?: number;
+    extra?: Record<string, unknown>;
+  };
+  requestInfo?: { headers?: unknown };
+};
+
+function readHeader(headers: unknown, name: string): string | undefined {
+  const lower = name.toLowerCase();
+  if (headers && typeof headers === 'object' && 'get' in headers) {
+    const value = (headers as { get: (key: string) => string | null | undefined }).get(name);
+    return value ?? undefined;
+  }
+  if (headers && typeof headers === 'object') {
+    const record = headers as Record<string, unknown>;
+    const value = record[name] ?? record[lower];
+    const firstValue = Array.isArray(value) ? value[0] : value;
+    if (typeof firstValue === 'string') return firstValue;
+    if (typeof firstValue === 'number' || typeof firstValue === 'boolean')
+      return String(firstValue);
+  }
+  return undefined;
+}
+
+function normalizeRemoteScope(scope: string): string {
+  return scope
+    .trim()
+    .replace(/^easyeda:/, 'easyeda.')
+    .replace('project-admin', 'project_admin');
+}
+
+function parseRemoteScopes(value: unknown): RemoteIdentity['scopes'] {
+  if (typeof value !== 'string') return [];
+  return value
+    .split(/[\s,]+/)
+    .map(normalizeRemoteScope)
+    .filter(Boolean) as RemoteIdentity['scopes'];
+}
+
+function remoteIdentityFromExtra(extra: unknown): RemoteIdentity | undefined {
+  const handlerExtra = extra as McpHandlerExtra | undefined;
+  const auth = handlerExtra?.authInfo;
+  if (auth) {
+    const claims = auth.extra ?? {};
+    let userId = auth.clientId;
+    if (typeof claims.userId === 'string') userId = claims.userId;
+    if (typeof claims.sub === 'string') userId = claims.sub;
+    if (!userId) return undefined;
+    return {
+      userId,
+      scopes: (auth.scopes ?? []).map(normalizeRemoteScope) as RemoteIdentity['scopes'],
+      expiresAt: auth.expiresAt ? new Date(auth.expiresAt * 1000) : undefined,
+    };
+  }
+
+  const headers = handlerExtra?.requestInfo?.headers;
+  const userId = readHeader(headers, 'x-remote-user-id');
+  if (!userId) return undefined;
+  const expiresAtHeader = readHeader(headers, 'x-remote-expires-at');
+  return {
+    userId,
+    scopes: parseRemoteScopes(readHeader(headers, 'x-remote-scopes') ?? 'easyeda.read'),
+    expiresAt: expiresAtHeader ? new Date(expiresAtHeader) : undefined,
+  };
+}
+
+function rawRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function remoteRiskForTool(tool: ToolDefinition): RemoteRiskLevel {
+  if (tool.name === 'easyeda_execute') return 'destructive';
+  if (tool.group === 'export') return 'export';
+  if (tool.confirmWrite || tool.risk === 'medium') return 'write';
+  if (tool.risk === 'high') return 'destructive';
+  return 'read';
+}
+
+function contextForRemoteRelay(
+  context: ToolContext,
+  tool: ToolDefinition,
+  raw: unknown,
+  extra: unknown,
+): ToolContext {
+  if (context.config.MCP_BRIDGE_BACKEND !== 'remote_relay') return context;
+  const gateway = context.remote?.gateway;
+  const controls = rawRecord(raw);
+  const configuredSessionId =
+    typeof context.config.MCP_REMOTE_SESSION_ID === 'string'
+      ? context.config.MCP_REMOTE_SESSION_ID
+      : '';
+  const sessionId =
+    typeof controls.remoteSessionId === 'string'
+      ? controls.remoteSessionId
+      : configuredSessionId || undefined;
+  const approvalId =
+    typeof controls.remoteApprovalId === 'string' ? controls.remoteApprovalId : undefined;
+  const identity = remoteIdentityFromExtra(extra);
+  const riskLevel = remoteRiskForTool(tool);
+
+  return {
+    ...context,
+    bridge: {
+      ...context.bridge,
+      get connected() {
+        return true;
+      },
+      call: async <TParams, TResult>(
+        method: string,
+        params?: TParams,
+        opts?: { timeoutMs?: number; traceparent?: string },
+      ): Promise<TResult> => {
+        if (!gateway) {
+          throw new Error('Remote relay backend requested but no RemoteGateway is configured.');
+        }
+        const result = await gateway.routeToolRequest({
+          identity,
+          sessionId,
+          toolName: method,
+          riskLevel,
+          input: params,
+          approvalId,
+          deadlineMs: opts?.timeoutMs,
+        });
+        if (!result.ok) {
+          throw new Error(`Remote relay ${result.code}: ${result.message}`);
+        }
+        return result.result as TResult;
+      },
+    },
+  };
+}
+
+function invalidWriteModeResponse(tool: ToolDefinition, error: ZodError) {
+  return structuredErrorResponse({
+    errorCode: ErrorCodes.INVALID_INPUT,
+    message: `Invalid writeMode for "${tool.name}": ${error.message}`,
+    details: { toolName: tool.name, issues: error.issues },
+  });
+}
+
+function forbiddenScopeResponse(
+  context: ToolContext,
+  tool: ToolDefinition,
+  requiredScopes: string[],
+) {
+  const allowedScopes = parseToolScopes(context.config.TOOL_SCOPES);
+  if (hasRequiredToolScopes(allowedScopes, requiredScopes)) return undefined;
+  return structuredErrorResponse({
+    errorCode: ErrorCodes.FORBIDDEN_SCOPE,
+    message: `Tool "${tool.name}" requires one of: ${requiredScopes.join(', ')}.`,
+    details: {
+      toolName: tool.name,
+      requiredScopes,
+      configuredScopes: allowedScopes ? Array.from(allowedScopes) : ['*'],
+    },
+  });
+}
+
+function writePlanningResponse(
+  tool: ToolDefinition,
+  raw: Record<string, unknown>,
+  writeMode: WriteMode,
+  requiredScopes: string[],
+) {
+  if (!tool.confirmWrite || writeMode === 'apply') return undefined;
+  const parsedPlan = tool.inputSchema.safeParse({ ...raw, confirmWrite: true });
+  if (!parsedPlan.success) {
+    return structuredErrorResponse({
+      errorCode: ErrorCodes.INVALID_INPUT,
+      message: `Invalid input for "${tool.name}": ${parsedPlan.error.message}`,
+      details: { toolName: tool.name, issues: parsedPlan.error.issues },
+    });
+  }
+  return writePlanResponse(tool, writeMode, omitWriteControls(parsedPlan.data), requiredScopes);
+}
+
+function confirmWriteResponse(tool: ToolDefinition, raw: Record<string, unknown>) {
+  if (!tool.confirmWrite || raw.confirmWrite === true) return undefined;
+  return structuredErrorResponse({
+    errorCode: ErrorCodes.CONFIRM_WRITE_REQUIRED,
+    message: `Tool "${tool.name}" can mutate design state and requires confirmWrite=true.`,
+    details: { toolName: tool.name, toolGroup: tool.group, risk: tool.risk },
+  });
+}
+
+async function executeToolWithMetrics(
+  context: ToolContext,
+  tool: ToolDefinition,
+  raw: Record<string, unknown>,
+  extra: unknown,
+  parsed: unknown,
+): Promise<unknown> {
+  const startedAt = Date.now();
+  try {
+    const executionContext = contextForRemoteRelay(context, tool, raw, extra);
+    const result = await tool.handler(executionContext, parsed);
+    getGlobalMetricsCollector().recordTimed({
+      category: categoryForTool(tool),
+      name: tool.name,
+      durationMs: Date.now() - startedAt,
+      ok: true,
+    });
+    return result;
+  } catch (err) {
+    getGlobalMetricsCollector().recordTimed({
+      category: categoryForTool(tool),
+      name: tool.name,
+      durationMs: Date.now() - startedAt,
+      ok: false,
+    });
+    throw err;
+  }
+}
+
+function formatToolSuccess(tool: ToolDefinition, result: unknown) {
+  const output = tool.outputSchema.safeParse(result);
+  if (!output.success) {
+    return structuredErrorResponse({
+      errorCode: ErrorCodes.TOOL_OUTPUT_INVALID,
+      message: `Tool "${tool.name}" returned output that does not match its declared outputSchema.`,
+      details: { toolName: tool.name, issues: output.error.issues },
+    });
+  }
+
+  const images = tool.imageContent?.(output.data) ?? [];
+  const responseData =
+    images.length > 0 && tool.imageContentOmitFields?.length
+      ? omitFields(output.data, tool.imageContentOmitFields)
+      : output.data;
+  const structuredContent =
+    typeof responseData === 'object' && responseData !== null
+      ? (responseData as Record<string, unknown>)
+      : { value: responseData };
+  return {
+    structuredContent,
+    content: [
+      { type: 'text' as const, text: JSON.stringify(responseData, null, 2) },
+      ...images.map((image) => ({
+        type: 'image' as const,
+        data: image.data,
+        mimeType: image.mimeType,
+      })),
+    ],
+  };
+}
+
+function toolFailureResponse(tool: ToolDefinition, context: ToolContext, err: unknown) {
+  if (err instanceof ZodError) {
+    return structuredErrorResponse({
+      errorCode: ErrorCodes.INVALID_INPUT,
+      message: `Invalid input for "${tool.name}": ${err.message}`,
+      details: { toolName: tool.name, issues: err.issues },
+    });
+  }
+
+  const msg = err instanceof Error ? err.message : String(err);
+  if (msg.includes('Bridge not connected') || msg.includes('Bridge disconnected')) {
+    return bridgeDisconnectedResponse(context.config.bridgeHost, String(context.config.bridgePort));
+  }
+
+  return structuredErrorResponse({
+    errorCode: ErrorCodes.TOOL_EXECUTION,
+    message: `Tool "${tool.name}" failed: ${msg}`,
+    details: { toolName: tool.name },
+  });
+}
+
+async function handleRegisteredToolCall(
+  tool: ToolDefinition,
+  context: ToolContext,
+  input: unknown,
+  extra: unknown,
+) {
+  try {
+    const raw = getRawInput(input);
+    const writeMode = parseWriteMode(raw);
+    if (writeMode instanceof ZodError) return invalidWriteModeResponse(tool, writeMode);
+
+    const requiredScopes = getRequiredToolScopes(tool);
+    const scopeError = forbiddenScopeResponse(context, tool, requiredScopes);
+    if (scopeError) return scopeError;
+
+    const planned = writePlanningResponse(tool, raw, writeMode, requiredScopes);
+    if (planned) return planned;
+
+    const confirmError = confirmWriteResponse(tool, raw);
+    if (confirmError) return confirmError;
+
+    const parsed = tool.inputSchema.parse(input ?? {});
+    const result = await executeToolWithMetrics(context, tool, raw, extra, parsed);
+    return formatToolSuccess(tool, result);
+  } catch (err) {
+    return toolFailureResponse(tool, context, err);
+  }
+}
+
 // ── Tool metadata snapshot ────────────────────────────────────────────────
 
 export interface ToolMetadata {
@@ -231,138 +537,8 @@ export class ToolRegistry {
           outputSchema: registeredOutputSchema(tool),
           annotations: tool.annotations,
         },
-        async (input: unknown) => {
-          try {
-            const raw = getRawInput(input);
-            const writeMode = parseWriteMode(raw);
-            if (writeMode instanceof ZodError) {
-              return structuredErrorResponse({
-                errorCode: ErrorCodes.INVALID_INPUT,
-                message: `Invalid writeMode for "${tool.name}": ${writeMode.message}`,
-                details: { toolName: tool.name, issues: writeMode.issues },
-              });
-            }
-
-            // ── Capability scope gate ────────────────────────────
-            const allowedScopes = parseToolScopes(context.config.TOOL_SCOPES);
-            const requiredScopes = getRequiredToolScopes(tool);
-            if (!hasRequiredToolScopes(allowedScopes, requiredScopes)) {
-              return structuredErrorResponse({
-                errorCode: ErrorCodes.FORBIDDEN_SCOPE,
-                message: `Tool "${tool.name}" requires one of: ${requiredScopes.join(', ')}.`,
-                details: {
-                  toolName: tool.name,
-                  requiredScopes,
-                  configuredScopes: allowedScopes ? Array.from(allowedScopes) : ['*'],
-                },
-              });
-            }
-
-            // ── Write transaction planning / preview / verification ─────
-            if (tool.confirmWrite && writeMode !== 'apply') {
-              const parsedPlan = tool.inputSchema.safeParse({ ...raw, confirmWrite: true });
-              if (!parsedPlan.success) {
-                return structuredErrorResponse({
-                  errorCode: ErrorCodes.INVALID_INPUT,
-                  message: `Invalid input for "${tool.name}": ${parsedPlan.error.message}`,
-                  details: { toolName: tool.name, issues: parsedPlan.error.issues },
-                });
-              }
-              return writePlanResponse(
-                tool,
-                writeMode,
-                omitWriteControls(parsedPlan.data),
-                requiredScopes,
-              );
-            }
-
-            // ── confirmWrite gate for apply ─────────────────────────────
-            if (tool.confirmWrite && raw.confirmWrite !== true) {
-              return structuredErrorResponse({
-                errorCode: ErrorCodes.CONFIRM_WRITE_REQUIRED,
-                message: `Tool "${tool.name}" can mutate design state and requires confirmWrite=true.`,
-                details: { toolName: tool.name, toolGroup: tool.group, risk: tool.risk },
-              });
-            }
-
-            // ── Parse & execute ───────────────────────────────────────
-            const parsed = tool.inputSchema.parse(input ?? {});
-            const startedAt = Date.now();
-            let result: unknown;
-            try {
-              result = await tool.handler(context, parsed);
-              getGlobalMetricsCollector().recordTimed({
-                category: categoryForTool(tool),
-                name: tool.name,
-                durationMs: Date.now() - startedAt,
-                ok: true,
-              });
-            } catch (err) {
-              getGlobalMetricsCollector().recordTimed({
-                category: categoryForTool(tool),
-                name: tool.name,
-                durationMs: Date.now() - startedAt,
-                ok: false,
-              });
-              throw err;
-            }
-            const output = tool.outputSchema.safeParse(result);
-
-            if (!output.success) {
-              return structuredErrorResponse({
-                errorCode: ErrorCodes.TOOL_OUTPUT_INVALID,
-                message: `Tool "${tool.name}" returned output that does not match its declared outputSchema.`,
-                details: { toolName: tool.name, issues: output.error.issues },
-              });
-            }
-
-            const images = tool.imageContent?.(output.data) ?? [];
-            const responseData =
-              images.length > 0 && tool.imageContentOmitFields?.length
-                ? omitFields(output.data, tool.imageContentOmitFields)
-                : output.data;
-            const structuredContent =
-              typeof responseData === 'object' && responseData !== null
-                ? (responseData as Record<string, unknown>)
-                : { value: responseData };
-            return {
-              structuredContent,
-              content: [
-                { type: 'text' as const, text: JSON.stringify(responseData, null, 2) },
-                ...images.map((image) => ({
-                  type: 'image' as const,
-                  data: image.data,
-                  mimeType: image.mimeType,
-                })),
-              ],
-            };
-          } catch (err) {
-            // ── Zod validation errors ─────────────────────────────────
-            if (err instanceof ZodError) {
-              return structuredErrorResponse({
-                errorCode: ErrorCodes.INVALID_INPUT,
-                message: `Invalid input for "${tool.name}": ${err.message}`,
-                details: { toolName: tool.name, issues: err.issues },
-              });
-            }
-
-            // ── Bridge-disconnected interception ──────────────────────
-            const msg = err instanceof Error ? err.message : String(err);
-            if (msg.includes('Bridge not connected') || msg.includes('Bridge disconnected')) {
-              return bridgeDisconnectedResponse(
-                context.config.bridgeHost,
-                String(context.config.bridgePort),
-              );
-            }
-
-            // ── Generic execution error ───────────────────────────────
-            return structuredErrorResponse({
-              errorCode: ErrorCodes.TOOL_EXECUTION,
-              message: `Tool "${tool.name}" failed: ${msg}`,
-              details: { toolName: tool.name },
-            });
-          }
-        },
+        async (input: unknown, extra: unknown) =>
+          handleRegisteredToolCall(tool, context, input, extra),
       );
     }
   }

--- a/src/tools/types.ts
+++ b/src/tools/types.ts
@@ -6,6 +6,7 @@ import { type JlcpcbClient } from '../vendors/jlcpcb/client.js';
 import { type MouserClient } from '../vendors/mouser/client.js';
 import { type DigiKeyClient } from '../vendors/digikey/client.js';
 import { type Storage } from '../storage/index.js';
+import { type RemoteGateway } from '../remote/gateway.js';
 
 export interface ToolDefinition<
   TInput extends z.ZodType = z.ZodType,
@@ -107,6 +108,9 @@ export interface ToolContext {
     bridgePort: number;
     keylessSourcingEnabled?: boolean;
     [key: string]: unknown;
+  };
+  remote?: {
+    gateway: RemoteGateway;
   };
   vendors: {
     lcsc: LcscClient | null;

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -730,3 +730,320 @@ describe('registered output schema compatibility', () => {
     expect(writePlanOutputSchema.safeParse({ success: true, transaction: {} }).success).toBe(false);
   });
 });
+
+describe('ToolRegistry remote relay backend', () => {
+  it('routes bridge calls through RemoteGateway when MCP_BRIDGE_BACKEND=remote_relay', async () => {
+    const routeToolRequest = vi.fn(async () => ({
+      ok: true as const,
+      sessionId: 'sess_1',
+      toolName: 'schematic.listComponents',
+      result: { ok: true },
+      durationMs: 4,
+    }));
+    const registry = new ToolRegistry();
+    registry.register(
+      createMockTool('remote_read_tool', 'core', {
+        inputSchema: z.object({ remoteSessionId: z.string().optional() }),
+        handler: async (ctx) =>
+          await ctx.bridge.call(
+            'schematic.listComponents',
+            { includeHidden: false },
+            { timeoutMs: 123 },
+          ),
+      }),
+    );
+    const { server, handlers } = mockMcpServer();
+    registry.registerAllOnServer(
+      server as any,
+      mockContext({
+        config: {
+          bridgeTimeoutMs: 1000,
+          artifactDir: '.easyeda-mcp-pro/artifacts',
+          bridgeHost: '127.0.0.1',
+          bridgePort: 49620,
+          MCP_BRIDGE_BACKEND: 'remote_relay',
+        },
+        remote: { gateway: { routeToolRequest } as any },
+      }),
+    );
+
+    const headers = new Map<string, string>([
+      ['x-remote-user-id', 'user-a'],
+      ['x-remote-scopes', 'easyeda.read'],
+    ]);
+    const response = await handlers.get('remote_read_tool')!(
+      { remoteSessionId: 'sess_1' },
+      { requestInfo: { headers } },
+    );
+
+    expect(response.isError).toBeFalsy();
+    expect(routeToolRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess_1',
+        toolName: 'schematic.listComponents',
+        riskLevel: 'read',
+        input: { includeHidden: false },
+        deadlineMs: 123,
+      }),
+    );
+    expect(routeToolRequest.mock.calls[0]?.[0].identity).toMatchObject({
+      userId: 'user-a',
+      scopes: ['easyeda.read'],
+    });
+  });
+
+  it('passes remote approval controls for write/export remote bridge calls', async () => {
+    const routeToolRequest = vi.fn(async () => ({
+      ok: true as const,
+      sessionId: 'sess_2',
+      toolName: 'board.exportGerbers',
+      result: { ok: true },
+      durationMs: 7,
+    }));
+    const registry = new ToolRegistry();
+    registry.register(
+      createMockTool('remote_export_tool', 'core', {
+        group: 'export',
+        risk: 'high',
+        confirmWrite: true,
+        inputSchema: z.object({
+          confirmWrite: z.boolean(),
+          remoteSessionId: z.string().optional(),
+          remoteApprovalId: z.string().optional(),
+        }),
+        handler: async (ctx) => await ctx.bridge.call('board.exportGerbers', { format: 'zip' }),
+      }),
+    );
+    const { server, handlers } = mockMcpServer();
+    registry.registerAllOnServer(
+      server as any,
+      mockContext({
+        config: {
+          bridgeTimeoutMs: 1000,
+          artifactDir: '.easyeda-mcp-pro/artifacts',
+          bridgeHost: '127.0.0.1',
+          bridgePort: 49620,
+          MCP_BRIDGE_BACKEND: 'remote_relay',
+        },
+        remote: { gateway: { routeToolRequest } as any },
+      }),
+    );
+
+    const response = await handlers.get('remote_export_tool')!(
+      {
+        confirmWrite: true,
+        remoteSessionId: 'sess_2',
+        remoteApprovalId: 'appr_1',
+      },
+      {
+        authInfo: {
+          clientId: 'client-a',
+          scopes: ['easyeda:export'],
+          extra: { sub: 'user-a' },
+        },
+      },
+    );
+
+    expect(response.isError).toBeFalsy();
+    expect(routeToolRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess_2',
+        toolName: 'board.exportGerbers',
+        riskLevel: 'export',
+        input: { format: 'zip' },
+        approvalId: 'appr_1',
+      }),
+    );
+    expect(routeToolRequest.mock.calls[0]?.[0].identity).toMatchObject({
+      userId: 'user-a',
+      scopes: ['easyeda.export'],
+    });
+  });
+
+  it('uses the configured Remote Relay session id when request input omits one', async () => {
+    const routeToolRequest = vi.fn(async () => ({
+      ok: true as const,
+      sessionId: 'sess_configured',
+      toolName: 'schematic.getDocument',
+      result: { ok: true },
+      durationMs: 2,
+    }));
+    const registry = new ToolRegistry();
+    registry.register(
+      createMockTool('remote_configured_session_tool', 'core', {
+        handler: async (ctx) => await ctx.bridge.call('schematic.getDocument'),
+      }),
+    );
+    const { server, handlers } = mockMcpServer();
+    registry.registerAllOnServer(
+      server as any,
+      mockContext({
+        config: {
+          bridgeTimeoutMs: 1000,
+          artifactDir: '.easyeda-mcp-pro/artifacts',
+          bridgeHost: '127.0.0.1',
+          bridgePort: 49620,
+          MCP_BRIDGE_BACKEND: 'remote_relay',
+          MCP_REMOTE_SESSION_ID: 'sess_configured',
+        },
+        remote: { gateway: { routeToolRequest } as any },
+      }),
+    );
+
+    const response = await handlers.get('remote_configured_session_tool')!({}, {});
+
+    expect(response.isError).toBeFalsy();
+    expect(routeToolRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'sess_configured' }),
+    );
+  });
+
+  it('surfaces Remote Relay routing failures as structured tool errors', async () => {
+    const routeToolRequest = vi.fn(async () => ({
+      ok: false as const,
+      code: 'REMOTE_SESSION_NOT_FOUND',
+      message: 'No paired session matched the request.',
+      suggestion: 'Pair an extension session first.',
+    }));
+    const registry = new ToolRegistry();
+    registry.register(
+      createMockTool('remote_failure_tool', 'core', {
+        inputSchema: z.object({ remoteSessionId: z.string().optional() }),
+        handler: async (ctx) => await ctx.bridge.call('schematic.getDocument'),
+      }),
+    );
+    const { server, handlers } = mockMcpServer();
+    registry.registerAllOnServer(
+      server as any,
+      mockContext({
+        config: {
+          bridgeTimeoutMs: 1000,
+          artifactDir: '.easyeda-mcp-pro/artifacts',
+          bridgeHost: '127.0.0.1',
+          bridgePort: 49620,
+          MCP_BRIDGE_BACKEND: 'remote_relay',
+        },
+        remote: { gateway: { routeToolRequest } as any },
+      }),
+    );
+
+    const response = await handlers.get('remote_failure_tool')!({ remoteSessionId: 'missing' });
+
+    expect(response.isError).toBe(true);
+    expect(response.structuredContent).toMatchObject({
+      errorCode: ErrorCodes.TOOL_EXECUTION,
+      details: { toolName: 'remote_failure_tool' },
+    });
+    expect(response.content[0].text).toContain('REMOTE_SESSION_NOT_FOUND');
+  });
+
+  it('surfaces a missing RemoteGateway when remote backend is enabled', async () => {
+    const registry = new ToolRegistry();
+    registry.register(
+      createMockTool('remote_missing_gateway_tool', 'core', {
+        handler: async (ctx) => await ctx.bridge.call('schematic.getDocument'),
+      }),
+    );
+    const { server, handlers } = mockMcpServer();
+    registry.registerAllOnServer(
+      server as any,
+      mockContext({
+        config: {
+          bridgeTimeoutMs: 1000,
+          artifactDir: '.easyeda-mcp-pro/artifacts',
+          bridgeHost: '127.0.0.1',
+          bridgePort: 49620,
+          MCP_BRIDGE_BACKEND: 'remote_relay',
+        },
+      }),
+    );
+
+    const response = await handlers.get('remote_missing_gateway_tool')!({});
+
+    expect(response.isError).toBe(true);
+    expect(response.content[0].text).toContain('no RemoteGateway is configured');
+  });
+
+  it('accepts Remote Relay identity from OAuth client id when no subject claim exists', async () => {
+    const routeToolRequest = vi.fn(async () => ({
+      ok: true as const,
+      sessionId: 'sess_client',
+      toolName: 'schematic.getDocument',
+      result: { ok: true },
+      durationMs: 2,
+    }));
+    const registry = new ToolRegistry();
+    registry.register(
+      createMockTool('remote_client_identity_tool', 'core', {
+        handler: async (ctx) => await ctx.bridge.call('schematic.getDocument'),
+      }),
+    );
+    const { server, handlers } = mockMcpServer();
+    registry.registerAllOnServer(
+      server as any,
+      mockContext({
+        config: {
+          bridgeTimeoutMs: 1000,
+          artifactDir: '.easyeda-mcp-pro/artifacts',
+          bridgeHost: '127.0.0.1',
+          bridgePort: 49620,
+          MCP_BRIDGE_BACKEND: 'remote_relay',
+          MCP_REMOTE_SESSION_ID: 'sess_client',
+        },
+        remote: { gateway: { routeToolRequest } as any },
+      }),
+    );
+
+    await handlers.get('remote_client_identity_tool')!(
+      {},
+      {
+        authInfo: { clientId: 'client-only', scopes: ['easyeda:read'], extra: {} },
+      },
+    );
+
+    expect(routeToolRequest.mock.calls[0]?.[0].identity).toMatchObject({
+      userId: 'client-only',
+      scopes: ['easyeda.read'],
+    });
+  });
+
+  it('ignores non-scalar debug identity headers instead of stringifying objects', async () => {
+    const routeToolRequest = vi.fn(async () => ({
+      ok: true as const,
+      sessionId: 'sess_headers',
+      toolName: 'schematic.getDocument',
+      result: { ok: true },
+      durationMs: 2,
+    }));
+    const registry = new ToolRegistry();
+    registry.register(
+      createMockTool('remote_non_scalar_headers_tool', 'core', {
+        handler: async (ctx) => await ctx.bridge.call('schematic.getDocument'),
+      }),
+    );
+    const { server, handlers } = mockMcpServer();
+    registry.registerAllOnServer(
+      server as any,
+      mockContext({
+        config: {
+          bridgeTimeoutMs: 1000,
+          artifactDir: '.easyeda-mcp-pro/artifacts',
+          bridgeHost: '127.0.0.1',
+          bridgePort: 49620,
+          MCP_BRIDGE_BACKEND: 'remote_relay',
+          MCP_REMOTE_SESSION_ID: 'sess_headers',
+        },
+        remote: { gateway: { routeToolRequest } as any },
+      }),
+    );
+
+    await handlers.get('remote_non_scalar_headers_tool')!(
+      {},
+      {
+        requestInfo: { headers: { 'x-remote-user-id': { bad: 'object' } } },
+      },
+    );
+
+    expect(routeToolRequest.mock.calls[0]?.[0].identity).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Part of #234.

- add `MCP_BRIDGE_BACKEND=local_bridge|remote_relay` with default `local_bridge`
- add optional `MCP_REMOTE_SESSION_ID` for fixed Remote Relay session selection
- share a `RemoteGateway` between HTTP transport and MCP tool context when `remote_relay` is enabled
- teach `ToolRegistry` to create a per-request remote bridge context that routes `ctx.bridge.call(...)` through `RemoteGateway.routeToolRequest(...)`
- derive remote identity from MCP handler `authInfo` or dev/test `x-remote-*` request headers
- pass `remoteSessionId` and `remoteApprovalId` controls into the remote gateway
- attach MCP SDK-compatible `req.auth` in OAuth middleware so handler `extra.authInfo` is populated
- document the status as an experimental foundation rather than beta-ready support

## Behavior

Default behavior is unchanged: `MCP_BRIDGE_BACKEND=local_bridge` keeps all tool calls on the existing localhost EasyEDA bridge.

With `MCP_BRIDGE_BACKEND=remote_relay`, tool handlers that call `ctx.bridge.call(...)` can route through a paired Remote Relay session without rewriting every tool implementation. This is still an explicit experimental path; live EasyEDA relay dogfood, production session UX, and MCP-driven approval request creation remain follow-up work.

## Verification

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test -- tests/unit/tools/registry.test.ts tests/unit/server/transports/http-remote-gateway.test.ts` — root suite completed successfully: 94 files / 1131 tests
- `pnpm verify:tool-coverage`
- `pnpm build`
- `pnpm test:extension` — 4 files / 61 tests
- `pnpm check:metadata`
- `pnpm docs:build`

Note: `pnpm docs:build` still emits the pre-existing VitePress `env` syntax-highlighter fallback warnings; build succeeds.