### PR TITLE
feat(remote): add relay readiness doctor checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,8 @@ Copy `.env.example` to `.env` and edit. All variables have safe defaults — onl
 | `MCP_REMOTE_SESSION_ID` | empty          | Optional fixed Remote Relay session id for `remote_relay` backend            |
 | `TRANSPORT`             | `stdio`        | Server transport: `stdio` (default) or `http`                                |
 
+For Remote Relay experiments, run `npx easyeda-mcp-pro doctor --fix` after setting `MCP_BRIDGE_BACKEND=remote_relay`; the doctor output validates HTTP transport, session selection, OAuth, and loopback-only development auth settings.
+
 ### Bridge (EasyEDA Pro connection)
 
 | Variable                        | Default       | Description                                                              |

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -61,7 +61,32 @@ Verify that your credentials are set in the `.env` file at the directory where y
 
 ---
 
-## 4. HTTP Transport Blocked by OAuth Safety Check
+## 4. Remote Relay Misconfiguration
+
+### Symptom:
+
+You set `MCP_BRIDGE_BACKEND=remote_relay`, but remote tool calls fail before reaching EasyEDA Pro or report that no relay session is available.
+
+### Checklist:
+
+Run:
+
+```bash
+npx easyeda-mcp-pro doctor --fix
+```
+
+The doctor output includes a `Remote backend:` line. For Remote Relay mode it checks whether:
+
+- `TRANSPORT=http` is configured, so `/remote/*` relay endpoints are mounted.
+- `MCP_REMOTE_SESSION_ID` is configured, or each MCP request is expected to pass `remoteSessionId`.
+- `OAUTH_ENABLED=true` is set for production identity propagation.
+- `HTTP_AUTH_DISABLED=true` is not accidentally used outside loopback-only development.
+
+`remote_relay` remains experimental. Use the default `MCP_BRIDGE_BACKEND=local_bridge` unless you are explicitly testing a paired Remote Relay session.
+
+---
+
+## 5. HTTP Transport Blocked by OAuth Safety Check
 
 ### Symptom:
 
@@ -75,7 +100,7 @@ To bypass this locally, bind to `127.0.0.1`. For production deployments, configu
 
 ---
 
-## 5. Stale MCP Client Config
+## 6. Stale MCP Client Config
 
 ### Symptom:
 
@@ -93,7 +118,7 @@ further action is needed — restart the client to pick up the corrected config.
 
 ---
 
-## 6. Release Pipeline / NPM Token Failures
+## 7. Release Pipeline / NPM Token Failures
 
 ### Symptom:
 

--- a/src/cli/local-setup.ts
+++ b/src/cli/local-setup.ts
@@ -50,6 +50,15 @@ export interface VendorDoctorStatus {
     'not-required' | 'optional-present' | 'optional-missing' | 'present' | 'missing';
 }
 
+export interface RemoteBackendDoctorStatus {
+  backend: 'local_bridge' | 'remote_relay' | 'unknown';
+  transport: string;
+  remoteSessionConfigured: boolean;
+  oauthEnabled: boolean;
+  httpAuthDisabled: boolean;
+  warnings: string[];
+}
+
 export interface DoctorReport {
   setup: LocalSetupInfo;
   nodeVersion: string;
@@ -62,6 +71,42 @@ export interface DoctorReport {
   toolCounts?: { profile: string; enabled: number; total: number };
   vendorsConfigured: Record<string, boolean>;
   vendorDiagnostics?: Record<string, VendorDoctorStatus>;
+  remoteBackend?: RemoteBackendDoctorStatus;
+}
+
+function remoteBackendStatusFromConfig(
+  config: EnvConfig | undefined,
+): RemoteBackendDoctorStatus | undefined {
+  if (!config) return undefined;
+  const warnings: string[] = [];
+  const backend = config.MCP_BRIDGE_BACKEND;
+  const transport = config.TRANSPORT;
+  const remoteSessionConfigured = config.MCP_REMOTE_SESSION_ID.trim().length > 0;
+  const oauthEnabled = config.OAUTH_ENABLED;
+  const httpAuthDisabled = config.HTTP_AUTH_DISABLED;
+
+  if (backend === 'remote_relay') {
+    if (transport !== 'http') {
+      warnings.push(
+        'remote_relay backend needs TRANSPORT=http so /remote/* relay endpoints are mounted.',
+      );
+    }
+    if (!remoteSessionConfigured) {
+      warnings.push(
+        'No MCP_REMOTE_SESSION_ID configured; MCP clients must pass remoteSessionId per tool call.',
+      );
+    }
+    if (!oauthEnabled) {
+      warnings.push(
+        'OAUTH_ENABLED=false; production remote relay should use OAuth for user identity.',
+      );
+    }
+    if (httpAuthDisabled) {
+      warnings.push('HTTP_AUTH_DISABLED=true is only appropriate for loopback/local development.');
+    }
+  }
+
+  return { backend, transport, remoteSessionConfigured, oauthEnabled, httpAuthDisabled, warnings };
 }
 
 function vendorStatusFromConfig(config: EnvConfig | undefined): Record<string, VendorDoctorStatus> {
@@ -255,6 +300,7 @@ export async function createDoctorReport(
   }
 
   const vendorDiagnostics = vendorStatusFromConfig(env.config);
+  const remoteBackend = remoteBackendStatusFromConfig(env.config);
   const vendorsConfigured: Record<string, boolean> = Object.fromEntries(
     Object.entries(vendorDiagnostics).map(([name, status]) => [name, status.configured]),
   );
@@ -271,6 +317,7 @@ export async function createDoctorReport(
     toolCounts,
     vendorsConfigured,
     vendorDiagnostics,
+    remoteBackend,
   };
 }
 
@@ -330,6 +377,13 @@ function buildSuggestedFixes(report: DoctorReport): string[] {
     );
   }
 
+  if (report.remoteBackend?.warnings.length) {
+    fixes.push('Remote Relay readiness warnings:');
+    for (const warning of report.remoteBackend.warnings) {
+      fixes.push(`  Fix: ${warning}`);
+    }
+  }
+
   if (report.vendorDiagnostics) {
     for (const [name, vendor] of Object.entries(report.vendorDiagnostics)) {
       if (vendor.credentialStatus === 'missing') {
@@ -369,6 +423,10 @@ export function formatDoctorReport(report: DoctorReport, options?: { fix?: boole
     ? `Profile '${report.toolCounts.profile}' with ${report.toolCounts.enabled} / ${report.toolCounts.total} tools enabled`
     : 'Unknown tool configuration';
 
+  const remoteBackendStr = report.remoteBackend
+    ? `${report.remoteBackend.backend} / transport=${report.remoteBackend.transport} / session=${report.remoteBackend.remoteSessionConfigured ? 'configured' : 'per-request'} / oauth=${report.remoteBackend.oauthEnabled ? 'enabled' : 'disabled'}${report.remoteBackend.warnings.length ? ` / warnings=${report.remoteBackend.warnings.length}` : ''}`
+    : 'Unknown remote backend configuration';
+
   const lines = [
     'easyeda-mcp-pro doctor',
     '',
@@ -378,6 +436,10 @@ export function formatDoctorReport(report: DoctorReport, options?: { fix?: boole
     `MCP server entry: ${status(report.setup.serverEntryExists)} ${report.setup.serverEntryPath}`,
     `EasyEDA extension package: ${status(report.setup.extensionPackageExists)} ${report.setup.extensionPackagePath}`,
     `Bridge server: ${reachable ? 'OK' : 'INFO'} ${bridgeStatus}`,
+    `Remote backend: ${remoteBackendStr}`,
+    ...(report.remoteBackend?.warnings.length
+      ? report.remoteBackend.warnings.map((warning) => `Remote warning: ${warning}`)
+      : []),
     `Tools: ${toolsStr}`,
     `Vendors: ${vendors}`,
     '',

--- a/tests/unit/cli/local-setup.test.ts
+++ b/tests/unit/cli/local-setup.test.ts
@@ -130,12 +130,23 @@ describe('local setup CLI helpers', () => {
           credentialStatus: 'optional-missing',
         },
       },
+      remoteBackend: {
+        backend: 'local_bridge',
+        transport: 'stdio',
+        remoteSessionConfigured: false,
+        oauthEnabled: false,
+        httpAuthDisabled: false,
+        warnings: [],
+      },
     };
 
     expect(formatDoctorReport(report)).toContain('Bridge server: OK reachable on 127.0.0.1:18601');
     expect(formatDoctorReport(report)).toContain('EasyEDA extension package: MISSING');
     expect(formatDoctorReport(report)).toContain(
       'LCSC: enabled / configured / optional-missing / public-jlcsearch',
+    );
+    expect(formatDoctorReport(report)).toContain(
+      'Remote backend: local_bridge / transport=stdio / session=per-request / oauth=disabled',
     );
     expect(formatDoctorReport(report)).not.toContain('Suggested fixes:');
   });
@@ -166,6 +177,17 @@ describe('local setup CLI helpers', () => {
       vendorDiagnostics: {
         MOUSER: { enabled: true, configured: false, mode: 'api', credentialStatus: 'missing' },
       },
+      remoteBackend: {
+        backend: 'remote_relay',
+        transport: 'stdio',
+        remoteSessionConfigured: false,
+        oauthEnabled: false,
+        httpAuthDisabled: false,
+        warnings: [
+          'remote_relay backend needs TRANSPORT=http so /remote/* relay endpoints are mounted.',
+          'No MCP_REMOTE_SESSION_ID configured; MCP clients must pass remoteSessionId per tool call.',
+        ],
+      },
     };
 
     const output = formatDoctorReport(report, { fix: true });
@@ -178,6 +200,9 @@ describe('local setup CLI helpers', () => {
     expect(output).toContain('pnpm build:extension');
     expect(output).toContain('Extension Manager and confirm the bridge extension is imported');
     expect(output).toContain('MOUSER is enabled but missing required credentials');
+    expect(output).toContain('Remote Relay readiness warnings:');
+    expect(output).toContain('remote_relay backend needs TRANSPORT=http');
+    expect(output).toContain('Remote warning: remote_relay backend needs TRANSPORT=http');
   });
 
   it('doctor --fix reports a fallback port and no issues when everything is healthy', () => {
@@ -201,6 +226,14 @@ describe('local setup CLI helpers', () => {
       toolCounts: { profile: 'core', enabled: 10, total: 20 },
       vendorsConfigured: {},
       vendorDiagnostics: {},
+      remoteBackend: {
+        backend: 'local_bridge',
+        transport: 'stdio',
+        remoteSessionConfigured: false,
+        oauthEnabled: false,
+        httpAuthDisabled: false,
+        warnings: [],
+      },
     };
 
     expect(formatDoctorReport(healthyReport, { fix: true })).toContain(
@@ -269,6 +302,63 @@ describe('local setup CLI helpers', () => {
       } finally {
         server.close();
       }
+    });
+
+    it('reports Remote Relay readiness warnings from environment configuration', async () => {
+      await withEnv(
+        {
+          MCP_BRIDGE_BACKEND: 'remote_relay',
+          TRANSPORT: 'stdio',
+          MCP_REMOTE_SESSION_ID: '',
+          OAUTH_ENABLED: 'false',
+          BRIDGE_PORT_SCAN: '1',
+        },
+        async () => {
+          const report = await createDoctorReport();
+
+          expect(report.remoteBackend).toMatchObject({
+            backend: 'remote_relay',
+            transport: 'stdio',
+            remoteSessionConfigured: false,
+            oauthEnabled: false,
+          });
+          expect(report.remoteBackend?.warnings).toContain(
+            'remote_relay backend needs TRANSPORT=http so /remote/* relay endpoints are mounted.',
+          );
+          expect(report.remoteBackend?.warnings).toContain(
+            'No MCP_REMOTE_SESSION_ID configured; MCP clients must pass remoteSessionId per tool call.',
+          );
+          expect(formatDoctorReport(report)).toContain('Remote backend: remote_relay');
+          expect(formatDoctorReport(report)).toContain('warnings=3');
+        },
+      );
+    });
+
+    it('reports Remote Relay as ready when http, OAuth, and fixed session are configured', async () => {
+      await withEnv(
+        {
+          MCP_BRIDGE_BACKEND: 'remote_relay',
+          TRANSPORT: 'http',
+          MCP_REMOTE_SESSION_ID: 'sess_fixed',
+          OAUTH_ENABLED: 'true',
+          OAUTH_JWKS_URI: 'https://auth.example.test/.well-known/jwks.json',
+          BRIDGE_PORT_SCAN: '1',
+        },
+        async () => {
+          const report = await createDoctorReport();
+
+          expect(report.remoteBackend).toMatchObject({
+            backend: 'remote_relay',
+            transport: 'http',
+            remoteSessionConfigured: true,
+            oauthEnabled: true,
+            warnings: [],
+          });
+          expect(formatDoctorReport(report)).toContain(
+            'Remote backend: remote_relay / transport=http / session=configured / oauth=enabled',
+          );
+        },
+      );
     });
 
     it('reports an unreachable bridge port when nothing is listening', async () => {


### PR DESCRIPTION
## Summary

- add Remote Relay backend readiness diagnostics to `easyeda-mcp-pro doctor`
- show `Remote backend:` status with backend, transport, session mode, OAuth state, and warning count
- emit explicit `Remote warning:` lines for common `remote_relay` misconfiguration cases
- include `doctor --fix` suggestions for Remote Relay readiness warnings
- document Remote Relay misconfiguration troubleshooting and README guidance

## Verification

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm test -- tests/unit/cli/local-setup.test.ts` — root suite completed successfully: 94 files / 1138 tests
- `pnpm docs:build` — succeeds with the pre-existing VitePress `env` highlighter fallback warnings
- `pnpm check:metadata`
- `pnpm build`
- `MCP_BRIDGE_BACKEND=remote_relay TRANSPORT=stdio OAUTH_ENABLED=false BRIDGE_PORT_SCAN=1 node dist/index.js --doctor --fix`