### PR TITLE
fix(dispatcher): avoid duplicate same-net wire labels

### DIFF
--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -290,6 +290,37 @@ async function buildForeignConnectivityMap(): Promise<Map<string, string>> {
   return new Map([...pinCoords, ...flagCoords]);
 }
 
+async function shouldSuppressDuplicateWireNetName(
+  points: Array<{ x: number; y: number }>,
+  netName: string | undefined,
+): Promise<boolean> {
+  if (!netName || points.length === 0) return false;
+
+  const pointKeys = new Set(points.map(pointKey));
+  const schWireClass = readFirstPath<any>(['SCH_PrimitiveWire', 'sch_PrimitiveWire']);
+  if (schWireClass && typeof schWireClass.getAll === 'function') {
+    try {
+      const wires = ((await schWireClass.getAll()) || []) as unknown[];
+      for (const wire of wires) {
+        const wireNet = String(safeGetState(wire, 'Net') ?? '');
+        if (wireNet !== netName) continue;
+        for (const point of normalizeWireLine(safeGetState(wire, 'Line'))) {
+          if (pointKeys.has(pointKey(point))) return true;
+        }
+      }
+    } catch (e) {
+      logRecoverableError('failed to read existing wires for duplicate-net-label suppression', e);
+    }
+  }
+
+  const connectivityMap = await buildForeignConnectivityMap();
+  for (const point of points) {
+    if (connectivityMap.get(pointKey(point)) === netName) return true;
+  }
+
+  return false;
+}
+
 async function findForeignNetCollision(
   points: Array<{ x: number; y: number }>,
   netName: string,
@@ -2210,10 +2241,13 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
       }
 
       const pts = rawPoints.flatMap((p) => [p.x, p.y]);
+      const wireNetName = (await shouldSuppressDuplicateWireNetName(rawPoints, netName))
+        ? undefined
+        : netName;
       return callFirst(
         ['SCH_PrimitiveWire.create', 'sch_PrimitiveWire.create'],
         pts,
-        netName,
+        wireNetName,
         params.color,
         params.lineWidth,
         params.lineType,

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -122,7 +122,61 @@ describe('createDispatcher', () => {
         { x: 10, y: 40 },
       ],
     });
-    expect(create).toHaveBeenCalledWith([10, 20, 10, 40], 'NET_A', undefined, undefined, undefined);
+    expect(create).toHaveBeenCalledWith(
+      [10, 20, 10, 40],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+
+  it('suppresses duplicate net names when addWire lands on a same-net flag', async () => {
+    const create = vi.fn(async () => ({ primitiveId: 'w3' }));
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        SCH_PrimitiveWire: { getAll: async () => [], create },
+        SCH_PrimitiveComponent: { getAll: async () => [fakeNetFlag('NET_VCC', 500, 500)] },
+      }),
+    );
+    await dispatcher.dispatch('schematic.addWire', {
+      netName: 'NET_VCC',
+      points: [
+        { x: 500, y: 500 },
+        { x: 500, y: 550 },
+      ],
+    });
+    expect(create).toHaveBeenCalledWith(
+      [500, 500, 500, 550],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+
+  it('keeps the net name for a disconnected new named wire seed', async () => {
+    const create = vi.fn(async () => ({ primitiveId: 'w4' }));
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        SCH_PrimitiveWire: { getAll: async () => [], create },
+        SCH_PrimitiveComponent: { getAll: async () => [] },
+      }),
+    );
+    await dispatcher.dispatch('schematic.addWire', {
+      netName: 'NET_NEW',
+      points: [
+        { x: 700, y: 700 },
+        { x: 700, y: 760 },
+      ],
+    });
+    expect(create).toHaveBeenCalledWith(
+      [700, 700, 700, 760],
+      'NET_NEW',
+      undefined,
+      undefined,
+      undefined,
+    );
   });
 
   // Live-verified (2026-07-07): a generic net label (SCH_PrimitiveAttribute.


### PR DESCRIPTION
## Summary

- suppress duplicate native `netName` stamping when `schematic.addWire` lands on an existing same-net wire/flag/pin coordinate
- keep the requested `netName` for disconnected new seed wires
- preserve the existing foreign-net coordinate collision guard

Fixes #242.

## Context

Live MSI testing of a generated NE555 astable schematic produced EasyEDA DRC warnings such as:

```text
Wire $1N4 has multiple net names: VCC VCC VCC VCC VCC
Wire $1N5 has multiple net names: GND GND GND GND GND GND
Wire $1N6 has multiple net names: DISCH DISCH
Wire $1N7 has multiple net names: TIMING TIMING TIMING
```

The root cause is repeatedly passing the same `netName` to native `SCH_PrimitiveWire.create` for later segments that already touch an existing same-net primitive. EasyEDA merges those coordinates electrically and DRC reports the repeated names on the merged wire.

## Verification

- `pnpm test:extension` — 4 files / 63 tests
- `pnpm typecheck:extension`
- `pnpm build:extension`
- `pnpm verify:extension`
- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test -- tests/unit/tools/schematic.test.ts tests/unit/tools/diagnostics-api.test.ts` — root suite completed: 94 files / 1138 tests
- `pnpm build`

## Follow-up work

Tracked separately:

- #243 layout-aware schematic authoring with title-block keep-out
- #244 post-write schematic QA for DRC/visual/layout regressions
- #245 professional NE555 astable template workflow