### PR TITLE
fix(workflows): reduce NE555 detached netports

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -3208,6 +3208,7 @@ Returns a JSON object matching the schema:
 | `anchor`          | `object (optional)`  | No             |               |
 | `preferredRegion` | `'upper-left'        | 'upper-center' | 'upper-right' | 'center-left' | 'center' | 'center-right' | 'lower-left' | 'lower-center' | 'lower-right'` | Yes |     |
 | `margin`          | `number (optional)`  | No             |               |
+| `createNetPorts`  | `boolean`            | Yes            |               |
 | `refs`            | `object (optional)`  | No             |               |
 | `nets`            | `object (optional)`  | No             |               |
 | `values`          | `object (optional)`  | No             |               |

--- a/src/tools/L2_workflows.ts
+++ b/src/tools/L2_workflows.ts
@@ -346,6 +346,12 @@ const ne555DevicesSchema = z.object({
   timingCapacitor: deviceItemSchema,
   bypassCapacitor: deviceItemSchema,
   led: deviceItemSchema,
+  r1: deviceItemSchema.optional(),
+  r2: deviceItemSchema.optional(),
+  rLed: deviceItemSchema.optional(),
+  cTiming: deviceItemSchema.optional(),
+  cCtrl: deviceItemSchema.optional(),
+  cDecouple: deviceItemSchema.optional(),
 });
 
 const ne555RefsSchema = z
@@ -418,6 +424,7 @@ const ne555InputSchema = z.object({
   anchor: pointSchema.optional(),
   preferredRegion: schematicRegionPreferenceSchema.default('upper-left'),
   margin: z.number().positive().optional(),
+  createNetPorts: z.boolean().default(false),
   refs: ne555RefsSchema,
   nets: ne555NetsSchema,
   values: ne555ValuesSchema,

--- a/src/workflows/ne555-astable-template.ts
+++ b/src/workflows/ne555-astable-template.ts
@@ -26,6 +26,12 @@ export interface Ne555AstableDevices {
   timingCapacitor: WorkflowDeviceItem;
   bypassCapacitor: WorkflowDeviceItem;
   led: WorkflowDeviceItem;
+  r1?: WorkflowDeviceItem;
+  r2?: WorkflowDeviceItem;
+  rLed?: WorkflowDeviceItem;
+  cTiming?: WorkflowDeviceItem;
+  cCtrl?: WorkflowDeviceItem;
+  cDecouple?: WorkflowDeviceItem;
 }
 
 export interface Ne555AstableRefs {
@@ -74,6 +80,7 @@ export interface Ne555AstableTemplateInput {
   sheetInfo?: unknown;
   preferredRegion?: SchematicRegionPreference;
   margin?: number;
+  createNetPorts?: boolean;
   refs?: Partial<Ne555AstableRefs>;
   nets?: Partial<Ne555AstableNets>;
   values?: Partial<Ne555AstableValues>;
@@ -204,6 +211,12 @@ export function buildNe555AstableTemplate(
     margin: input.margin,
   });
   const anchor = input.anchor ?? safeRegion.anchor;
+  const r1Device = input.devices.r1 ?? input.devices.resistor;
+  const r2Device = input.devices.r2 ?? input.devices.resistor;
+  const rLedDevice = input.devices.rLed ?? input.devices.resistor;
+  const cTimingDevice = input.devices.cTiming ?? input.devices.timingCapacitor;
+  const cCtrlDevice = input.devices.cCtrl ?? input.devices.bypassCapacitor;
+  const cDecoupleDevice = input.devices.cDecouple ?? input.devices.bypassCapacitor;
 
   const components: NonNullable<WorkflowBlockInput['components']> = [
     {
@@ -225,7 +238,7 @@ export function buildNe555AstableTemplate(
     {
       ref: refs.r1,
       role: `timing-resistor-r1-${values.r1Ohms}ohm`,
-      deviceItem: input.devices.resistor,
+      deviceItem: r1Device,
       placementOffset: { dx: 120, dy: -70 },
       pinConnections: [
         { pin: pinMaps.resistor.p1, netName: nets.vcc },
@@ -235,7 +248,7 @@ export function buildNe555AstableTemplate(
     {
       ref: refs.r2,
       role: `timing-resistor-r2-${values.r2Ohms}ohm`,
-      deviceItem: input.devices.resistor,
+      deviceItem: r2Device,
       placementOffset: { dx: 120, dy: -155 },
       pinConnections: [
         { pin: pinMaps.resistor.p1, netName: nets.discharge },
@@ -245,7 +258,7 @@ export function buildNe555AstableTemplate(
     {
       ref: refs.cTiming,
       role: `timing-capacitor-${values.timingCapacitanceUf}uf`,
-      deviceItem: input.devices.timingCapacitor,
+      deviceItem: cTimingDevice,
       placementOffset: { dx: 120, dy: -250 },
       pinConnections: [
         { pin: pinMaps.capacitor.p1, netName: nets.timing },
@@ -255,7 +268,7 @@ export function buildNe555AstableTemplate(
     {
       ref: refs.cCtrl,
       role: `control-bypass-${values.controlCapacitanceNf}nf`,
-      deviceItem: input.devices.bypassCapacitor,
+      deviceItem: cCtrlDevice,
       placementOffset: { dx: 390, dy: -245 },
       pinConnections: [
         { pin: pinMaps.capacitor.p1, netName: nets.control },
@@ -265,7 +278,7 @@ export function buildNe555AstableTemplate(
     {
       ref: refs.cDecouple,
       role: `supply-decoupling-${values.decouplingCapacitanceNf}nf`,
-      deviceItem: input.devices.bypassCapacitor,
+      deviceItem: cDecoupleDevice,
       placementOffset: { dx: 390, dy: -65 },
       pinConnections: [
         { pin: pinMaps.capacitor.p1, netName: nets.vcc },
@@ -275,7 +288,7 @@ export function buildNe555AstableTemplate(
     {
       ref: refs.rLed,
       role: `led-series-resistor-${values.ledSeriesOhms}ohm`,
-      deviceItem: input.devices.resistor,
+      deviceItem: rLedDevice,
       placementOffset: { dx: 470, dy: -150 },
       pinConnections: [
         { pin: pinMaps.resistor.p1, netName: nets.output },
@@ -300,15 +313,17 @@ export function buildNe555AstableTemplate(
     anchor,
     spacing: 70,
     components,
-    netPortAnchor: { x: anchor.x, y: anchor.y - 20 },
-    netPorts: [
-      { netName: nets.vcc, portType: 'input' },
-      { netName: nets.gnd, portType: 'passive' },
-      { netName: nets.output, portType: 'output' },
-      { netName: nets.timing, portType: 'passive' },
-      { netName: nets.discharge, portType: 'passive' },
-      { netName: nets.control, portType: 'passive' },
-    ],
+    netPortAnchor: input.createNetPorts ? { x: anchor.x, y: anchor.y - 20 } : undefined,
+    netPorts: input.createNetPorts
+      ? [
+          { netName: nets.vcc, portType: 'input' },
+          { netName: nets.gnd, portType: 'passive' },
+          { netName: nets.output, portType: 'output' },
+          { netName: nets.timing, portType: 'passive' },
+          { netName: nets.discharge, portType: 'passive' },
+          { netName: nets.control, portType: 'passive' },
+        ]
+      : [],
   };
 
   return {
@@ -324,7 +339,8 @@ export function buildNe555AstableTemplate(
       'NE555 astable LED flasher: U1 is centered, timing network is left, decoupling/control bypass are near U1, and output LED chain is right.',
       'Pin 2 TRIG and pin 6 THRESH are tied to the timing node; pin 7 DISCH is between R1 and R2.',
       'Pin 4 RESET is tied to VCC; pin 5 CTRL is bypassed to GND; C3 is a local VCC/GND decoupling capacitor.',
-      'Use post-write QA with circuit policy after apply; duplicate net names, free wire-only nets, and floating pins are blocking failures.',
+      'Detached external netports are disabled by default; local pin-to-net labels avoid disconnected netport DRC info.',
+      'Use post-write QA with circuit policy after apply; duplicate net names, free wire-only nets, disconnected netports, and floating pins are blocking failures.',
     ],
   };
 }

--- a/tests/unit/tools/workflows.test.ts
+++ b/tests/unit/tools/workflows.test.ts
@@ -60,6 +60,7 @@ describe('Workflow Tools', () => {
       expect(result.design.calculated.frequency_hz).toBeCloseTo(1.053, 3);
       expect(result.placements).toHaveLength(8);
       expect(result.operations.filter((op: any) => op.kind === 'connectPinToNet')).toHaveLength(22);
+      expect(result.operations.filter((op: any) => op.kind === 'createNetPort')).toHaveLength(0);
       expect(bridgeCall).toHaveBeenCalledTimes(1);
       expect(bridgeCall).toHaveBeenCalledWith('schematic.getSheetInfo', { projectId: 'proj-555' });
     });

--- a/tests/unit/workflows/ne555-astable-template.test.ts
+++ b/tests/unit/workflows/ne555-astable-template.test.ts
@@ -37,7 +37,7 @@ describe('NE555 astable template', () => {
     expect(result.safeRegion.preferredRegion).toBe('upper-left');
     expect(result.workflowInput.anchor.y).toBeGreaterThan(700);
     expect(result.workflowInput.components).toHaveLength(8);
-    expect(result.workflowInput.netPorts).toHaveLength(6);
+    expect(result.workflowInput.netPorts).toHaveLength(0);
 
     const byRef = new Map(result.workflowInput.components?.map((c) => [c.ref, c]));
     expect(byRef.get('U1')?.placementOffset).toEqual({ dx: 280, dy: -150 });
@@ -61,6 +61,27 @@ describe('NE555 astable template', () => {
     ]);
   });
 
+  it('supports per-reference device items so visual values can differ', () => {
+    const r1 = { libraryUuid: 'lib-r', uuid: 'r1-1k' };
+    const r2 = { libraryUuid: 'lib-r', uuid: 'r2-68k' };
+    const rLed = { libraryUuid: 'lib-r', uuid: 'r3-330r' };
+    const cCtrl = { libraryUuid: 'lib-c', uuid: 'c2-10n' };
+    const cDecouple = { libraryUuid: 'lib-c', uuid: 'c3-100n' };
+    const result = buildNe555AstableTemplate({
+      projectId: 'proj-555',
+      devices: { ...devices, r1, r2, rLed, cCtrl, cDecouple },
+    });
+    const byRef = new Map(
+      result.workflowInput.components?.map((component) => [component.ref, component]),
+    );
+
+    expect(byRef.get('R1')?.deviceItem).toBe(r1);
+    expect(byRef.get('R2')?.deviceItem).toBe(r2);
+    expect(byRef.get('R3')?.deviceItem).toBe(rLed);
+    expect(byRef.get('C2')?.deviceItem).toBe(cCtrl);
+    expect(byRef.get('C3')?.deviceItem).toBe(cDecouple);
+  });
+
   it('supports custom nets, pins, and values without changing topology', () => {
     const result = buildNe555AstableTemplate({
       projectId: 'proj-555',
@@ -73,7 +94,11 @@ describe('NE555 astable template', () => {
     expect(result.values.supplyVoltage).toBe(12);
     expect(result.values.r2Ohms).toBe(100000);
     expect(result.nets.vcc).toBe('VCC_12V');
-    expect(result.workflowInput.netPorts?.some((port) => port.netName === 'BLINK_OUT')).toBe(true);
+    expect(
+      result.workflowInput.components?.some((component) =>
+        component.pinConnections.some((connection) => connection.netName === 'BLINK_OUT'),
+      ),
+    ).toBe(true);
 
     const led = result.workflowInput.components?.find((c) => c.ref === 'D1');
     expect(led?.pinConnections).toContainEqual({ pin: 'A', netName: 'LED_A' });


### PR DESCRIPTION
## Summary

- disable detached NE555 external netports by default to avoid EasyEDA `Netport ... is not connected to wire or bus` info messages in normal circuit output
- add optional per-reference device items for R1/R2/R3 and C1/C2/C3 so the template can use visually correct 1k / 68k / 330R and 10uF / 10nF / 100nF parts instead of one shared resistor/bypass capacitor
- preserve the old external-port row as an opt-in `createNetPorts=true` behavior
- update generated docs and tests

Partially addresses #253.

## Live-test motivation

0.29.0 live MSI/EasyEDA test showed:

- workflow apply succeeded: `applied=true`, 36/36 operations, no rollback
- manual DRC was clean for errors/warnings, but produced info messages for detached netports
- visual quality was not professional enough because netports floated above the circuit and R/C values were not visually distinct

This PR removes the most obvious cosmetic/DRC-info regression without attempting full orthogonal wiring yet.

## Verification

- `pnpm test -- tests/unit/workflows/ne555-astable-template.test.ts tests/unit/tools/workflows.test.ts` — root suite completed: 97 files / 1161 tests
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint`
- `pnpm lint:tools`
- `pnpm verify:tool-coverage`
- `pnpm generate:tools-doc`
- `pnpm build`
- `pnpm docs:build`

## Follow-up

Still needed for full professional schematic quality:

- actual orthogonal visible wire/stub generation around NE555 pins
- layout QA for floating labels and overlap
- post-write QA classification for detached/unconnected netport info when `createNetPorts=true` is used in circuit mode