### PR TITLE
fix(bridge): include list rectangles in method registry

### DIFF
--- a/src/bridge/types.ts
+++ b/src/bridge/types.ts
@@ -7,6 +7,7 @@ export const EasyedaApiMethodSchema = z.enum([
   'schematic.listNets',
   'schematic.getNetDetail',
   'schematic.listComponents',
+  'schematic.listRectangles',
   'schematic.searchDevice',
   'schematic.getSheetInfo',
   'schematic.placeComponent',


### PR DESCRIPTION
## Summary

- add `schematic.listRectangles` to the server-side `EasyedaApiMethodSchema`
- fixes a false `registry_mismatch=true` health degradation when the extension dispatcher already exposes `schematic.listRectangles`
- keeps the server registry hash in lockstep with the extension dispatcher method list

## MSI live verification

On `/home/msi/Desktop/REPOLAR/easyeda-mcp-pro` with EasyEDA Pro `3.2.149.88089769` running and the bridge extension connected:

Before the fix:

```json
{
  "status": "degraded",
  "bridge_connected": true,
  "extension_version": "0.25.0",
  "extension_version_mismatch": false,
  "registry_mismatch": true
}
```

After adding `schematic.listRectangles`, rebuilding, restarting the MCP HTTP server, and reconnecting the EasyEDA extension:

```json
{
  "status": "ok",
  "version": "0.25.0",
  "bridge_connected": true,
  "extension_version": "0.25.0",
  "extension_version_mismatch": false,
  "registry_mismatch": false,
  "transport": "http",
  "catalog_device_count": 14
}
```

Additional live read-only smoke already passed on the same machine:

- `easyeda_bridge_status`
- `easyeda_api_inventory`
- `easyeda_schematic_sheet_info`
- `easyeda_schematic_components`
- `easyeda_schematic_nets`

## Verification

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test -- tests/unit/bridge tests/unit/tools/L0_diagnostics_core.test.ts` — root suite completed successfully: 94 files / 1138 tests