### PR TITLE
feat(schematic): add safe region planner

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -83,6 +83,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_schematic_net_detail`          | `core`  | `low`    | Get full details for a specific net in the schematic including all connected pins and components.                                                                                                                                                                                                                                |
 | `easyeda_schematic_nets`                | `core`  | `low`    | List all nets in the schematic with their node connections.                                                                                                                                                                                                                                                                      |
 | `easyeda_schematic_place_component`     | `core`  | `medium` | Place a library component/device on the active schematic sheet. Auto-assigns the next free designator ("R?" → "R1") — check the returned value, duplicate "R?" merge into one node. On a timeout error, auto-reconciles against the sheet before reporting failure (see reconciled/unconfirmed) — do not blindly retry.          |
+| `easyeda_schematic_plan_safe_region`    | `core`  | `low`    | Compute a safe schematic drawing region before placing components. Uses live sheet info when available, assumes EasyEDA bottom-left coordinates, reserves the default lower-right title-block keep-out, and returns an anchor/bounds plan that avoids title-block overlap.                                                       |
 | `easyeda_schematic_search_device`       | `core`  | `low`    | Search for schematic symbols/devices in the EasyEDA library by keywords. Full results carry the library's complete metadata object per device; pass minimal:true to get back only uuid/libraryUuid/name/pin_count/symbol_type when that is all you need.                                                                         |
 | `easyeda_schematic_set_title_block`     | `core`  | `medium` | Update schematic title block text fields (Company, Version, Drawn, Reviewed, Page Size). Only these 5 are exposed — writing Symbol/Border/Device/etc once corrupted a real title block; those are read-only natively and must be fixed via the EasyEDA Pro UI.                                                                   |
 | `easyeda_schematic_sheet_info`          | `core`  | `low`    | Return read-only active schematic sheet metadata including page size, frame, origin, and grid hints for safer component placement.                                                                                                                                                                                               |
@@ -2584,6 +2585,47 @@ Returns a JSON object matching the schema:
   unconfirmed: boolean(optional);
   warning: string(optional);
   error: string(optional);
+}
+```
+
+---
+
+## `easyeda_schematic_plan_safe_region`
+
+**Profile:** `core` | **Risk Level:** `low`
+
+> Compute a safe schematic drawing region before placing components. Uses live sheet info when available, assumes EasyEDA bottom-left coordinates, reserves the default lower-right title-block keep-out, and returns an anchor/bounds plan that avoids title-block overlap.
+
+### Input Parameters
+
+| Parameter           | Type                | Required       | Description                                                                       |
+| ------------------- | ------------------- | -------------- | --------------------------------------------------------------------------------- |
+| `projectId`         | `string (optional)` | No             |                                                                                   |
+| `contentWidth`      | `number`            | Yes            | Estimated width of the planned circuit block in EasyEDA coordinates               |
+| `contentHeight`     | `number`            | Yes            | Estimated height of the planned circuit block in EasyEDA coordinates              |
+| `preferredRegion`   | `'upper-left'       | 'upper-center' | 'upper-right'                                                                     | 'center-left' | 'center' | 'center-right' | 'lower-left' | 'lower-center' | 'lower-right'` | Yes |     |
+| `margin`            | `number (optional)` | No             |                                                                                   |
+| `titleBlockKeepout` | `object (optional)` | No             | Optional explicit title-block keep-out rectangle when the sheet template is known |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  project_id: string (optional);
+  blocked: boolean;
+  preferred_region: string;
+  sheet: object;
+  usable_bounds: object;
+  requested_bounds: object;
+  bounds: object;
+  anchor: object;
+  keepouts: object[];
+  warnings: string[];
+  issues: object[];
+  not_available: boolean (optional);
+  error: string (optional);
 }
 ```
 

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -14,7 +14,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Core',
     description:
       'High-confidence tools: diagnostics, EasyEDA API inventory, schematic, BOM, DRC/ERC, board layers/stackup, Gerber export',
-    approxToolCount: '60',
+    approxToolCount: '61',
     isDefault: true,
   },
   pro: {
@@ -22,7 +22,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Pro',
     description:
       'Adds pick-and-place, PDF, netlist export, compound transactional workflow tools, autorouting, route-context export, and offline SPICE verification for manufacturing workflows',
-    approxToolCount: '76',
+    approxToolCount: '77',
     isDefault: false,
   },
   full: {
@@ -30,7 +30,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls and CircuitIR-driven floorplanning for full runtime control without raw JavaScript execution',
-    approxToolCount: '88',
+    approxToolCount: '89',
     isDefault: false,
   },
   dev: {
@@ -38,14 +38,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '93',
+    approxToolCount: '94',
     isDefault: false,
   },
   experimental: {
     name: 'experimental',
     label: 'Experimental',
     description: 'MCP Apps, Tasks, AI action plans',
-    approxToolCount: '93',
+    approxToolCount: '94',
     isDefault: false,
   },
 };

--- a/src/tools/L1_schematic_read.ts
+++ b/src/tools/L1_schematic_read.ts
@@ -3,6 +3,19 @@ import { type ToolDefinition, type ToolContext } from './types.js';
 import { type EnvConfig } from '../config/env.js';
 import { fetchComponentPins } from './schematic-helpers.js';
 import { scanSheetForPinCollisions } from '../workflows/collision.js';
+import { planSafeSchematicRegion } from '../workflows/schematic-safe-region.js';
+
+const schematicRegionPreferenceSchema = z.enum([
+  'upper-left',
+  'upper-center',
+  'upper-right',
+  'center-left',
+  'center',
+  'center-right',
+  'lower-left',
+  'lower-center',
+  'lower-right',
+]);
 
 const searchDeviceInputSchema = z.object({
   key: z
@@ -605,6 +618,134 @@ function registerSchematicReadTools(
           error: err instanceof Error ? err.message : String(err),
         };
       }
+    },
+  });
+
+  registry.register({
+    name: 'easyeda_schematic_plan_safe_region',
+    title: 'Plan safe schematic drawing region',
+    description:
+      'Compute a safe schematic drawing region before placing components. Uses live sheet info when available, assumes EasyEDA bottom-left coordinates, reserves the default lower-right title-block keep-out, and returns an anchor/bounds plan that avoids title-block overlap.',
+    profile: 'core',
+    evidence: ['runtime-probe', 'inferred'],
+    risk: 'low',
+    confirmWrite: false,
+    group: 'schematic',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+    inputSchema: z.object({
+      projectId: z.string().optional(),
+      contentWidth: z
+        .number()
+        .positive()
+        .describe('Estimated width of the planned circuit block in EasyEDA coordinates'),
+      contentHeight: z
+        .number()
+        .positive()
+        .describe('Estimated height of the planned circuit block in EasyEDA coordinates'),
+      preferredRegion: schematicRegionPreferenceSchema.default('upper-left'),
+      margin: z.number().positive().optional(),
+      titleBlockKeepout: z
+        .object({
+          x: z.number(),
+          y: z.number(),
+          width: z.number().positive(),
+          height: z.number().positive(),
+        })
+        .optional()
+        .describe(
+          'Optional explicit title-block keep-out rectangle when the sheet template is known',
+        ),
+    }),
+    outputSchema: z.object({
+      project_id: z.string().optional(),
+      blocked: z.boolean(),
+      preferred_region: z.string(),
+      sheet: z.object({
+        width: z.number(),
+        height: z.number(),
+        unit: z.string(),
+        origin: z.string(),
+        source: z.string(),
+      }),
+      usable_bounds: z.object({
+        x: z.number(),
+        y: z.number(),
+        width: z.number(),
+        height: z.number(),
+      }),
+      requested_bounds: z.object({
+        x: z.number(),
+        y: z.number(),
+        width: z.number(),
+        height: z.number(),
+      }),
+      bounds: z.object({ x: z.number(), y: z.number(), width: z.number(), height: z.number() }),
+      anchor: z.object({ x: z.number(), y: z.number() }),
+      keepouts: z.array(
+        z.object({
+          x: z.number(),
+          y: z.number(),
+          width: z.number(),
+          height: z.number(),
+          kind: z.string(),
+        }),
+      ),
+      warnings: z.array(z.string()),
+      issues: z.array(z.object({ code: z.string(), message: z.string() })),
+      not_available: z.boolean().optional(),
+      error: z.string().optional(),
+    }),
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const p = z
+        .object({
+          projectId: z.string().optional(),
+          contentWidth: z.number().positive(),
+          contentHeight: z.number().positive(),
+          preferredRegion: schematicRegionPreferenceSchema.default('upper-left'),
+          margin: z.number().positive().optional(),
+          titleBlockKeepout: z
+            .object({
+              x: z.number(),
+              y: z.number(),
+              width: z.number().positive(),
+              height: z.number().positive(),
+            })
+            .optional(),
+        })
+        .parse(params ?? {});
+      let sheetInfo: unknown;
+      try {
+        sheetInfo = await ctx.bridge.call('schematic.getSheetInfo', { projectId: p.projectId });
+      } catch {
+        // Degrade to the conservative A4 default rather than blocking preview
+        // planning, because this tool is often used before a live sheet is fully ready.
+        sheetInfo = undefined;
+      }
+      const plan = planSafeSchematicRegion({
+        sheetInfo,
+        contentWidth: p.contentWidth,
+        contentHeight: p.contentHeight,
+        preferredRegion: p.preferredRegion,
+        margin: p.margin,
+        titleBlockKeepout: p.titleBlockKeepout,
+      });
+      return {
+        project_id: p.projectId,
+        blocked: plan.blocked,
+        preferred_region: plan.preferredRegion,
+        sheet: plan.sheet,
+        usable_bounds: plan.usableBounds,
+        requested_bounds: plan.requestedBounds,
+        bounds: plan.bounds,
+        anchor: plan.anchor,
+        keepouts: plan.keepouts,
+        warnings: plan.warnings,
+        issues: plan.issues,
+      };
     },
   });
 

--- a/src/workflows/schematic-safe-region.ts
+++ b/src/workflows/schematic-safe-region.ts
@@ -1,0 +1,311 @@
+/**
+ * Schematic sheet safe-region planner.
+ *
+ * EasyEDA Pro schematic coordinates observed in live MSI testing use a
+ * bottom-left-style sheet origin: larger Y values move objects upward on the
+ * page. The default A4 title block occupies the lower/right portion of the
+ * frame, so hard-coded low-Y coordinates easily collide with the title block.
+ *
+ * This module is deliberately pure and conservative. It does not resize the
+ * sheet; it returns a safe bounding box/anchor or a blocked plan with reasons
+ * that callers can surface before applying any writes.
+ */
+
+export type SchematicRegionPreference =
+  | 'upper-left'
+  | 'upper-center'
+  | 'upper-right'
+  | 'center-left'
+  | 'center'
+  | 'center-right'
+  | 'lower-left'
+  | 'lower-center'
+  | 'lower-right';
+
+export interface SchematicRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SchematicPoint {
+  x: number;
+  y: number;
+}
+
+export interface SchematicSheetGeometry {
+  width: number;
+  height: number;
+  unit: string;
+  origin: 'bottom-left';
+  source: 'sheet-info' | 'default-a4-landscape';
+}
+
+export interface SafeSchematicRegionPlanInput {
+  sheetInfo?: unknown;
+  contentWidth: number;
+  contentHeight: number;
+  preferredRegion?: SchematicRegionPreference;
+  margin?: number;
+  titleBlockKeepout?: SchematicRect;
+}
+
+export interface SafeSchematicRegionPlan {
+  blocked: boolean;
+  preferredRegion: SchematicRegionPreference;
+  sheet: SchematicSheetGeometry;
+  usableBounds: SchematicRect;
+  requestedBounds: SchematicRect;
+  bounds: SchematicRect;
+  anchor: SchematicPoint;
+  keepouts: Array<SchematicRect & { kind: 'title-block' }>;
+  warnings: string[];
+  issues: Array<{ code: string; message: string }>;
+}
+
+const DEFAULT_A4_LANDSCAPE = {
+  // EasyEDA schematic coordinates are not guaranteed to be true millimetres,
+  // but the live A4 frame behaves consistently with this 1189x841-style
+  // internal coordinate scale. Prefer runtime sheet-info when available.
+  width: 1189,
+  height: 841,
+  unit: 'easyeda-coordinate',
+} as const;
+
+const DEFAULT_MARGIN = 80;
+
+const REGION_ROWS: Record<SchematicRegionPreference, 'upper' | 'center' | 'lower'> = {
+  'upper-left': 'upper',
+  'upper-center': 'upper',
+  'upper-right': 'upper',
+  'center-left': 'center',
+  center: 'center',
+  'center-right': 'center',
+  'lower-left': 'lower',
+  'lower-center': 'lower',
+  'lower-right': 'lower',
+};
+
+const REGION_COLUMNS: Record<SchematicRegionPreference, 'left' | 'center' | 'right'> = {
+  'upper-left': 'left',
+  'upper-center': 'center',
+  'upper-right': 'right',
+  'center-left': 'left',
+  center: 'center',
+  'center-right': 'right',
+  'lower-left': 'left',
+  'lower-center': 'center',
+  'lower-right': 'right',
+};
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+function readNumber(record: Record<string, unknown>, keys: readonly string[]): number | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'number' && Number.isFinite(value) && value > 0) return value;
+    if (typeof value === 'string') {
+      const parsed = Number(value.trim());
+      if (Number.isFinite(parsed) && parsed > 0) return parsed;
+    }
+  }
+  return undefined;
+}
+
+function readString(record: Record<string, unknown>, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return undefined;
+}
+
+export function inferSchematicSheetGeometry(sheetInfo: unknown): SchematicSheetGeometry {
+  const root = readRecord(sheetInfo);
+  const current = readRecord(root.currentPage);
+  const currentOrRoot = Object.keys(current).length > 0 ? current : root;
+  const pageSize = readRecord(
+    root.page_size ?? root.pageSize ?? currentOrRoot.page_size ?? currentOrRoot.pageSize,
+  );
+  const width =
+    readNumber(pageSize, ['width', 'pageWidth', 'paperWidth', 'w']) ??
+    readNumber(currentOrRoot, ['width', 'pageWidth', 'paperWidth', 'w', 'Width']) ??
+    readNumber(root, ['width', 'pageWidth', 'paperWidth', 'w', 'Width']);
+  const height =
+    readNumber(pageSize, ['height', 'pageHeight', 'paperHeight', 'h']) ??
+    readNumber(currentOrRoot, ['height', 'pageHeight', 'paperHeight', 'h', 'Height']) ??
+    readNumber(root, ['height', 'pageHeight', 'paperHeight', 'h', 'Height']);
+  const unit =
+    readString(pageSize, ['unit', 'units', 'pageUnit']) ??
+    readString(currentOrRoot, ['unit', 'units', 'pageUnit']) ??
+    readString(root, ['unit', 'units', 'pageUnit']) ??
+    DEFAULT_A4_LANDSCAPE.unit;
+
+  if (width !== undefined && height !== undefined) {
+    return { width, height, unit, origin: 'bottom-left', source: 'sheet-info' };
+  }
+
+  return {
+    width: DEFAULT_A4_LANDSCAPE.width,
+    height: DEFAULT_A4_LANDSCAPE.height,
+    unit,
+    origin: 'bottom-left',
+    source: 'default-a4-landscape',
+  };
+}
+
+export function defaultTitleBlockKeepout(sheet: SchematicSheetGeometry): SchematicRect {
+  return {
+    x: sheet.width * 0.55,
+    y: 0,
+    width: sheet.width * 0.45,
+    height: sheet.height * 0.26,
+  };
+}
+
+export function rectsOverlap(a: SchematicRect, b: SchematicRect): boolean {
+  return a.x < b.x + b.width && a.x + a.width > b.x && a.y < b.y + b.height && a.y + a.height > b.y;
+}
+
+function candidateBounds(
+  usable: SchematicRect,
+  width: number,
+  height: number,
+  preference: SchematicRegionPreference,
+): SchematicRect {
+  const column = REGION_COLUMNS[preference];
+  const row = REGION_ROWS[preference];
+  const x =
+    column === 'left'
+      ? usable.x
+      : column === 'center'
+        ? usable.x + (usable.width - width) / 2
+        : usable.x + usable.width - width;
+  const y =
+    row === 'lower'
+      ? usable.y
+      : row === 'center'
+        ? usable.y + (usable.height - height) / 2
+        : usable.y + usable.height - height;
+  return { x, y, width, height };
+}
+
+function clampBoundsToUsable(bounds: SchematicRect, usable: SchematicRect): SchematicRect {
+  return {
+    ...bounds,
+    x: Math.min(Math.max(bounds.x, usable.x), usable.x + usable.width - bounds.width),
+    y: Math.min(Math.max(bounds.y, usable.y), usable.y + usable.height - bounds.height),
+  };
+}
+
+const FALLBACK_REGIONS: SchematicRegionPreference[] = [
+  'upper-left',
+  'upper-center',
+  'center-left',
+  'center',
+  'upper-right',
+  'center-right',
+  'lower-left',
+  'lower-center',
+  'lower-right',
+];
+
+export function planSafeSchematicRegion(
+  input: SafeSchematicRegionPlanInput,
+): SafeSchematicRegionPlan {
+  const sheet = inferSchematicSheetGeometry(input.sheetInfo);
+  const margin = input.margin ?? DEFAULT_MARGIN;
+  const preferredRegion = input.preferredRegion ?? 'upper-left';
+  const keepout = {
+    ...(input.titleBlockKeepout ?? defaultTitleBlockKeepout(sheet)),
+    kind: 'title-block' as const,
+  };
+  const usableBounds: SchematicRect = {
+    x: margin,
+    y: margin,
+    width: Math.max(0, sheet.width - margin * 2),
+    height: Math.max(0, sheet.height - margin * 2),
+  };
+
+  const issues: SafeSchematicRegionPlan['issues'] = [];
+  const warnings: string[] = [];
+
+  if (input.contentWidth <= 0 || input.contentHeight <= 0) {
+    issues.push({
+      code: 'INVALID_CONTENT_SIZE',
+      message: 'contentWidth and contentHeight must be positive.',
+    });
+  }
+  if (input.contentWidth > usableBounds.width || input.contentHeight > usableBounds.height) {
+    issues.push({
+      code: 'CONTENT_DOES_NOT_FIT_USABLE_BOUNDS',
+      message: `Requested content ${input.contentWidth}x${input.contentHeight} exceeds usable sheet bounds ${usableBounds.width}x${usableBounds.height}.`,
+    });
+  }
+
+  const requestedBounds = clampBoundsToUsable(
+    candidateBounds(usableBounds, input.contentWidth, input.contentHeight, preferredRegion),
+    usableBounds,
+  );
+
+  let bounds = requestedBounds;
+  if (rectsOverlap(bounds, keepout)) {
+    warnings.push(
+      `Preferred region ${preferredRegion} intersects the title-block keep-out; searching fallback safe regions.`,
+    );
+    const fallback = FALLBACK_REGIONS.map((region) =>
+      clampBoundsToUsable(
+        candidateBounds(usableBounds, input.contentWidth, input.contentHeight, region),
+        usableBounds,
+      ),
+    ).find((candidate) => !rectsOverlap(candidate, keepout));
+    if (fallback) {
+      bounds = fallback;
+    } else {
+      issues.push({
+        code: 'NO_SAFE_REGION_OUTSIDE_TITLE_BLOCK',
+        message: 'No candidate region fits outside the title-block keep-out.',
+      });
+    }
+  }
+
+  if (bounds.x < usableBounds.x || bounds.y < usableBounds.y) {
+    issues.push({
+      code: 'BOUNDS_OUTSIDE_USABLE_AREA',
+      message: 'Computed bounds start outside usable area.',
+    });
+  }
+  if (
+    bounds.x + bounds.width > usableBounds.x + usableBounds.width ||
+    bounds.y + bounds.height > usableBounds.y + usableBounds.height
+  ) {
+    issues.push({
+      code: 'BOUNDS_EXCEED_USABLE_AREA',
+      message: 'Computed bounds exceed usable area.',
+    });
+  }
+  if (rectsOverlap(bounds, keepout)) {
+    issues.push({
+      code: 'TITLE_BLOCK_OVERLAP',
+      message: 'Computed bounds overlap the title-block keep-out.',
+    });
+  }
+
+  return {
+    blocked: issues.length > 0,
+    preferredRegion,
+    sheet,
+    usableBounds,
+    requestedBounds,
+    bounds,
+    anchor: { x: bounds.x, y: bounds.y + bounds.height },
+    keepouts: [keepout],
+    warnings,
+    issues,
+  };
+}

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -39,14 +39,14 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for core', () => {
-    expect(PROFILE_DEFINITIONS.core.approxToolCount).toBe('60');
+    expect(PROFILE_DEFINITIONS.core.approxToolCount).toBe('61');
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('76');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('77');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('88');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('89');
   });
 });

--- a/tests/unit/workflows/schematic-safe-region.test.ts
+++ b/tests/unit/workflows/schematic-safe-region.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import {
+  defaultTitleBlockKeepout,
+  inferSchematicSheetGeometry,
+  planSafeSchematicRegion,
+  rectsOverlap,
+} from '../../../src/workflows/schematic-safe-region.js';
+
+describe('schematic safe-region planner', () => {
+  it('defaults to bottom-left EasyEDA coordinates on A4 landscape when sheet info is missing', () => {
+    const sheet = inferSchematicSheetGeometry(undefined);
+    expect(sheet).toEqual({
+      width: 1189,
+      height: 841,
+      unit: 'easyeda-coordinate',
+      origin: 'bottom-left',
+      source: 'default-a4-landscape',
+    });
+  });
+
+  it('reads runtime sheet-info page size when available', () => {
+    const sheet = inferSchematicSheetGeometry({
+      currentPage: { Width: '1600', Height: 1000, unit: 'coord' },
+    });
+    expect(sheet).toMatchObject({ width: 1600, height: 1000, unit: 'coord', source: 'sheet-info' });
+  });
+
+  it('places upper-left content at high Y, not near the lower title block', () => {
+    const plan = planSafeSchematicRegion({
+      contentWidth: 360,
+      contentHeight: 180,
+      preferredRegion: 'upper-left',
+    });
+    expect(plan.blocked).toBe(false);
+    expect(plan.bounds.x).toBe(80);
+    expect(plan.bounds.y).toBeGreaterThan(500);
+    expect(plan.anchor).toEqual({ x: plan.bounds.x, y: plan.bounds.y + plan.bounds.height });
+    expect(rectsOverlap(plan.bounds, plan.keepouts[0])).toBe(false);
+  });
+
+  it('keeps the default title-block keep-out on the lower-right of the sheet', () => {
+    const sheet = inferSchematicSheetGeometry(undefined);
+    const keepout = defaultTitleBlockKeepout(sheet);
+    expect(keepout.x).toBeGreaterThan(sheet.width / 2);
+    expect(keepout.y).toBe(0);
+    expect(keepout.height).toBeGreaterThan(200);
+  });
+
+  it('moves a lower-right request away from the title-block keep-out', () => {
+    const plan = planSafeSchematicRegion({
+      contentWidth: 360,
+      contentHeight: 180,
+      preferredRegion: 'lower-right',
+    });
+    expect(plan.blocked).toBe(false);
+    expect(plan.warnings).toContain(
+      'Preferred region lower-right intersects the title-block keep-out; searching fallback safe regions.',
+    );
+    expect(rectsOverlap(plan.requestedBounds, plan.keepouts[0])).toBe(true);
+    expect(rectsOverlap(plan.bounds, plan.keepouts[0])).toBe(false);
+  });
+
+  it('blocks content that cannot fit outside the usable bounds', () => {
+    const plan = planSafeSchematicRegion({
+      contentWidth: 2000,
+      contentHeight: 2000,
+      preferredRegion: 'center',
+    });
+    expect(plan.blocked).toBe(true);
+    expect(plan.issues.some((issue) => issue.code === 'CONTENT_DOES_NOT_FIT_USABLE_BOUNDS')).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- add a pure schematic safe-region planner that models EasyEDA schematic coordinates as bottom-left origin / high-Y-is-up
- reserve a conservative lower-right title-block keep-out for default A4 templates
- add `easyeda_schematic_plan_safe_region` so agents can preflight a content bounding box before writing schematic objects
- update generated tool docs

Partially addresses #243.

## Live MSI verification

After the live issue where an intended "upper-left" drawing landed near the lower title block, the new tool was tested against the connected EasyEDA Pro session with a planned NE555-sized block:

```json
{
  "blocked": false,
  "preferred": "upper-left",
  "sheet": {
    "width": 1189,
    "height": 841,
    "origin": "bottom-left",
    "source": "default-a4-landscape"
  },
  "bounds": {
    "x": 80,
    "y": 441,
    "width": 520,
    "height": 320
  },
  "anchor": {
    "x": 80,
    "y": 761
  },
  "warnings": [],
  "issues": []
}
```

This fixes the first planning error: `upper-left` now resolves to a high-Y region away from the lower-right title block.

## Verification

- `pnpm format:check`
- `pnpm typecheck`
- `pnpm test -- tests/unit/workflows/schematic-safe-region.test.ts tests/unit/tools/schematic.test.ts` — root suite completed: 95 files / 1144 tests
- `pnpm lint:tools`
- `pnpm lint`
- `pnpm generate:tools-doc`
- `pnpm build`
- `pnpm docs:build`

## Follow-up

This is the first safe-region planning primitive. Remaining #243 work:

- feed this planner into high-level circuit workflows before writes
- use live sheet/page geometry when EasyEDA exposes reliable dimensions
- add visual/post-write QA to fail on title-block overlap (#244)
- apply planner in the NE555 template workflow (#245)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new schematic layout planning tool that suggests safe drawing regions, avoids the title block, and returns placement bounds, anchors, keep-outs, and warnings.
  * Improved region selection with fallback options when the preferred area overlaps reserved space or when sheet details are unavailable.

* **Bug Fixes**
  * Better handles content that does not fit within the available area by clearly marking the plan as blocked.

* **Tests**
  * Added coverage for default sheet sizing, placement fallback behavior, keep-out handling, and blocked-layout cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->