### PR TITLE
feat(workflows): add NE555 astable template

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -100,6 +100,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_workflow_connector_breakout`   | `pro`   | `medium` | Place a connector, wire each declared pin to its net, and create a net port for each net so the breakout is accessible off-sheet — all as a single atomic transaction (confirmWrite required).                                                                                                                                   |
 | `easyeda_workflow_decouple_ic`          | `pro`   | `medium` | Place one decoupling capacitor per declared IC power pin and wire each to the pin's net and ground, in a single atomic transaction. Cites design-rules decoupling guidance (rule-of-thumb, not datasheet-specific) alongside the plan (confirmWrite required).                                                                   |
 | `easyeda_workflow_layout_section`       | `pro`   | `medium` | Compute and create a section rectangle + title sized from the real pin extents of the given already-placed components (or replace an existing rectangle/title pair). Reports overlap with other rectangles and page-size overflow as warnings; never resizes the page.                                                           |
+| `easyeda_workflow_ne555_astable`        | `pro`   | `medium` | Create a deterministic NE555 astable LED flasher workflow using safe sheet-region planning, component-level layout offsets, explicit pin-to-net connectivity, and optional post-write QA. Caller supplies already-resolved EasyEDA device items; this tool does not guess catalog parts (confirmWrite required).                 |
 | `easyeda_workflow_place_block`          | `pro`   | `medium` | Place a group of components, wire their pin-to-net connections (new and/or pre-existing components), and create net ports for block-external nets — all as a single atomic transaction with rollback on partial failure (confirmWrite required).                                                                                 |
 | `easyeda_workflow_power_rail`           | `pro`   | `medium` | Place a regulator and its supporting passives and wire them to input/output/ground nets in a single atomic transaction, instead of one primitive call per component. Caller supplies already-resolved device items and pin connections; this tool does not select parts (confirmWrite required).                                 |
 
@@ -3186,6 +3187,57 @@ Returns a JSON object matching the schema:
   title_primitive_id: string (optional);
   deleted_primitive_ids: string[];
   error: string (optional);
+}
+```
+
+---
+
+## `easyeda_workflow_ne555_astable`
+
+**Profile:** `pro` | **Risk Level:** `medium`
+
+> Create a deterministic NE555 astable LED flasher workflow using safe sheet-region planning, component-level layout offsets, explicit pin-to-net connectivity, and optional post-write QA. Caller supplies already-resolved EasyEDA device items; this tool does not guess catalog parts (confirmWrite required).
+
+### Input Parameters
+
+| Parameter         | Type                 | Required       | Description   |
+| ----------------- | -------------------- | -------------- | ------------- |
+| `projectId`       | `string`             | Yes            |               |
+| `mode`            | `'preview'           | 'apply'`       | Yes           |               |
+| `devices`         | `object`             | Yes            |               |
+| `anchor`          | `object (optional)`  | No             |               |
+| `preferredRegion` | `'upper-left'        | 'upper-center' | 'upper-right' | 'center-left' | 'center' | 'center-right' | 'lower-left' | 'lower-center' | 'lower-right'` | Yes |     |
+| `margin`          | `number (optional)`  | No             |               |
+| `refs`            | `object (optional)`  | No             |               |
+| `nets`            | `object (optional)`  | No             |               |
+| `values`          | `object (optional)`  | No             |               |
+| `pinMaps`         | `object (optional)`  | No             |               |
+| `runPostWriteQa`  | `boolean`            | Yes            |               |
+| `confirmWrite`    | `boolean (optional)` | No             |               |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  success: boolean;
+  project_id: string;
+  transaction_id: string;
+  mode: string;
+  applied: boolean;
+  blocked: boolean;
+  rolled_back: boolean;
+  placements: object[];
+  operations: object[];
+  apply_results: object[] (optional);
+  issues: object[];
+  summary: string;
+  rollback_notes: string[];
+  error: string (optional);
+  safe_region: object;
+  design: object;
+  post_write_qa: object (optional);
 }
 ```
 

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -22,7 +22,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Pro',
     description:
       'Adds pick-and-place, PDF, netlist export, compound transactional workflow tools, autorouting, route-context export, and offline SPICE verification for manufacturing workflows',
-    approxToolCount: '78',
+    approxToolCount: '79',
     isDefault: false,
   },
   full: {
@@ -30,7 +30,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls and CircuitIR-driven floorplanning for full runtime control without raw JavaScript execution',
-    approxToolCount: '90',
+    approxToolCount: '91',
     isDefault: false,
   },
   dev: {
@@ -38,14 +38,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '95',
+    approxToolCount: '96',
     isDefault: false,
   },
   experimental: {
     name: 'experimental',
     label: 'Experimental',
     description: 'MCP Apps, Tasks, AI action plans',
-    approxToolCount: '95',
+    approxToolCount: '96',
     isDefault: false,
   },
 };

--- a/src/tools/L1_drc_erc.ts
+++ b/src/tools/L1_drc_erc.ts
@@ -10,7 +10,10 @@ import {
 } from '../net-validation/schema.js';
 import { classifyNetType, classifyPinElectricalType } from '../net-validation/pin-classifier.js';
 import { analyzePowerTree } from '../power-tree/index.js';
-import { classifyPostWriteQa } from '../workflows/schematic-post-write-qa.js';
+import {
+  classifyPostWriteQa,
+  collectNativeRuleRunsForPostWriteQa,
+} from '../workflows/schematic-post-write-qa.js';
 import { fetchComponentPins } from './schematic-helpers.js';
 
 /** Shared error/warning mapper for both the hand-authored and auto-extracted
@@ -876,73 +879,13 @@ function registerDrcErcTools(
       let nativeUsed = false;
 
       if (p.useNativeChecks) {
-        if (!drc) {
-          try {
-            const result = (await ctx.bridge.call('design.drc', { projectId: p.projectId })) as {
-              violations?: Array<{
-                rule?: string;
-                description?: string;
-                severity?: string;
-                net?: string;
-                component?: string;
-              }>;
-              totalViolations?: number;
-              errorCount?: number;
-              warningCount?: number;
-            };
-            drc = {
-              violations: result.violations?.map((v) => ({
-                ...v,
-                severity:
-                  v.severity === 'error' || v.severity === 'warning' || v.severity === 'info'
-                    ? v.severity
-                    : undefined,
-              })),
-              total_violations: result.totalViolations,
-              error_count: result.errorCount,
-              warning_count: result.warningCount,
-            };
-            nativeUsed = true;
-          } catch (err) {
-            drc = { not_available: true, error: err instanceof Error ? err.message : String(err) };
-          }
-        }
-        if (!erc) {
-          try {
-            const result = (await ctx.bridge.call('design.erc', { projectId: p.projectId })) as {
-              violations?: Array<{
-                description?: string;
-                severity?: string;
-                net?: string;
-                component?: string;
-              }>;
-              totalViolations?: number;
-              errorCount?: number;
-              warningCount?: number;
-              inferredFloatingPins?: Array<{
-                primitiveId?: string;
-                designator?: string;
-                pinNumber?: string;
-              }>;
-            };
-            erc = {
-              violations: result.violations?.map((v) => ({
-                ...v,
-                severity:
-                  v.severity === 'error' || v.severity === 'warning' || v.severity === 'info'
-                    ? v.severity
-                    : undefined,
-              })),
-              total_violations: result.totalViolations,
-              error_count: result.errorCount,
-              warning_count: result.warningCount,
-              inferred_floating_pins: result.inferredFloatingPins,
-            };
-            nativeUsed = true;
-          } catch (err) {
-            erc = { not_available: true, error: err instanceof Error ? err.message : String(err) };
-          }
-        }
+        const native = await collectNativeRuleRunsForPostWriteQa(ctx.bridge, p.projectId, {
+          drc: !drc,
+          erc: !erc,
+        });
+        if (!drc) drc = native.drc;
+        if (!erc) erc = native.erc;
+        nativeUsed = Boolean(native.drc || native.erc);
       }
 
       const summary = classifyPostWriteQa({ projectId: p.projectId, policy: p.policy, drc, erc });

--- a/src/tools/L2_workflows.ts
+++ b/src/tools/L2_workflows.ts
@@ -4,6 +4,11 @@ import { type EnvConfig } from '../config/env.js';
 import { planWorkflowBlock } from '../workflows/planner.js';
 import { reconcilePlacementCollisions } from '../workflows/collision.js';
 import {
+  classifyPostWriteQa,
+  collectNativeRuleRunsForPostWriteQa,
+} from '../workflows/schematic-post-write-qa.js';
+import { buildNe555AstableTemplate } from '../workflows/ne555-astable-template.js';
+import {
   computeSectionBounds,
   findOverlappingRectangles,
   checkAgainstPageFrame,
@@ -39,6 +44,10 @@ const componentInputSchema = z.object({
   rotation: z.number().optional(),
   mirror: z.boolean().optional(),
   subPartName: z.string().optional(),
+  placementOffset: z
+    .object({ dx: z.number(), dy: z.number() })
+    .optional()
+    .describe('Optional offset from workflow anchor for grid/layout-aware templates.'),
   pinConnections: z.array(pinConnectionSchema).default([]),
 });
 
@@ -319,6 +328,158 @@ const verifyRailInputSchema = z.object({
 
 type VerifyRailInput = z.infer<typeof verifyRailInputSchema>;
 
+const schematicRegionPreferenceSchema = z.enum([
+  'upper-left',
+  'upper-center',
+  'upper-right',
+  'center-left',
+  'center',
+  'center-right',
+  'lower-left',
+  'lower-center',
+  'lower-right',
+]);
+
+const ne555DevicesSchema = z.object({
+  timer: deviceItemSchema,
+  resistor: deviceItemSchema,
+  timingCapacitor: deviceItemSchema,
+  bypassCapacitor: deviceItemSchema,
+  led: deviceItemSchema,
+});
+
+const ne555RefsSchema = z
+  .object({
+    timer: z.string().min(1).optional(),
+    r1: z.string().min(1).optional(),
+    r2: z.string().min(1).optional(),
+    cTiming: z.string().min(1).optional(),
+    cCtrl: z.string().min(1).optional(),
+    cDecouple: z.string().min(1).optional(),
+    rLed: z.string().min(1).optional(),
+    led: z.string().min(1).optional(),
+  })
+  .optional();
+
+const ne555NetsSchema = z
+  .object({
+    vcc: z.string().min(1).optional(),
+    gnd: z.string().min(1).optional(),
+    timing: z.string().min(1).optional(),
+    discharge: z.string().min(1).optional(),
+    control: z.string().min(1).optional(),
+    output: z.string().min(1).optional(),
+    ledAnode: z.string().min(1).optional(),
+  })
+  .optional();
+
+const ne555ValuesSchema = z
+  .object({
+    supplyVoltage: z.number().positive().optional(),
+    r1Ohms: z.number().positive().optional(),
+    r2Ohms: z.number().positive().optional(),
+    timingCapacitanceUf: z.number().positive().optional(),
+    controlCapacitanceNf: z.number().positive().optional(),
+    decouplingCapacitanceNf: z.number().positive().optional(),
+    ledSeriesOhms: z.number().positive().optional(),
+  })
+  .optional();
+
+const ne555PinMapsSchema = z
+  .object({
+    timer: z
+      .object({
+        gnd: z.string().min(1).optional(),
+        trig: z.string().min(1).optional(),
+        out: z.string().min(1).optional(),
+        reset: z.string().min(1).optional(),
+        ctrl: z.string().min(1).optional(),
+        thresh: z.string().min(1).optional(),
+        disch: z.string().min(1).optional(),
+        vcc: z.string().min(1).optional(),
+      })
+      .optional(),
+    resistor: z
+      .object({ p1: z.string().min(1).optional(), p2: z.string().min(1).optional() })
+      .optional(),
+    capacitor: z
+      .object({ p1: z.string().min(1).optional(), p2: z.string().min(1).optional() })
+      .optional(),
+    led: z
+      .object({ anode: z.string().min(1).optional(), cathode: z.string().min(1).optional() })
+      .optional(),
+  })
+  .optional();
+
+const ne555InputSchema = z.object({
+  projectId: z.string().min(1),
+  mode: z.enum(['preview', 'apply']).default('preview'),
+  devices: ne555DevicesSchema,
+  anchor: pointSchema.optional(),
+  preferredRegion: schematicRegionPreferenceSchema.default('upper-left'),
+  margin: z.number().positive().optional(),
+  refs: ne555RefsSchema,
+  nets: ne555NetsSchema,
+  values: ne555ValuesSchema,
+  pinMaps: ne555PinMapsSchema,
+  runPostWriteQa: z.boolean().default(true),
+  confirmWrite: z.boolean().optional(),
+});
+
+const safeRegionOutputSchema = z.object({
+  blocked: z.boolean(),
+  preferred_region: z.string(),
+  sheet: z.object({
+    width: z.number(),
+    height: z.number(),
+    unit: z.string(),
+    origin: z.string(),
+    source: z.string(),
+  }),
+  bounds: z.object({ x: z.number(), y: z.number(), width: z.number(), height: z.number() }),
+  anchor: z.object({ x: z.number(), y: z.number() }),
+  warnings: z.array(z.string()),
+  issues: z.array(z.object({ code: z.string(), message: z.string() })),
+});
+
+const postWriteQaOutputSchema = z.object({
+  project_id: z.string(),
+  status: z.enum(['pass', 'fail', 'inconclusive']),
+  passed: z.boolean(),
+  policy: z.string(),
+  issue_count: z.number().int().nonnegative(),
+  fatal_count: z.number().int().nonnegative(),
+  warning_count: z.number().int().nonnegative(),
+  inconclusive_count: z.number().int().nonnegative(),
+  categories: z.record(z.string(), z.number().int().nonnegative()),
+  issues: z.array(z.record(z.string(), z.unknown())),
+  summary: z.string(),
+});
+
+const ne555OutputSchema = workflowOutputSchema.extend({
+  safe_region: safeRegionOutputSchema,
+  design: z.object({
+    refs: z.record(z.string(), z.string()),
+    nets: z.record(z.string(), z.string()),
+    values: z.record(z.string(), z.number()),
+    calculated: z.object({
+      frequency_hz: z.number(),
+      period_seconds: z.number(),
+      high_time_seconds: z.number(),
+      low_time_seconds: z.number(),
+      duty_cycle_percent: z.number(),
+    }),
+    component_count: z.number().int().positive(),
+    notes: z.array(z.string()),
+  }),
+  post_write_qa: postWriteQaOutputSchema.optional(),
+});
+
+async function runPostWriteQa(ctx: ToolContext, projectId: string) {
+  const { drc, erc } = await collectNativeRuleRunsForPostWriteQa(ctx.bridge, projectId);
+  return classifyPostWriteQa({ projectId, policy: 'circuit', drc, erc });
+}
+
 const railVerificationOutputSchema = z.object({
   available: z.boolean(),
   ngspice_version: z.string().optional(),
@@ -472,6 +633,103 @@ function registerWorkflowTools(
   registry: { register: (def: ToolDefinition) => void },
   _config: EnvConfig,
 ) {
+  registry.register({
+    name: 'easyeda_workflow_ne555_astable',
+    title: 'Plan or apply a professional NE555 astable LED flasher template',
+    description:
+      'Create a deterministic NE555 astable LED flasher workflow using safe sheet-region planning, ' +
+      'component-level layout offsets, explicit pin-to-net connectivity, and optional post-write QA. ' +
+      'Caller supplies already-resolved EasyEDA device items; this tool does not guess catalog parts (confirmWrite required).',
+    profile: 'pro',
+    evidence: ['inferred', 'runtime-probe'],
+    risk: 'medium',
+    confirmWrite: true,
+    group: 'workflows',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
+    inputSchema: ne555InputSchema,
+    outputSchema: ne555OutputSchema,
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const p = ne555InputSchema.parse(params ?? {});
+      let sheetInfo: unknown;
+      try {
+        sheetInfo = await ctx.bridge.call('schematic.getSheetInfo', { projectId: p.projectId });
+      } catch {
+        sheetInfo = undefined;
+      }
+
+      const template = buildNe555AstableTemplate({ ...p, sheetInfo });
+      const result = (await runWorkflow(
+        ctx,
+        template.workflowInput,
+        'wf_ne555_astable',
+        p.confirmWrite,
+        (plan) => {
+          for (const warning of template.safeRegion.warnings) {
+            pushIssue(plan, {
+              code: 'WORKFLOW_SAFE_REGION',
+              severity: 'warning',
+              message: warning,
+              remediationHint:
+                'Review the returned safe_region bounds and use its anchor before applying the template.',
+            });
+          }
+          for (const issue of template.safeRegion.issues) {
+            pushIssue(plan, {
+              code: 'WORKFLOW_SAFE_REGION',
+              severity: 'error',
+              message: `${issue.code}: ${issue.message}`,
+              remediationHint:
+                'Reduce content size, choose another preferredRegion, increase the sheet size manually, or provide a safe anchor.',
+            });
+          }
+        },
+      )) as Record<string, unknown>;
+
+      let postWriteQa;
+      if (result.applied === true && p.runPostWriteQa) {
+        postWriteQa = await runPostWriteQa(ctx, p.projectId);
+      }
+
+      const qaFailed = Boolean(postWriteQa && postWriteQa.status !== 'pass');
+      return {
+        ...result,
+        success: Boolean(result.success) && !qaFailed,
+        summary: qaFailed
+          ? `${String(result.summary)} Post-write QA ${postWriteQa?.status}: ${postWriteQa?.summary}`
+          : result.summary,
+        safe_region: {
+          blocked: template.safeRegion.blocked,
+          preferred_region: template.safeRegion.preferredRegion,
+          sheet: template.safeRegion.sheet,
+          bounds: template.safeRegion.bounds,
+          anchor: template.workflowInput.anchor,
+          warnings: template.safeRegion.warnings,
+          issues: template.safeRegion.issues,
+        },
+        design: {
+          refs: template.refs,
+          nets: template.nets,
+          values: template.values,
+          calculated: {
+            frequency_hz: template.calculated.frequencyHz,
+            period_seconds: template.calculated.periodSeconds,
+            high_time_seconds: template.calculated.highTimeSeconds,
+            low_time_seconds: template.calculated.lowTimeSeconds,
+            duty_cycle_percent: template.calculated.dutyCyclePercent,
+          },
+          component_count: template.componentCount,
+          notes: template.designNotes,
+        },
+        post_write_qa: postWriteQa,
+      };
+    },
+  });
+
   registry.register({
     name: 'easyeda_workflow_power_rail',
     title: 'Plan or apply a power rail (regulator + passives) as one transaction',

--- a/src/workflows/ne555-astable-template.ts
+++ b/src/workflows/ne555-astable-template.ts
@@ -1,0 +1,330 @@
+import {
+  planSafeSchematicRegion,
+  type SchematicRegionPreference,
+} from './schematic-safe-region.js';
+import type { WorkflowBlockInput, WorkflowDeviceItem } from './types.js';
+
+export interface TwoPinMap {
+  p1: string;
+  p2: string;
+}
+
+export interface Ne555TimerPinMap {
+  gnd: string;
+  trig: string;
+  out: string;
+  reset: string;
+  ctrl: string;
+  thresh: string;
+  disch: string;
+  vcc: string;
+}
+
+export interface Ne555AstableDevices {
+  timer: WorkflowDeviceItem;
+  resistor: WorkflowDeviceItem;
+  timingCapacitor: WorkflowDeviceItem;
+  bypassCapacitor: WorkflowDeviceItem;
+  led: WorkflowDeviceItem;
+}
+
+export interface Ne555AstableRefs {
+  timer: string;
+  r1: string;
+  r2: string;
+  cTiming: string;
+  cCtrl: string;
+  cDecouple: string;
+  rLed: string;
+  led: string;
+}
+
+export interface Ne555AstableNets {
+  vcc: string;
+  gnd: string;
+  timing: string;
+  discharge: string;
+  control: string;
+  output: string;
+  ledAnode: string;
+}
+
+export interface Ne555AstableValues {
+  supplyVoltage: number;
+  r1Ohms: number;
+  r2Ohms: number;
+  timingCapacitanceUf: number;
+  controlCapacitanceNf: number;
+  decouplingCapacitanceNf: number;
+  ledSeriesOhms: number;
+}
+
+export interface Ne555AstablePinMaps {
+  timer: Ne555TimerPinMap;
+  resistor: TwoPinMap;
+  capacitor: TwoPinMap;
+  led: { anode: string; cathode: string };
+}
+
+export interface Ne555AstableTemplateInput {
+  projectId: string;
+  mode?: 'preview' | 'apply';
+  devices: Ne555AstableDevices;
+  anchor?: { x: number; y: number };
+  sheetInfo?: unknown;
+  preferredRegion?: SchematicRegionPreference;
+  margin?: number;
+  refs?: Partial<Ne555AstableRefs>;
+  nets?: Partial<Ne555AstableNets>;
+  values?: Partial<Ne555AstableValues>;
+  pinMaps?: Partial<{
+    timer: Partial<Ne555TimerPinMap>;
+    resistor: Partial<TwoPinMap>;
+    capacitor: Partial<TwoPinMap>;
+    led: Partial<{ anode: string; cathode: string }>;
+  }>;
+}
+
+export interface Ne555AstableTemplatePlan {
+  workflowInput: WorkflowBlockInput;
+  safeRegion: ReturnType<typeof planSafeSchematicRegion>;
+  refs: Ne555AstableRefs;
+  nets: Ne555AstableNets;
+  values: Ne555AstableValues;
+  pinMaps: Ne555AstablePinMaps;
+  calculated: {
+    frequencyHz: number;
+    periodSeconds: number;
+    highTimeSeconds: number;
+    lowTimeSeconds: number;
+    dutyCyclePercent: number;
+  };
+  designNotes: string[];
+  componentCount: number;
+}
+
+export const NE555_ASTABLE_CONTENT = {
+  width: 620,
+  height: 360,
+} as const;
+
+const DEFAULT_REFS: Ne555AstableRefs = {
+  timer: 'U1',
+  r1: 'R1',
+  r2: 'R2',
+  cTiming: 'C1',
+  cCtrl: 'C2',
+  cDecouple: 'C3',
+  rLed: 'R3',
+  led: 'D1',
+};
+
+const DEFAULT_NETS: Ne555AstableNets = {
+  vcc: '+5V',
+  gnd: 'GND',
+  timing: 'TIMING',
+  discharge: 'DISCH',
+  control: 'CTRL',
+  output: 'OUT',
+  ledAnode: 'LED_A',
+};
+
+const DEFAULT_VALUES: Ne555AstableValues = {
+  supplyVoltage: 5,
+  r1Ohms: 1000,
+  r2Ohms: 68000,
+  timingCapacitanceUf: 10,
+  controlCapacitanceNf: 10,
+  decouplingCapacitanceNf: 100,
+  ledSeriesOhms: 330,
+};
+
+const DEFAULT_PIN_MAPS: Ne555AstablePinMaps = {
+  timer: {
+    gnd: '1',
+    trig: '2',
+    out: '3',
+    reset: '4',
+    ctrl: '5',
+    thresh: '6',
+    disch: '7',
+    vcc: '8',
+  },
+  resistor: { p1: '1', p2: '2' },
+  capacitor: { p1: '1', p2: '2' },
+  led: { anode: '1', cathode: '2' },
+};
+
+function round(value: number, digits: number): number {
+  const scale = 10 ** digits;
+  return Math.round(value * scale) / scale;
+}
+
+export function calculateNe555Astable(values: Ne555AstableValues) {
+  const capacitanceF = values.timingCapacitanceUf * 1e-6;
+  const highTimeSeconds = 0.693 * (values.r1Ohms + values.r2Ohms) * capacitanceF;
+  const lowTimeSeconds = 0.693 * values.r2Ohms * capacitanceF;
+  const periodSeconds = highTimeSeconds + lowTimeSeconds;
+  const frequencyHz = periodSeconds > 0 ? 1 / periodSeconds : 0;
+  const dutyCyclePercent = periodSeconds > 0 ? (highTimeSeconds / periodSeconds) * 100 : 0;
+  return {
+    frequencyHz: round(frequencyHz, 3),
+    periodSeconds: round(periodSeconds, 3),
+    highTimeSeconds: round(highTimeSeconds, 3),
+    lowTimeSeconds: round(lowTimeSeconds, 3),
+    dutyCyclePercent: round(dutyCyclePercent, 1),
+  };
+}
+
+function mergePinMaps(input?: Ne555AstableTemplateInput['pinMaps']): Ne555AstablePinMaps {
+  return {
+    timer: input?.timer ? { ...DEFAULT_PIN_MAPS.timer, ...input.timer } : DEFAULT_PIN_MAPS.timer,
+    resistor: input?.resistor
+      ? { ...DEFAULT_PIN_MAPS.resistor, ...input.resistor }
+      : DEFAULT_PIN_MAPS.resistor,
+    capacitor: input?.capacitor
+      ? { ...DEFAULT_PIN_MAPS.capacitor, ...input.capacitor }
+      : DEFAULT_PIN_MAPS.capacitor,
+    led: input?.led ? { ...DEFAULT_PIN_MAPS.led, ...input.led } : DEFAULT_PIN_MAPS.led,
+  };
+}
+
+export function buildNe555AstableTemplate(
+  input: Ne555AstableTemplateInput,
+): Ne555AstableTemplatePlan {
+  const refs = input.refs ? { ...DEFAULT_REFS, ...input.refs } : DEFAULT_REFS;
+  const nets = input.nets ? { ...DEFAULT_NETS, ...input.nets } : DEFAULT_NETS;
+  const values = input.values ? { ...DEFAULT_VALUES, ...input.values } : DEFAULT_VALUES;
+  const pinMaps = mergePinMaps(input.pinMaps);
+  const safeRegion = planSafeSchematicRegion({
+    sheetInfo: input.sheetInfo,
+    contentWidth: NE555_ASTABLE_CONTENT.width,
+    contentHeight: NE555_ASTABLE_CONTENT.height,
+    preferredRegion: input.preferredRegion ?? 'upper-left',
+    margin: input.margin,
+  });
+  const anchor = input.anchor ?? safeRegion.anchor;
+
+  const components: NonNullable<WorkflowBlockInput['components']> = [
+    {
+      ref: refs.timer,
+      role: 'ne555-timer',
+      deviceItem: input.devices.timer,
+      placementOffset: { dx: 280, dy: -150 },
+      pinConnections: [
+        { pin: pinMaps.timer.gnd, netName: nets.gnd },
+        { pin: pinMaps.timer.trig, netName: nets.timing },
+        { pin: pinMaps.timer.out, netName: nets.output },
+        { pin: pinMaps.timer.reset, netName: nets.vcc },
+        { pin: pinMaps.timer.ctrl, netName: nets.control },
+        { pin: pinMaps.timer.thresh, netName: nets.timing },
+        { pin: pinMaps.timer.disch, netName: nets.discharge },
+        { pin: pinMaps.timer.vcc, netName: nets.vcc },
+      ],
+    },
+    {
+      ref: refs.r1,
+      role: `timing-resistor-r1-${values.r1Ohms}ohm`,
+      deviceItem: input.devices.resistor,
+      placementOffset: { dx: 120, dy: -70 },
+      pinConnections: [
+        { pin: pinMaps.resistor.p1, netName: nets.vcc },
+        { pin: pinMaps.resistor.p2, netName: nets.discharge },
+      ],
+    },
+    {
+      ref: refs.r2,
+      role: `timing-resistor-r2-${values.r2Ohms}ohm`,
+      deviceItem: input.devices.resistor,
+      placementOffset: { dx: 120, dy: -155 },
+      pinConnections: [
+        { pin: pinMaps.resistor.p1, netName: nets.discharge },
+        { pin: pinMaps.resistor.p2, netName: nets.timing },
+      ],
+    },
+    {
+      ref: refs.cTiming,
+      role: `timing-capacitor-${values.timingCapacitanceUf}uf`,
+      deviceItem: input.devices.timingCapacitor,
+      placementOffset: { dx: 120, dy: -250 },
+      pinConnections: [
+        { pin: pinMaps.capacitor.p1, netName: nets.timing },
+        { pin: pinMaps.capacitor.p2, netName: nets.gnd },
+      ],
+    },
+    {
+      ref: refs.cCtrl,
+      role: `control-bypass-${values.controlCapacitanceNf}nf`,
+      deviceItem: input.devices.bypassCapacitor,
+      placementOffset: { dx: 390, dy: -245 },
+      pinConnections: [
+        { pin: pinMaps.capacitor.p1, netName: nets.control },
+        { pin: pinMaps.capacitor.p2, netName: nets.gnd },
+      ],
+    },
+    {
+      ref: refs.cDecouple,
+      role: `supply-decoupling-${values.decouplingCapacitanceNf}nf`,
+      deviceItem: input.devices.bypassCapacitor,
+      placementOffset: { dx: 390, dy: -65 },
+      pinConnections: [
+        { pin: pinMaps.capacitor.p1, netName: nets.vcc },
+        { pin: pinMaps.capacitor.p2, netName: nets.gnd },
+      ],
+    },
+    {
+      ref: refs.rLed,
+      role: `led-series-resistor-${values.ledSeriesOhms}ohm`,
+      deviceItem: input.devices.resistor,
+      placementOffset: { dx: 470, dy: -150 },
+      pinConnections: [
+        { pin: pinMaps.resistor.p1, netName: nets.output },
+        { pin: pinMaps.resistor.p2, netName: nets.ledAnode },
+      ],
+    },
+    {
+      ref: refs.led,
+      role: 'output-led-indicator',
+      deviceItem: input.devices.led,
+      placementOffset: { dx: 560, dy: -150 },
+      pinConnections: [
+        { pin: pinMaps.led.anode, netName: nets.ledAnode },
+        { pin: pinMaps.led.cathode, netName: nets.gnd },
+      ],
+    },
+  ];
+
+  const workflowInput: WorkflowBlockInput = {
+    projectId: input.projectId,
+    mode: input.mode ?? 'preview',
+    anchor,
+    spacing: 70,
+    components,
+    netPortAnchor: { x: anchor.x, y: anchor.y - 20 },
+    netPorts: [
+      { netName: nets.vcc, portType: 'input' },
+      { netName: nets.gnd, portType: 'passive' },
+      { netName: nets.output, portType: 'output' },
+      { netName: nets.timing, portType: 'passive' },
+      { netName: nets.discharge, portType: 'passive' },
+      { netName: nets.control, portType: 'passive' },
+    ],
+  };
+
+  return {
+    workflowInput,
+    safeRegion,
+    refs,
+    nets,
+    values,
+    pinMaps,
+    calculated: calculateNe555Astable(values),
+    componentCount: components.length,
+    designNotes: [
+      'NE555 astable LED flasher: U1 is centered, timing network is left, decoupling/control bypass are near U1, and output LED chain is right.',
+      'Pin 2 TRIG and pin 6 THRESH are tied to the timing node; pin 7 DISCH is between R1 and R2.',
+      'Pin 4 RESET is tied to VCC; pin 5 CTRL is bypassed to GND; C3 is a local VCC/GND decoupling capacitor.',
+      'Use post-write QA with circuit policy after apply; duplicate net names, free wire-only nets, and floating pins are blocking failures.',
+    ],
+  };
+}

--- a/src/workflows/planner.ts
+++ b/src/workflows/planner.ts
@@ -162,8 +162,14 @@ export function planWorkflowBlock(
   const placements: WorkflowPlannedComponent[] = components.map((component, index) => ({
     ref: component.ref,
     role: component.role,
-    x: input.anchor.x + index * spacing,
-    y: input.anchor.y,
+    x:
+      component.placementOffset !== undefined
+        ? input.anchor.x + component.placementOffset.dx
+        : input.anchor.x + index * spacing,
+    y:
+      component.placementOffset !== undefined
+        ? input.anchor.y + component.placementOffset.dy
+        : input.anchor.y,
   }));
 
   const operations: WorkflowOperation[] = [];

--- a/src/workflows/schematic-post-write-qa.ts
+++ b/src/workflows/schematic-post-write-qa.ts
@@ -19,7 +19,7 @@ export interface NativeRuleViolationInput {
   rule?: string;
   description?: string;
   message?: string;
-  severity?: string;
+  severity?: QaSeverity;
   net?: string;
   component?: string;
 }
@@ -222,6 +222,91 @@ function classifyNativeRun(
   }
 
   return issues;
+}
+
+export interface NativeQaBridge {
+  call<TParams = Record<string, unknown>, TResult = unknown>(
+    method: string,
+    params?: TParams,
+  ): Promise<TResult>;
+}
+
+function normalizeRuleSeverity(severity: string | undefined): QaSeverity | undefined {
+  return severity === 'error' || severity === 'warning' || severity === 'info'
+    ? severity
+    : undefined;
+}
+
+export async function collectNativeRuleRunsForPostWriteQa(
+  bridge: NativeQaBridge,
+  projectId: string,
+  options: { drc?: boolean; erc?: boolean } = { drc: true, erc: true },
+): Promise<{ drc?: NativeRuleRunInput; erc?: NativeRuleRunInput }> {
+  let drc: NativeRuleRunInput | undefined;
+  let erc: NativeRuleRunInput | undefined;
+
+  if (options.drc ?? true) {
+    try {
+      const result = (await bridge.call('design.drc', { projectId })) as {
+        violations?: Array<{
+          rule?: string;
+          description?: string;
+          severity?: string;
+          net?: string;
+          component?: string;
+        }>;
+        totalViolations?: number;
+        errorCount?: number;
+        warningCount?: number;
+      };
+      drc = {
+        violations: result.violations?.map((v) => ({
+          ...v,
+          severity: normalizeRuleSeverity(v.severity),
+        })),
+        total_violations: result.totalViolations,
+        error_count: result.errorCount,
+        warning_count: result.warningCount,
+      };
+    } catch (err) {
+      drc = { not_available: true, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  if (options.erc ?? true) {
+    try {
+      const result = (await bridge.call('design.erc', { projectId })) as {
+        violations?: Array<{
+          description?: string;
+          severity?: string;
+          net?: string;
+          component?: string;
+        }>;
+        totalViolations?: number;
+        errorCount?: number;
+        warningCount?: number;
+        inferredFloatingPins?: Array<{
+          primitiveId?: string;
+          designator?: string;
+          pinNumber?: string;
+        }>;
+      };
+      erc = {
+        violations: result.violations?.map((v) => ({
+          ...v,
+          severity: normalizeRuleSeverity(v.severity),
+        })),
+        total_violations: result.totalViolations,
+        error_count: result.errorCount,
+        warning_count: result.warningCount,
+        inferred_floating_pins: result.inferredFloatingPins,
+      };
+    } catch (err) {
+      erc = { not_available: true, error: err instanceof Error ? err.message : String(err) };
+    }
+  }
+
+  return { drc, erc };
 }
 
 export function classifyPostWriteQa(input: PostWriteQaInput): PostWriteQaSummary {

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -8,7 +8,9 @@ export type WorkflowIssueCode =
   | 'WORKFLOW_NO_COMPONENTS'
   | 'WORKFLOW_MISSING_ROLE'
   | 'WORKFLOW_DUPLICATE_NET_PORT'
-  | 'WORKFLOW_PIN_COLLISION';
+  | 'WORKFLOW_PIN_COLLISION'
+  | 'WORKFLOW_SAFE_REGION'
+  | 'WORKFLOW_POST_WRITE_QA';
 
 export interface WorkflowIssue {
   code: WorkflowIssueCode;
@@ -40,6 +42,8 @@ export interface WorkflowComponentInput {
   rotation?: number;
   mirror?: boolean;
   subPartName?: string;
+  /** Optional placement offset from the workflow anchor. If omitted, the legacy horizontal spacing planner is used. */
+  placementOffset?: { dx: number; dy: number };
   pinConnections: WorkflowPinConnection[];
 }
 

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -43,10 +43,10 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('78');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('79');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('90');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('91');
   });
 });

--- a/tests/unit/tools/workflows.test.ts
+++ b/tests/unit/tools/workflows.test.ts
@@ -36,6 +36,107 @@ describe('Workflow Tools', () => {
     };
   });
 
+  describe('easyeda_workflow_ne555_astable', () => {
+    const devices = {
+      timer: deviceItem,
+      resistor: deviceItem,
+      timingCapacitor: deviceItem,
+      bypassCapacitor: deviceItem,
+      led: deviceItem,
+    };
+
+    it('previews a safe NE555 astable plan without write operations', async () => {
+      bridgeCall.mockResolvedValueOnce({ currentPage: { width: 1189, height: 841 } });
+      const tool = registry.get('easyeda_workflow_ne555_astable');
+      const result = (await tool?.handler(context, {
+        projectId: 'proj-555',
+        mode: 'preview',
+        devices,
+      })) as any;
+
+      expect(result.applied).toBe(false);
+      expect(result.blocked).toBe(false);
+      expect(result.safe_region.blocked).toBe(false);
+      expect(result.design.calculated.frequency_hz).toBeCloseTo(1.053, 3);
+      expect(result.placements).toHaveLength(8);
+      expect(result.operations.filter((op: any) => op.kind === 'connectPinToNet')).toHaveLength(22);
+      expect(bridgeCall).toHaveBeenCalledTimes(1);
+      expect(bridgeCall).toHaveBeenCalledWith('schematic.getSheetInfo', { projectId: 'proj-555' });
+    });
+
+    it('runs post-write QA after a successful apply and keeps success true when QA passes', async () => {
+      bridgeCall.mockImplementation(async (method: string) => {
+        if (method === 'schematic.getSheetInfo')
+          return { currentPage: { width: 1189, height: 841 } };
+        if (method === 'schematic.placeComponent')
+          return { primitiveId: `id-${bridgeCall.mock.calls.length}` };
+        if (method === 'schematic.connectPinToNet') return { success: true };
+        if (method === 'schematic.createNetPort')
+          return { primitiveId: `net-${bridgeCall.mock.calls.length}` };
+        if (method === 'schematic.listComponents') return { total: 8, items: [] };
+        if (method === 'design.drc' || method === 'design.erc') {
+          return { violations: [], totalViolations: 0, errorCount: 0, warningCount: 0 };
+        }
+        return { result: [] };
+      });
+
+      const tool = registry.get('easyeda_workflow_ne555_astable');
+      const result = (await tool?.handler(context, {
+        projectId: 'proj-555',
+        mode: 'apply',
+        confirmWrite: true,
+        devices,
+      })) as any;
+
+      expect(result.applied).toBe(true);
+      expect(result.success).toBe(true);
+      expect(result.post_write_qa.status).toBe('pass');
+      expect(bridgeCall).toHaveBeenCalledWith('design.drc', { projectId: 'proj-555' });
+      expect(bridgeCall).toHaveBeenCalledWith('design.erc', { projectId: 'proj-555' });
+    });
+
+    it('gates successful writes as failed when post-write QA fails', async () => {
+      bridgeCall.mockImplementation(async (method: string) => {
+        if (method === 'schematic.getSheetInfo')
+          return { currentPage: { width: 1189, height: 841 } };
+        if (method === 'schematic.placeComponent')
+          return { primitiveId: `id-${bridgeCall.mock.calls.length}` };
+        if (method === 'schematic.connectPinToNet') return { success: true };
+        if (method === 'schematic.createNetPort')
+          return { primitiveId: `net-${bridgeCall.mock.calls.length}` };
+        if (method === 'schematic.listComponents') return { total: 8, items: [] };
+        if (method === 'design.drc') {
+          return {
+            violations: [
+              {
+                description: 'Wire $1N4 has multiple net names: +5V +5V',
+                severity: 'warning',
+                net: '+5V',
+              },
+            ],
+            totalViolations: 1,
+            warningCount: 1,
+          };
+        }
+        if (method === 'design.erc') return { violations: [], totalViolations: 0, errorCount: 0 };
+        return { result: [] };
+      });
+
+      const tool = registry.get('easyeda_workflow_ne555_astable');
+      const result = (await tool?.handler(context, {
+        projectId: 'proj-555',
+        mode: 'apply',
+        confirmWrite: true,
+        devices,
+      })) as any;
+
+      expect(result.applied).toBe(true);
+      expect(result.success).toBe(false);
+      expect(result.post_write_qa.status).toBe('fail');
+      expect(result.post_write_qa.categories.duplicate_net_names).toBe(1);
+    });
+  });
+
   describe('easyeda_workflow_power_rail', () => {
     const basePowerRailInput = () => ({
       projectId: 'proj-1',

--- a/tests/unit/workflows/ne555-astable-template.test.ts
+++ b/tests/unit/workflows/ne555-astable-template.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildNe555AstableTemplate,
+  calculateNe555Astable,
+} from '../../../src/workflows/ne555-astable-template.js';
+
+const deviceItem = { libraryUuid: 'lib-1', uuid: 'dev-1' };
+const devices = {
+  timer: deviceItem,
+  resistor: deviceItem,
+  timingCapacitor: deviceItem,
+  bypassCapacitor: deviceItem,
+  led: deviceItem,
+};
+
+describe('NE555 astable template', () => {
+  it('calculates the default astable timing near 1 Hz', () => {
+    const result = calculateNe555Astable({
+      supplyVoltage: 5,
+      r1Ohms: 1000,
+      r2Ohms: 68000,
+      timingCapacitanceUf: 10,
+      controlCapacitanceNf: 10,
+      decouplingCapacitanceNf: 100,
+      ledSeriesOhms: 330,
+    });
+
+    expect(result.frequencyHz).toBeCloseTo(1.053, 3);
+    expect(result.periodSeconds).toBeCloseTo(0.949, 3);
+    expect(result.dutyCyclePercent).toBeCloseTo(50.4, 1);
+  });
+
+  it('builds a safe upper-left professional placement plan', () => {
+    const result = buildNe555AstableTemplate({ projectId: 'proj-555', devices });
+
+    expect(result.safeRegion.blocked).toBe(false);
+    expect(result.safeRegion.preferredRegion).toBe('upper-left');
+    expect(result.workflowInput.anchor.y).toBeGreaterThan(700);
+    expect(result.workflowInput.components).toHaveLength(8);
+    expect(result.workflowInput.netPorts).toHaveLength(6);
+
+    const byRef = new Map(result.workflowInput.components?.map((c) => [c.ref, c]));
+    expect(byRef.get('U1')?.placementOffset).toEqual({ dx: 280, dy: -150 });
+    expect(byRef.get('R1')?.placementOffset).toEqual({ dx: 120, dy: -70 });
+    expect(byRef.get('D1')?.placementOffset).toEqual({ dx: 560, dy: -150 });
+  });
+
+  it('wires NE555 pins to the correct astable nets', () => {
+    const result = buildNe555AstableTemplate({ projectId: 'proj-555', devices });
+    const timer = result.workflowInput.components?.find((c) => c.ref === 'U1');
+
+    expect(timer?.pinConnections).toEqual([
+      { pin: '1', netName: 'GND' },
+      { pin: '2', netName: 'TIMING' },
+      { pin: '3', netName: 'OUT' },
+      { pin: '4', netName: '+5V' },
+      { pin: '5', netName: 'CTRL' },
+      { pin: '6', netName: 'TIMING' },
+      { pin: '7', netName: 'DISCH' },
+      { pin: '8', netName: '+5V' },
+    ]);
+  });
+
+  it('supports custom nets, pins, and values without changing topology', () => {
+    const result = buildNe555AstableTemplate({
+      projectId: 'proj-555',
+      devices,
+      nets: { vcc: 'VCC_12V', output: 'BLINK_OUT' },
+      values: { supplyVoltage: 12, r2Ohms: 100000 },
+      pinMaps: { led: { anode: 'A', cathode: 'K' } },
+    });
+
+    expect(result.values.supplyVoltage).toBe(12);
+    expect(result.values.r2Ohms).toBe(100000);
+    expect(result.nets.vcc).toBe('VCC_12V');
+    expect(result.workflowInput.netPorts?.some((port) => port.netName === 'BLINK_OUT')).toBe(true);
+
+    const led = result.workflowInput.components?.find((c) => c.ref === 'D1');
+    expect(led?.pinConnections).toContainEqual({ pin: 'A', netName: 'LED_A' });
+    expect(led?.pinConnections).toContainEqual({ pin: 'K', netName: 'GND' });
+  });
+});


### PR DESCRIPTION
## Summary

- add `easyeda_workflow_ne555_astable` for a professional NE555 astable LED flasher workflow
- add a deterministic NE555 template builder with:
  - safe-region planning / title-block avoidance
  - grid-style component placement offsets instead of one-line placement
  - explicit NE555 pin-to-net connectivity
  - default ~1 Hz values: R1=1k, R2=68k, C1=10uF, C2=10nF, C3=100nF, R3=330R
  - post-write QA gate using the #244 classifier after apply
- extend workflow components with optional `placementOffset` while preserving legacy horizontal spacing behavior
- update profile counts and generated tool docs

Addresses #245.

## Engineering intent

Default topology:

- U1 NE555
- R1 from VCC to DISCH
- R2 from DISCH to TIMING
- C1 from TIMING to GND
- pin 2 TRIG and pin 6 THRESH joined at TIMING
- pin 4 RESET tied to VCC
- pin 5 CTRL bypassed to GND with C2
- C3 local VCC/GND decoupling
- pin 3 OUT -> R3 -> LED -> GND

Calculated defaults:

- frequency ≈ 1.053 Hz
- period ≈ 0.949 s
- duty ≈ 50.4%

## Verification

- `pnpm test -- tests/unit/workflows/ne555-astable-template.test.ts tests/unit/workflows/planner.test.ts tests/unit/tools/workflows.test.ts` — root suite completed: 97 files / 1157 tests
- `pnpm test -- tests/unit/tools/workflows.test.ts` — root suite completed: 97 files / 1160 tests
- `pnpm typecheck`
- `pnpm verify:tool-coverage`
- `pnpm test -- tests/unit/config/profiles.test.ts`
- `pnpm format:check`
- `pnpm lint`
- `pnpm lint:tools`
- `pnpm generate:tools-doc`
- `pnpm build`
- `pnpm docs:build`

## Notes / follow-up

This tool still expects caller-supplied EasyEDA `deviceItem`s. The next live test should:

1. search/resolve NE555, resistor, capacitor, LED device items in the connected EasyEDA catalog
2. run the workflow in preview mode
3. apply with `confirmWrite=true`
4. inspect `post_write_qa`
5. capture the canvas and address any remaining visual QA gaps