### PR TITLE
feat(schematic): add post-write QA classifier

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -61,6 +61,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_pcb_route_path_plan`           | `full`  | `high`   | Create a high-level, constraint-checked route path plan for one net and optionally apply it after explicit confirmation.                                                                                                                                                                                                         |
 | `easyeda_pcb_tracks`                    | `core`  | `low`    | List copper track segments on the active PCB layout: primitiveId, net, layer, start/end coordinates, width. A multi-point track drawn by add_track appears as several consecutive segments sharing one net. Returns an empty list (not an error) if no PCB tab is focused.                                                       |
 | `easyeda_pcb_vias`                      | `core`  | `low`    | List vias on the active PCB layout: primitiveId, net, position, hole/outer diameter (native unit, same scale as x/y — not independently verified against a known physical dimension). Requires a focused PCB tab — returns an empty list (not an error) if none is active.                                                       |
+| `easyeda_post_write_qa`                 | `core`  | `medium` | Run and classify post-write schematic QA after generated edits. Combines native DRC/ERC results with policy-aware classification so duplicate net names, free networks, and unconnected pins are reported as pass/fail/inconclusive instead of raw warning counts.                                                               |
 | `easyeda_power_tree_analyze`            | `core`  | `medium` | Analyze supply sources, regulators, loads, protection, bulk capacitance, current budget, dropout, and regulator thermal risk. Returns machine-readable issues and a human-readable summary.                                                                                                                                      |
 | `easyeda_production_qa_artifacts`       | `pro`   | `low`    | Generate testpoint checklist, assembly notes, bring-up plan, production QA checklist, and machine-readable QA manifest for board handoff.                                                                                                                                                                                        |
 | `easyeda_project_save`                  | `core`  | `medium` | Explicitly save the current EasyEDA Pro project. This ensures all netlist changes, net flags, pin connections, and other mutations are persisted to the project file. Save is never implicit — the caller must explicitly request it. Requires confirmWrite.                                                                     |
@@ -1889,6 +1890,47 @@ Returns a JSON object matching the schema:
   total: number;
   not_available: boolean (optional);
   error: string (optional);
+}
+```
+
+---
+
+## `easyeda_post_write_qa`
+
+**Profile:** `core` | **Risk Level:** `medium`
+
+> Run and classify post-write schematic QA after generated edits. Combines native DRC/ERC results with policy-aware classification so duplicate net names, free networks, and unconnected pins are reported as pass/fail/inconclusive instead of raw warning counts.
+
+### Input Parameters
+
+| Parameter           | Type                  | Required              | Description                                                                                       |
+| ------------------- | --------------------- | --------------------- | ------------------------------------------------------------------------------------------------- |
+| `projectId`         | `string`              | Yes                   |                                                                                                   |
+| `policy`            | `'circuit'            | 'diagnostic-fixture'` | Yes                                                                                               |     |
+| `useNativeChecks`   | `boolean`             | Yes                   |                                                                                                   |
+| `manualDrcMessages` | `string[] (optional)` | No                    | Optional user-copied EasyEDA DRC log lines for classification when native details are unavailable |
+| `manualErcMessages` | `string[] (optional)` | No                    | Optional user-copied EasyEDA ERC log lines for classification when native details are unavailable |
+| `drc`               | `object (optional)`   | No                    | Optional explicit DRC result override for tests or log ingestion                                  |
+| `erc`               | `object (optional)`   | No                    | Optional explicit ERC result override for tests or log ingestion                                  |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  project_id: string;
+  status: 'pass' | 'fail' | 'inconclusive';
+  passed: boolean;
+  policy: 'circuit' | 'diagnostic-fixture';
+  issue_count: number;
+  fatal_count: number;
+  warning_count: number;
+  inconclusive_count: number;
+  categories: Record<string, number>;
+  issues: object[];
+  summary: string;
+  detail_source: 'native' | 'manual' | 'override' | 'mixed' (optional);
 }
 ```
 

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -14,7 +14,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Core',
     description:
       'High-confidence tools: diagnostics, EasyEDA API inventory, schematic, BOM, DRC/ERC, board layers/stackup, Gerber export',
-    approxToolCount: '61',
+    approxToolCount: '62',
     isDefault: true,
   },
   pro: {
@@ -22,7 +22,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Pro',
     description:
       'Adds pick-and-place, PDF, netlist export, compound transactional workflow tools, autorouting, route-context export, and offline SPICE verification for manufacturing workflows',
-    approxToolCount: '77',
+    approxToolCount: '78',
     isDefault: false,
   },
   full: {
@@ -30,7 +30,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls and CircuitIR-driven floorplanning for full runtime control without raw JavaScript execution',
-    approxToolCount: '89',
+    approxToolCount: '90',
     isDefault: false,
   },
   dev: {
@@ -38,14 +38,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '94',
+    approxToolCount: '95',
     isDefault: false,
   },
   experimental: {
     name: 'experimental',
     label: 'Experimental',
     description: 'MCP Apps, Tasks, AI action plans',
-    approxToolCount: '94',
+    approxToolCount: '95',
     isDefault: false,
   },
 };

--- a/src/tools/L1_drc_erc.ts
+++ b/src/tools/L1_drc_erc.ts
@@ -10,6 +10,7 @@ import {
 } from '../net-validation/schema.js';
 import { classifyNetType, classifyPinElectricalType } from '../net-validation/pin-classifier.js';
 import { analyzePowerTree } from '../power-tree/index.js';
+import { classifyPostWriteQa } from '../workflows/schematic-post-write-qa.js';
 import { fetchComponentPins } from './schematic-helpers.js';
 
 /** Shared error/warning mapper for both the hand-authored and auto-extracted
@@ -746,6 +747,219 @@ function registerDrcErcTools(
         regulators: report.regulators,
         issues: report.issues,
         summary: report.summary,
+      };
+    },
+  });
+
+  const qaViolationSchema = z.object({
+    rule: z.string().optional(),
+    description: z.string().optional(),
+    message: z.string().optional(),
+    severity: z.enum(['error', 'warning', 'info']).optional(),
+    net: z.string().optional(),
+    component: z.string().optional(),
+  });
+
+  const qaRunOverrideSchema = z.object({
+    not_available: z.boolean().optional(),
+    error: z.string().optional(),
+    violations: z.array(qaViolationSchema).optional(),
+    total_violations: z.number().int().nonnegative().optional(),
+    error_count: z.number().int().nonnegative().optional(),
+    warning_count: z.number().int().nonnegative().optional(),
+    passed: z.boolean().optional(),
+    inferred_floating_pins: z
+      .array(
+        z.object({
+          primitiveId: z.string().optional(),
+          designator: z.string().optional(),
+          pinNumber: z.string().optional(),
+        }),
+      )
+      .optional(),
+  });
+
+  registry.register({
+    name: 'easyeda_post_write_qa',
+    title: 'Classify post-write schematic QA results',
+    description:
+      'Run and classify post-write schematic QA after generated edits. Combines native DRC/ERC results ' +
+      'with policy-aware classification so duplicate net names, free networks, and unconnected pins are ' +
+      'reported as pass/fail/inconclusive instead of raw warning counts.',
+    profile: 'core',
+    evidence: ['runtime-probe', 'inferred'],
+    risk: 'medium',
+    confirmWrite: false,
+    group: 'drc-erc',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+    },
+    inputSchema: z.object({
+      projectId: z.string(),
+      policy: z.enum(['circuit', 'diagnostic-fixture']).default('circuit'),
+      useNativeChecks: z.boolean().default(true),
+      manualDrcMessages: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Optional user-copied EasyEDA DRC log lines for classification when native details are unavailable',
+        ),
+      manualErcMessages: z
+        .array(z.string())
+        .optional()
+        .describe(
+          'Optional user-copied EasyEDA ERC log lines for classification when native details are unavailable',
+        ),
+      drc: qaRunOverrideSchema
+        .optional()
+        .describe('Optional explicit DRC result override for tests or log ingestion'),
+      erc: qaRunOverrideSchema
+        .optional()
+        .describe('Optional explicit ERC result override for tests or log ingestion'),
+    }),
+    outputSchema: z.object({
+      project_id: z.string(),
+      status: z.enum(['pass', 'fail', 'inconclusive']),
+      passed: z.boolean(),
+      policy: z.enum(['circuit', 'diagnostic-fixture']),
+      issue_count: z.number().int().nonnegative(),
+      fatal_count: z.number().int().nonnegative(),
+      warning_count: z.number().int().nonnegative(),
+      inconclusive_count: z.number().int().nonnegative(),
+      categories: z.record(z.string(), z.number().int().nonnegative()),
+      issues: z.array(
+        z.object({
+          source: z.enum(['drc', 'erc', 'layout', 'manual-log']),
+          category: z.string(),
+          severity: z.enum(['error', 'warning', 'info']),
+          fatal: z.boolean(),
+          message: z.string(),
+          rule: z.string().optional(),
+          net: z.string().optional(),
+          component: z.string().optional(),
+          remediation_hint: z.string(),
+        }),
+      ),
+      summary: z.string(),
+      detail_source: z.enum(['native', 'manual', 'override', 'mixed']).optional(),
+    }),
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const p = z
+        .object({
+          projectId: z.string(),
+          policy: z.enum(['circuit', 'diagnostic-fixture']).default('circuit'),
+          useNativeChecks: z.boolean().default(true),
+          manualDrcMessages: z.array(z.string()).optional(),
+          manualErcMessages: z.array(z.string()).optional(),
+          drc: qaRunOverrideSchema.optional(),
+          erc: qaRunOverrideSchema.optional(),
+        })
+        .parse(params ?? {});
+
+      const manualDrc = p.manualDrcMessages?.map((description) => ({
+        description,
+        severity: 'warning' as const,
+      }));
+      const manualErc = p.manualErcMessages?.map((description) => ({
+        description,
+        severity: 'warning' as const,
+      }));
+      let drc =
+        p.drc ??
+        (manualDrc ? { violations: manualDrc, total_violations: manualDrc.length } : undefined);
+      let erc =
+        p.erc ??
+        (manualErc ? { violations: manualErc, total_violations: manualErc.length } : undefined);
+      let nativeUsed = false;
+
+      if (p.useNativeChecks) {
+        if (!drc) {
+          try {
+            const result = (await ctx.bridge.call('design.drc', { projectId: p.projectId })) as {
+              violations?: Array<{
+                rule?: string;
+                description?: string;
+                severity?: string;
+                net?: string;
+                component?: string;
+              }>;
+              totalViolations?: number;
+              errorCount?: number;
+              warningCount?: number;
+            };
+            drc = {
+              violations: result.violations?.map((v) => ({
+                ...v,
+                severity:
+                  v.severity === 'error' || v.severity === 'warning' || v.severity === 'info'
+                    ? v.severity
+                    : undefined,
+              })),
+              total_violations: result.totalViolations,
+              error_count: result.errorCount,
+              warning_count: result.warningCount,
+            };
+            nativeUsed = true;
+          } catch (err) {
+            drc = { not_available: true, error: err instanceof Error ? err.message : String(err) };
+          }
+        }
+        if (!erc) {
+          try {
+            const result = (await ctx.bridge.call('design.erc', { projectId: p.projectId })) as {
+              violations?: Array<{
+                description?: string;
+                severity?: string;
+                net?: string;
+                component?: string;
+              }>;
+              totalViolations?: number;
+              errorCount?: number;
+              warningCount?: number;
+              inferredFloatingPins?: Array<{
+                primitiveId?: string;
+                designator?: string;
+                pinNumber?: string;
+              }>;
+            };
+            erc = {
+              violations: result.violations?.map((v) => ({
+                ...v,
+                severity:
+                  v.severity === 'error' || v.severity === 'warning' || v.severity === 'info'
+                    ? v.severity
+                    : undefined,
+              })),
+              total_violations: result.totalViolations,
+              error_count: result.errorCount,
+              warning_count: result.warningCount,
+              inferred_floating_pins: result.inferredFloatingPins,
+            };
+            nativeUsed = true;
+          } catch (err) {
+            erc = { not_available: true, error: err instanceof Error ? err.message : String(err) };
+          }
+        }
+      }
+
+      const summary = classifyPostWriteQa({ projectId: p.projectId, policy: p.policy, drc, erc });
+      const hasManual = Boolean(p.manualDrcMessages?.length || p.manualErcMessages?.length);
+      const hasOverride = Boolean(p.drc || p.erc);
+      return {
+        ...summary,
+        detail_source:
+          [nativeUsed, hasManual, hasOverride].filter(Boolean).length > 1
+            ? 'mixed'
+            : nativeUsed
+              ? 'native'
+              : hasManual
+                ? 'manual'
+                : hasOverride
+                  ? 'override'
+                  : undefined,
       };
     },
   });

--- a/src/workflows/schematic-post-write-qa.ts
+++ b/src/workflows/schematic-post-write-qa.ts
@@ -1,0 +1,265 @@
+export type QaSource = 'drc' | 'erc' | 'layout' | 'manual-log';
+
+export type QaSeverity = 'error' | 'warning' | 'info';
+
+export type QaCategory =
+  | 'duplicate_net_names'
+  | 'free_network_no_pins'
+  | 'unconnected_pin'
+  | 'native_drc_unavailable'
+  | 'native_erc_unavailable'
+  | 'native_rule_violation'
+  | 'uncategorized';
+
+export type QaPolicy = 'circuit' | 'diagnostic-fixture';
+
+export type QaStatus = 'pass' | 'fail' | 'inconclusive';
+
+export interface NativeRuleViolationInput {
+  rule?: string;
+  description?: string;
+  message?: string;
+  severity?: string;
+  net?: string;
+  component?: string;
+}
+
+export interface NativeRuleRunInput {
+  not_available?: boolean;
+  error?: string;
+  violations?: NativeRuleViolationInput[];
+  total_violations?: number;
+  error_count?: number;
+  warning_count?: number;
+  passed?: boolean;
+  inferred_floating_pins?: Array<{ primitiveId?: string; designator?: string; pinNumber?: string }>;
+}
+
+export interface ClassifiedQaIssue {
+  source: QaSource;
+  category: QaCategory;
+  severity: QaSeverity;
+  fatal: boolean;
+  message: string;
+  rule?: string;
+  net?: string;
+  component?: string;
+  remediation_hint: string;
+}
+
+export interface PostWriteQaInput {
+  projectId: string;
+  policy?: QaPolicy;
+  drc?: NativeRuleRunInput;
+  erc?: NativeRuleRunInput;
+}
+
+export interface PostWriteQaSummary {
+  project_id: string;
+  status: QaStatus;
+  passed: boolean;
+  policy: QaPolicy;
+  issue_count: number;
+  fatal_count: number;
+  warning_count: number;
+  inconclusive_count: number;
+  categories: Record<QaCategory, number>;
+  issues: ClassifiedQaIssue[];
+  summary: string;
+}
+
+const CATEGORY_ZERO: Record<QaCategory, number> = {
+  duplicate_net_names: 0,
+  free_network_no_pins: 0,
+  unconnected_pin: 0,
+  native_drc_unavailable: 0,
+  native_erc_unavailable: 0,
+  native_rule_violation: 0,
+  uncategorized: 0,
+};
+
+function normalizeText(value: unknown): string {
+  return String(value ?? '').trim();
+}
+
+function classifyDescription(description: string): QaCategory {
+  const lower = description.toLowerCase();
+  if (lower.includes('multiple net names') || lower.includes('duplicate net'))
+    return 'duplicate_net_names';
+  if (lower.includes('free network') && lower.includes('no pins')) return 'free_network_no_pins';
+  if (lower.includes('no pins attached')) return 'free_network_no_pins';
+  if (lower.includes('unconnected') && lower.includes('pin')) return 'unconnected_pin';
+  if (lower.includes('floating') && lower.includes('pin')) return 'unconnected_pin';
+  return 'uncategorized';
+}
+
+function normalizeSeverity(value: string | undefined, fallback: QaSeverity): QaSeverity {
+  return value === 'error' || value === 'warning' || value === 'info' ? value : fallback;
+}
+
+function policyFatal(category: QaCategory, severity: QaSeverity, policy: QaPolicy): boolean {
+  if (category === 'duplicate_net_names') return true;
+  if (category === 'unconnected_pin') return true;
+  if (category === 'native_drc_unavailable' || category === 'native_erc_unavailable') return false;
+  if (category === 'free_network_no_pins') return policy === 'circuit';
+  return severity === 'error';
+}
+
+function remediationHint(category: QaCategory, policy: QaPolicy): string {
+  switch (category) {
+    case 'duplicate_net_names':
+      return 'Do not stamp the same native netName repeatedly on merged wire segments; seed the net once and continue same-net segments unlabeled.';
+    case 'free_network_no_pins':
+      return policy === 'diagnostic-fixture'
+        ? 'Allowed for diagnostic fixtures that intentionally draw wire-only nets. Real circuits must connect each named net to at least one component pin.'
+        : 'Connect the named net to component pins, or remove the orphan wire/net flag before accepting the generated circuit.';
+    case 'unconnected_pin':
+      return 'Connect the expected pin, mark it as intentional no-connect where valid, or update the circuit template connectivity expectations.';
+    case 'native_drc_unavailable':
+      return 'Native DRC details were not available from the EasyEDA runtime. Capture/manual DRC-log ingestion is required before accepting a production schematic.';
+    case 'native_erc_unavailable':
+      return 'Native ERC details were not available from the EasyEDA runtime. Capture/manual ERC-log ingestion is required before accepting a production schematic.';
+    case 'native_rule_violation':
+      return 'Inspect the native rule violation and update routing/layout or component placement before release.';
+    case 'uncategorized':
+      return 'Review the warning manually and add a classifier rule if this warning recurs in live testing.';
+  }
+}
+
+function pushNativeUnavailable(
+  issues: ClassifiedQaIssue[],
+  source: 'drc' | 'erc',
+  error: string | undefined,
+): void {
+  const category: QaCategory =
+    source === 'drc' ? 'native_drc_unavailable' : 'native_erc_unavailable';
+  issues.push({
+    source,
+    category,
+    severity: 'warning',
+    fatal: false,
+    message: error
+      ? `${source.toUpperCase()} unavailable: ${error}`
+      : `${source.toUpperCase()} unavailable`,
+    remediation_hint: remediationHint(category, 'circuit'),
+  });
+}
+
+function classifyViolation(
+  source: 'drc' | 'erc',
+  violation: NativeRuleViolationInput,
+  policy: QaPolicy,
+): ClassifiedQaIssue {
+  const description = normalizeText(
+    violation.description || violation.message || violation.rule || 'Rule violation',
+  );
+  const category = classifyDescription(description);
+  const severity = normalizeSeverity(
+    violation.severity,
+    category === 'uncategorized' ? 'warning' : 'error',
+  );
+  const normalizedCategory =
+    category === 'uncategorized' && severity === 'error' ? 'native_rule_violation' : category;
+  return {
+    source,
+    category: normalizedCategory,
+    severity,
+    fatal: policyFatal(normalizedCategory, severity, policy),
+    message: description,
+    rule: normalizeText(violation.rule) || undefined,
+    net: normalizeText(violation.net) || undefined,
+    component: normalizeText(violation.component) || undefined,
+    remediation_hint: remediationHint(normalizedCategory, policy),
+  };
+}
+
+function classifyNativeRun(
+  source: 'drc' | 'erc',
+  run: NativeRuleRunInput | undefined,
+  policy: QaPolicy,
+): ClassifiedQaIssue[] {
+  const issues: ClassifiedQaIssue[] = [];
+  if (!run) return issues;
+  if (run.not_available) {
+    pushNativeUnavailable(issues, source, run.error);
+    return issues;
+  }
+
+  for (const violation of run.violations ?? []) {
+    issues.push(classifyViolation(source, violation, policy));
+  }
+
+  if (source === 'erc') {
+    for (const pin of run.inferred_floating_pins ?? []) {
+      const designator = normalizeText(pin.designator) || 'unknown component';
+      const pinNumber = normalizeText(pin.pinNumber) || 'unknown pin';
+      const message = `Unconnected inferred pin ${designator}.${pinNumber}`;
+      const category: QaCategory = 'unconnected_pin';
+      issues.push({
+        source: 'erc',
+        category,
+        severity: 'error',
+        fatal: policyFatal(category, 'error', policy),
+        message,
+        component: designator,
+        remediation_hint: remediationHint(category, policy),
+      });
+    }
+  }
+
+  const total = run.total_violations ?? 0;
+  if (total > 0 && issues.length === 0) {
+    const category: QaCategory = 'native_rule_violation';
+    const severity: QaSeverity = (run.error_count ?? 0) > 0 ? 'error' : 'warning';
+    issues.push({
+      source,
+      category,
+      severity,
+      fatal: policyFatal(category, severity, policy),
+      message: `${source.toUpperCase()} reported ${total} violation(s), but detailed violations were not available.`,
+      remediation_hint: remediationHint(category, policy),
+    });
+  }
+
+  return issues;
+}
+
+export function classifyPostWriteQa(input: PostWriteQaInput): PostWriteQaSummary {
+  const policy = input.policy ?? 'circuit';
+  const issues = [
+    ...classifyNativeRun('drc', input.drc, policy),
+    ...classifyNativeRun('erc', input.erc, policy),
+  ];
+  const categories: Record<QaCategory, number> = { ...CATEGORY_ZERO };
+  for (const issue of issues) categories[issue.category] += 1;
+
+  const fatalCount = issues.filter((issue) => issue.fatal).length;
+  const inconclusiveCount = issues.filter(
+    (issue) =>
+      issue.category === 'native_drc_unavailable' || issue.category === 'native_erc_unavailable',
+  ).length;
+  const warningCount = issues.filter(
+    (issue) => issue.severity === 'warning' && !issue.fatal,
+  ).length;
+  const status: QaStatus =
+    fatalCount > 0 ? 'fail' : inconclusiveCount > 0 ? 'inconclusive' : 'pass';
+
+  return {
+    project_id: input.projectId,
+    status,
+    passed: status === 'pass',
+    policy,
+    issue_count: issues.length,
+    fatal_count: fatalCount,
+    warning_count: warningCount,
+    inconclusive_count: inconclusiveCount,
+    categories,
+    issues,
+    summary:
+      status === 'pass'
+        ? 'Post-write QA passed.'
+        : status === 'inconclusive'
+          ? 'Post-write QA is inconclusive because native rule details were unavailable.'
+          : `Post-write QA failed with ${fatalCount} fatal issue(s).`,
+  };
+}

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -39,14 +39,14 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for core', () => {
-    expect(PROFILE_DEFINITIONS.core.approxToolCount).toBe('61');
+    expect(PROFILE_DEFINITIONS.core.approxToolCount).toBe('62');
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('77');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('78');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('89');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('90');
   });
 });

--- a/tests/unit/tools/drc-erc.test.ts
+++ b/tests/unit/tools/drc-erc.test.ts
@@ -489,6 +489,75 @@ describe('DRC/ERC Tools', () => {
     expect(result?.overall_passed).toBe(true);
   });
 
+  it('easyeda_post_write_qa classifies manual DRC log lines without bridge calls', async () => {
+    const tool = registry.get('easyeda_post_write_qa');
+    expect(tool).toBeDefined();
+
+    const result = await tool?.handler(context, {
+      projectId: 'proj-qa',
+      useNativeChecks: false,
+      policy: 'circuit',
+      manualDrcMessages: ['Wire $1N4 has multiple net names: VCC VCC VCC'],
+    });
+
+    expect(bridgeCall).not.toHaveBeenCalled();
+    expect(result?.status).toBe('fail');
+    expect(result?.passed).toBe(false);
+    expect(result?.detail_source).toBe('manual');
+    expect(result?.categories.duplicate_net_names).toBe(1);
+  });
+
+  it('easyeda_post_write_qa uses native DRC/ERC and fails free networks for circuit policy', async () => {
+    const tool = registry.get('easyeda_post_write_qa');
+    expect(tool).toBeDefined();
+
+    bridgeCall
+      .mockResolvedValueOnce({
+        violations: [
+          {
+            description: 'The wire VCC $1N4 is a free network with no pins attached.',
+            severity: 'warning',
+            net: 'VCC',
+          },
+        ],
+        totalViolations: 1,
+        warningCount: 1,
+      })
+      .mockResolvedValueOnce({
+        violations: [],
+        totalViolations: 0,
+        errorCount: 0,
+        warningCount: 0,
+      });
+
+    const result = await tool?.handler(context, {
+      projectId: 'proj-qa',
+      policy: 'circuit',
+    });
+
+    expect(bridgeCall).toHaveBeenNthCalledWith(1, 'design.drc', { projectId: 'proj-qa' });
+    expect(bridgeCall).toHaveBeenNthCalledWith(2, 'design.erc', { projectId: 'proj-qa' });
+    expect(result?.status).toBe('fail');
+    expect(result?.detail_source).toBe('native');
+    expect(result?.categories.free_network_no_pins).toBe(1);
+    expect(result?.issues[0].fatal).toBe(true);
+  });
+
+  it('easyeda_post_write_qa reports inconclusive when native checks are unavailable', async () => {
+    const tool = registry.get('easyeda_post_write_qa');
+    expect(tool).toBeDefined();
+
+    bridgeCall.mockRejectedValue(new Error('native unavailable'));
+
+    const result = await tool?.handler(context, { projectId: 'proj-qa' });
+
+    expect(result?.status).toBe('inconclusive');
+    expect(result?.passed).toBe(false);
+    expect(result?.categories.native_drc_unavailable).toBe(1);
+    expect(result?.categories.native_erc_unavailable).toBe(1);
+    expect(result?.inconclusive_count).toBe(2);
+  });
+
   it('easyeda_drc_run handles bridge failure gracefully', async () => {
     const tool = registry.get('easyeda_drc_run');
     expect(tool).toBeDefined();

--- a/tests/unit/workflows/schematic-post-write-qa.test.ts
+++ b/tests/unit/workflows/schematic-post-write-qa.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it } from 'vitest';
+import { classifyPostWriteQa } from '../../../src/workflows/schematic-post-write-qa.js';
+
+describe('schematic post-write QA classifier', () => {
+  it('fails duplicate net-name DRC warnings even when reported as warning', () => {
+    const result = classifyPostWriteQa({
+      projectId: 'proj-qa',
+      drc: {
+        violations: [
+          {
+            rule: 'wire-net',
+            description: 'Wire $1N4 has multiple net names: VCC VCC VCC',
+            severity: 'warning',
+            net: 'VCC',
+          },
+        ],
+        total_violations: 1,
+        warning_count: 1,
+      },
+      erc: { violations: [], total_violations: 0, error_count: 0, warning_count: 0 },
+    });
+
+    expect(result.status).toBe('fail');
+    expect(result.passed).toBe(false);
+    expect(result.categories.duplicate_net_names).toBe(1);
+    expect(result.issues[0]).toMatchObject({
+      source: 'drc',
+      category: 'duplicate_net_names',
+      fatal: true,
+      net: 'VCC',
+    });
+  });
+
+  it('allows free wire-only networks for diagnostic fixtures', () => {
+    const result = classifyPostWriteQa({
+      projectId: 'fixture',
+      policy: 'diagnostic-fixture',
+      drc: {
+        violations: [
+          {
+            description: 'The wire GND $1N5 is a free network with no pins attached.',
+            severity: 'warning',
+            net: 'GND',
+          },
+        ],
+        total_violations: 1,
+        warning_count: 1,
+      },
+      erc: { violations: [], total_violations: 0, error_count: 0, warning_count: 0 },
+    });
+
+    expect(result.status).toBe('pass');
+    expect(result.passed).toBe(true);
+    expect(result.categories.free_network_no_pins).toBe(1);
+    expect(result.issues[0].fatal).toBe(false);
+  });
+
+  it('fails free wire-only networks for real circuit workflows', () => {
+    const result = classifyPostWriteQa({
+      projectId: 'circuit',
+      policy: 'circuit',
+      drc: {
+        violations: [
+          {
+            description: 'The wire VCC $1N4 is a free network with no pins attached.',
+            severity: 'warning',
+            net: 'VCC',
+          },
+        ],
+        total_violations: 1,
+        warning_count: 1,
+      },
+      erc: { violations: [], total_violations: 0, error_count: 0, warning_count: 0 },
+    });
+
+    expect(result.status).toBe('fail');
+    expect(result.categories.free_network_no_pins).toBe(1);
+    expect(result.issues[0].fatal).toBe(true);
+  });
+
+  it('fails inferred ERC floating pins', () => {
+    const result = classifyPostWriteQa({
+      projectId: 'proj-qa',
+      drc: { violations: [], total_violations: 0, error_count: 0, warning_count: 0 },
+      erc: {
+        violations: [],
+        total_violations: 1,
+        warning_count: 1,
+        inferred_floating_pins: [{ primitiveId: 'u1', designator: 'U1', pinNumber: '4' }],
+      },
+    });
+
+    expect(result.status).toBe('fail');
+    expect(result.categories.unconnected_pin).toBe(1);
+    expect(result.issues[0]).toMatchObject({
+      source: 'erc',
+      component: 'U1',
+      fatal: true,
+    });
+  });
+
+  it('returns inconclusive when native DRC is unavailable and no fatal issue exists', () => {
+    const result = classifyPostWriteQa({
+      projectId: 'proj-qa',
+      drc: { not_available: true, error: 'native DRC unavailable' },
+      erc: { violations: [], total_violations: 0, error_count: 0, warning_count: 0 },
+    });
+
+    expect(result.status).toBe('inconclusive');
+    expect(result.passed).toBe(false);
+    expect(result.categories.native_drc_unavailable).toBe(1);
+    expect(result.inconclusive_count).toBe(1);
+  });
+
+  it('passes a clean native DRC/ERC report', () => {
+    const result = classifyPostWriteQa({
+      projectId: 'proj-clean',
+      drc: { violations: [], total_violations: 0, error_count: 0, warning_count: 0 },
+      erc: { violations: [], total_violations: 0, error_count: 0, warning_count: 0 },
+    });
+
+    expect(result.status).toBe('pass');
+    expect(result.passed).toBe(true);
+    expect(result.issue_count).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

- add a policy-aware post-write schematic QA classifier
- add `easyeda_post_write_qa` to combine native DRC/ERC, manual log lines, and explicit override inputs into a pass/fail/inconclusive result
- classify live-debug categories from #244:
  - duplicate net names => fatal
  - free network/no pins => fatal for real circuit workflows, allowed for diagnostic fixtures
  - unconnected/floating pins => fatal
  - native DRC/ERC unavailable => inconclusive
- update profile counts and generated tool docs

Partially addresses #244.

## Why

Live EasyEDA testing showed that raw DRC warning counts are not enough. The diagnostic VCC/GND wire-only fixture legitimately produced `free network with no pins attached`, while real circuit generation should fail on the same warning. This PR makes that distinction explicit and machine-readable.

## Verification

- `pnpm test -- tests/unit/workflows/schematic-post-write-qa.test.ts tests/unit/tools/drc-erc.test.ts` — root suite completed: 96 files / 1153 tests
- `pnpm typecheck`
- `pnpm verify:tool-coverage`
- `pnpm test -- tests/unit/config/profiles.test.ts`
- `pnpm format:check`
- `pnpm lint`
- `pnpm lint:tools`
- `pnpm generate:tools-doc`
- `pnpm build`
- `pnpm docs:build`

## Follow-up

Remaining #244 work after this first classifier/tool PR:

- ingest EasyEDA DRC/ERC log panel details automatically when runtime APIs return only coarse counts
- add layout/title-block overlap QA using object bounding boxes and canvas capture
- wire this QA into high-level templates such as #245 NE555 astable generation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new post-write QA check that summarizes schematic DRC/ERC results into pass, fail, or inconclusive outcomes.
  * Expanded QA details with issue counts, categories, summaries, and result source tracking for native, manual, override, or mixed inputs.
  * Updated tool listings and profile counts to include the new capability.

* **Bug Fixes**
  * Improved handling when native checks are unavailable, including clearer inconclusive results.
  * Added coverage for duplicate nets, floating pins, and free-wire conditions across different QA policies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->