### PR TITLE
feat(workflows): add NE555 visible wire stubs

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -3209,6 +3209,7 @@ Returns a JSON object matching the schema:
 | `preferredRegion` | `'upper-left'        | 'upper-center' | 'upper-right' | 'center-left' | 'center' | 'center-right' | 'lower-left' | 'lower-center' | 'lower-right'` | Yes |     |
 | `margin`          | `number (optional)`  | No             |               |
 | `createNetPorts`  | `boolean`            | Yes            |               |
+| `createWireStubs` | `boolean`            | Yes            |               |
 | `refs`            | `object (optional)`  | No             |               |
 | `nets`            | `object (optional)`  | No             |               |
 | `values`          | `object (optional)`  | No             |               |
@@ -3263,6 +3264,7 @@ Returns a JSON object matching the schema:
 | `existingComponents` | `object[]`           | Yes      |             |
 | `netPorts`           | `object[]`           | Yes      |             |
 | `netPortAnchor`      | `object (optional)`  | No       |             |
+| `wires`              | `object[]`           | Yes      |             |
 | `confirmWrite`       | `boolean (optional)` | No       |             |
 
 ### Output Format

--- a/src/tools/L2_workflows.ts
+++ b/src/tools/L2_workflows.ts
@@ -66,6 +66,14 @@ const netPortInputSchema = z.object({
 
 const pointSchema = z.object({ x: z.number(), y: z.number() });
 
+const wireInputSchema = z.object({
+  ref: z.string().optional(),
+  role: z.string().min(1),
+  netName: z.string().min(1).optional(),
+  points: z.array(pointSchema).min(2),
+  lineWidth: z.number().positive().optional(),
+});
+
 /** Fields every `easyeda_workflow_*` tool accepts, regardless of its own domain-specific input. */
 const workflowIdentitySchema = z.object({
   projectId: z.string().min(1),
@@ -204,7 +212,8 @@ async function applySingleOperation(
       refToPrimitiveId.set(op.ref, primitiveId);
     }
     const createsNewPrimitive =
-      (op.kind === 'placeComponent' || op.kind === 'createNetPort') && Boolean(primitiveId);
+      (op.kind === 'placeComponent' || op.kind === 'createNetPort' || op.kind === 'addWire') &&
+      Boolean(primitiveId);
 
     return {
       outcome: { method: op.method, ref: operationRef(op), success: true, primitiveId },
@@ -425,6 +434,7 @@ const ne555InputSchema = z.object({
   preferredRegion: schematicRegionPreferenceSchema.default('upper-left'),
   margin: z.number().positive().optional(),
   createNetPorts: z.boolean().default(false),
+  createWireStubs: z.boolean().default(true),
   refs: ne555RefsSchema,
   nets: ne555NetsSchema,
   values: ne555ValuesSchema,
@@ -939,6 +949,7 @@ function registerWorkflowTools(
       existingComponents: z.array(existingComponentInputSchema).default([]),
       netPorts: z.array(netPortInputSchema).default([]),
       netPortAnchor: pointSchema.optional(),
+      wires: z.array(wireInputSchema).default([]),
       confirmWrite: z.boolean().optional(),
     }),
     outputSchema: workflowOutputSchema,
@@ -953,6 +964,7 @@ function registerWorkflowTools(
         existingComponents: p.existingComponents,
         netPorts: p.netPorts,
         netPortAnchor: p.netPortAnchor,
+        wires: p.wires,
       };
       return runWorkflow(ctx, input, 'wf_place_block', p.confirmWrite);
     },

--- a/src/workflows/ne555-astable-template.ts
+++ b/src/workflows/ne555-astable-template.ts
@@ -3,6 +3,7 @@ import {
   type SchematicRegionPreference,
 } from './schematic-safe-region.js';
 import type { WorkflowBlockInput, WorkflowDeviceItem } from './types.js';
+import { buildNe555VisibleWireStubs } from './ne555-wire-stubs.js';
 
 export interface TwoPinMap {
   p1: string;
@@ -81,6 +82,7 @@ export interface Ne555AstableTemplateInput {
   preferredRegion?: SchematicRegionPreference;
   margin?: number;
   createNetPorts?: boolean;
+  createWireStubs?: boolean;
   refs?: Partial<Ne555AstableRefs>;
   nets?: Partial<Ne555AstableNets>;
   values?: Partial<Ne555AstableValues>;
@@ -307,12 +309,16 @@ export function buildNe555AstableTemplate(
     },
   ];
 
+  const wires =
+    input.createWireStubs === false ? [] : buildNe555VisibleWireStubs(anchor, refs, nets);
+
   const workflowInput: WorkflowBlockInput = {
     projectId: input.projectId,
     mode: input.mode ?? 'preview',
     anchor,
     spacing: 70,
     components,
+    wires,
     netPortAnchor: input.createNetPorts ? { x: anchor.x, y: anchor.y - 20 } : undefined,
     netPorts: input.createNetPorts
       ? [
@@ -340,6 +346,7 @@ export function buildNe555AstableTemplate(
       'Pin 2 TRIG and pin 6 THRESH are tied to the timing node; pin 7 DISCH is between R1 and R2.',
       'Pin 4 RESET is tied to VCC; pin 5 CTRL is bypassed to GND; C3 is a local VCC/GND decoupling capacitor.',
       'Detached external netports are disabled by default; local pin-to-net labels avoid disconnected netport DRC info.',
+      'Visible wire stubs are drawn from each known pin by default so the generated schematic reads less like isolated net labels.',
       'Use post-write QA with circuit policy after apply; duplicate net names, free wire-only nets, disconnected netports, and floating pins are blocking failures.',
     ],
   };

--- a/src/workflows/ne555-wire-stubs.ts
+++ b/src/workflows/ne555-wire-stubs.ts
@@ -1,0 +1,75 @@
+import type { WorkflowWireInput } from './types.js';
+import type { Ne555AstableNets, Ne555AstableRefs } from './ne555-astable-template.js';
+
+function horizontalStub(
+  role: string,
+  netName: string,
+  x: number,
+  y: number,
+  direction: 'left' | 'right',
+  length = 18,
+): WorkflowWireInput {
+  const endX = direction === 'left' ? x - length : x + length;
+  return {
+    role,
+    netName,
+    points: [
+      { x, y },
+      { x: endX, y },
+    ],
+    lineWidth: 1,
+  };
+}
+
+export function buildNe555VisibleWireStubs(
+  anchor: { x: number; y: number },
+  refs: Ne555AstableRefs,
+  nets: Ne555AstableNets,
+): WorkflowWireInput[] {
+  const at = (dx: number, dy: number) => ({ x: anchor.x + dx, y: anchor.y + dy });
+  const wires: WorkflowWireInput[] = [];
+
+  const u1 = at(280, -150);
+  wires.push(horizontalStub(`${refs.timer}-pin1-gnd-stub`, nets.gnd, u1.x - 55, u1.y + 15, 'left'));
+  wires.push(
+    horizontalStub(`${refs.timer}-pin2-trig-stub`, nets.timing, u1.x - 55, u1.y + 5, 'left'),
+  );
+  wires.push(
+    horizontalStub(`${refs.timer}-pin3-out-stub`, nets.output, u1.x - 55, u1.y - 5, 'left'),
+  );
+  wires.push(
+    horizontalStub(`${refs.timer}-pin4-reset-stub`, nets.vcc, u1.x - 55, u1.y - 15, 'left'),
+  );
+  wires.push(
+    horizontalStub(`${refs.timer}-pin5-ctrl-stub`, nets.control, u1.x + 55, u1.y - 15, 'right'),
+  );
+  wires.push(
+    horizontalStub(`${refs.timer}-pin6-thresh-stub`, nets.timing, u1.x + 55, u1.y - 5, 'right'),
+  );
+  wires.push(
+    horizontalStub(`${refs.timer}-pin7-disch-stub`, nets.discharge, u1.x + 55, u1.y + 5, 'right'),
+  );
+  wires.push(
+    horizontalStub(`${refs.timer}-pin8-vcc-stub`, nets.vcc, u1.x + 55, u1.y + 15, 'right'),
+  );
+
+  const twoPin = (
+    ref: string,
+    center: { x: number; y: number },
+    leftNet: string,
+    rightNet: string,
+  ) => {
+    wires.push(horizontalStub(`${ref}-pin1-stub`, leftNet, center.x - 20, center.y, 'left'));
+    wires.push(horizontalStub(`${ref}-pin2-stub`, rightNet, center.x + 20, center.y, 'right'));
+  };
+
+  twoPin(refs.r1, at(120, -70), nets.vcc, nets.discharge);
+  twoPin(refs.r2, at(120, -155), nets.discharge, nets.timing);
+  twoPin(refs.cTiming, at(120, -250), nets.timing, nets.gnd);
+  twoPin(refs.cCtrl, at(390, -245), nets.control, nets.gnd);
+  twoPin(refs.cDecouple, at(390, -65), nets.vcc, nets.gnd);
+  twoPin(refs.rLed, at(470, -150), nets.output, nets.ledAnode);
+  twoPin(refs.led, at(560, -150), nets.ledAnode, nets.gnd);
+
+  return wires;
+}

--- a/src/workflows/planner.ts
+++ b/src/workflows/planner.ts
@@ -23,6 +23,7 @@ import type {
   WorkflowIssue,
   WorkflowNetPortInput,
   WorkflowOperation,
+  WorkflowWireInput,
   WorkflowPlan,
   WorkflowPlannedComponent,
 } from './types.js';
@@ -134,6 +135,7 @@ function workflowPlanSummary(
   components: WorkflowComponentInput[],
   existingComponents: WorkflowExistingComponentInput[],
   netPorts: WorkflowNetPortInput[],
+  wires: WorkflowWireInput[],
   operations: WorkflowOperation[],
 ): string {
   if (blocked) {
@@ -142,8 +144,8 @@ function workflowPlanSummary(
   }
   const verb = mode === 'apply' ? 'Applying' : 'Planned';
   return (
-    `${verb} ${components.length} new component(s), ${existingComponents.length} ` +
-    `existing-component wiring, and ${netPorts.length} net port(s) across ${operations.length} operation(s).`
+    `${verb} ${components.length} new component(s), ${existingComponents.length} existing-component wiring, ` +
+    `${netPorts.length} net port(s), and ${wires.length} wire(s) across ${operations.length} operation(s).`
   );
 }
 
@@ -155,6 +157,7 @@ export function planWorkflowBlock(
   const components = input.components ?? [];
   const existingComponents = input.existingComponents ?? [];
   const netPorts = input.netPorts ?? [];
+  const wires = input.wires ?? [];
   const spacing = input.spacing ?? 10;
   const issues = validateWorkflowInputs(components, existingComponents, netPorts);
   const blocked = issues.some((entry) => entry.severity === 'error');
@@ -247,8 +250,24 @@ export function planWorkflowBlock(
     });
   });
 
+  for (const wire of wires) {
+    operations.push({
+      kind: 'addWire',
+      ref: wire.ref,
+      role: wire.role,
+      netName: wire.netName,
+      method: 'schematic.addWire',
+      params: {
+        projectId: input.projectId,
+        points: wire.points,
+        netName: wire.netName,
+        lineWidth: wire.lineWidth,
+      },
+    });
+  }
+
   const rollbackNotes = [
-    'Newly-placed components (and any net ports created in this transaction) are deleted on rollback.',
+    'Newly-created primitives (placed components, net ports, and wires created in this transaction) are deleted on rollback.',
   ];
   if (existingComponents.some((component) => component.pinConnections.length > 0)) {
     rollbackNotes.push(
@@ -265,6 +284,7 @@ export function planWorkflowBlock(
     components,
     existingComponents,
     netPorts,
+    wires,
     operations,
   );
 

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -61,6 +61,14 @@ export interface WorkflowNetPortInput {
   rotation?: number;
 }
 
+export interface WorkflowWireInput {
+  ref?: string;
+  role: string;
+  netName?: string;
+  points: Array<{ x: number; y: number }>;
+  lineWidth?: number;
+}
+
 export interface WorkflowBlockInput {
   projectId: string;
   mode?: WorkflowExecutionMode;
@@ -72,6 +80,7 @@ export interface WorkflowBlockInput {
   existingComponents?: WorkflowExistingComponentInput[];
   netPorts?: WorkflowNetPortInput[];
   netPortAnchor?: { x: number; y: number };
+  wires?: WorkflowWireInput[];
 }
 
 export type WorkflowOperation =
@@ -93,6 +102,14 @@ export type WorkflowOperation =
       kind: 'createNetPort';
       netName: string;
       method: 'schematic.createNetPort';
+      params: Record<string, unknown>;
+    }
+  | {
+      kind: 'addWire';
+      ref?: string;
+      role: string;
+      netName?: string;
+      method: 'schematic.addWire';
       params: Record<string, unknown>;
     };
 

--- a/tests/unit/tools/workflows.test.ts
+++ b/tests/unit/tools/workflows.test.ts
@@ -60,6 +60,7 @@ describe('Workflow Tools', () => {
       expect(result.design.calculated.frequency_hz).toBeCloseTo(1.053, 3);
       expect(result.placements).toHaveLength(8);
       expect(result.operations.filter((op: any) => op.kind === 'connectPinToNet')).toHaveLength(22);
+      expect(result.operations.filter((op: any) => op.kind === 'addWire')).toHaveLength(22);
       expect(result.operations.filter((op: any) => op.kind === 'createNetPort')).toHaveLength(0);
       expect(bridgeCall).toHaveBeenCalledTimes(1);
       expect(bridgeCall).toHaveBeenCalledWith('schematic.getSheetInfo', { projectId: 'proj-555' });
@@ -72,6 +73,8 @@ describe('Workflow Tools', () => {
         if (method === 'schematic.placeComponent')
           return { primitiveId: `id-${bridgeCall.mock.calls.length}` };
         if (method === 'schematic.connectPinToNet') return { success: true };
+        if (method === 'schematic.addWire')
+          return { primitiveId: `wire-${bridgeCall.mock.calls.length}` };
         if (method === 'schematic.createNetPort')
           return { primitiveId: `net-${bridgeCall.mock.calls.length}` };
         if (method === 'schematic.listComponents') return { total: 8, items: [] };
@@ -103,6 +106,8 @@ describe('Workflow Tools', () => {
         if (method === 'schematic.placeComponent')
           return { primitiveId: `id-${bridgeCall.mock.calls.length}` };
         if (method === 'schematic.connectPinToNet') return { success: true };
+        if (method === 'schematic.addWire')
+          return { primitiveId: `wire-${bridgeCall.mock.calls.length}` };
         if (method === 'schematic.createNetPort')
           return { primitiveId: `net-${bridgeCall.mock.calls.length}` };
         if (method === 'schematic.listComponents') return { total: 8, items: [] };

--- a/tests/unit/workflows/ne555-astable-template.test.ts
+++ b/tests/unit/workflows/ne555-astable-template.test.ts
@@ -38,11 +38,22 @@ describe('NE555 astable template', () => {
     expect(result.workflowInput.anchor.y).toBeGreaterThan(700);
     expect(result.workflowInput.components).toHaveLength(8);
     expect(result.workflowInput.netPorts).toHaveLength(0);
+    expect(result.workflowInput.wires).toHaveLength(22);
 
     const byRef = new Map(result.workflowInput.components?.map((c) => [c.ref, c]));
     expect(byRef.get('U1')?.placementOffset).toEqual({ dx: 280, dy: -150 });
     expect(byRef.get('R1')?.placementOffset).toEqual({ dx: 120, dy: -70 });
     expect(byRef.get('D1')?.placementOffset).toEqual({ dx: 560, dy: -150 });
+  });
+
+  it('allows wire stubs to be disabled for pure connectivity fixtures', () => {
+    const result = buildNe555AstableTemplate({
+      projectId: 'proj-555',
+      devices,
+      createWireStubs: false,
+    });
+
+    expect(result.workflowInput.wires).toHaveLength(0);
   });
 
   it('wires NE555 pins to the correct astable nets', () => {


### PR DESCRIPTION
## Summary

- add generic `addWire` workflow operations so compound workflows can create visible schematic wire primitives transactionally
- add rollback support for newly-created workflow wires
- add NE555 visible wire stubs by default: 22 short pin-attached stubs for U1, R1/R2/R3, C1/C2/C3, and D1
- keep the wire stubs optional via `createWireStubs=false`
- update generated tool docs and tests

Partially addresses #253.

## Why

The 0.29.1 live test removed detached top-row netports and got DRC to Fatal=0 / Error=0 / Warning=0 / Info=0. The schematic is cleaner, but still reads like isolated net labels. This PR adds a low-risk visual wiring layer: short stubs attached to known pin coordinates. It does not yet attempt full long orthogonal routing between all functional blocks.

## Verification

- `pnpm test -- tests/unit/workflows/ne555-astable-template.test.ts tests/unit/workflows/planner.test.ts tests/unit/tools/workflows.test.ts` — root suite completed: 97 files / 1162 tests
- `pnpm typecheck`
- `pnpm format:check`
- `pnpm lint`
- `pnpm lint:tools`
- `pnpm verify:tool-coverage`
- `pnpm generate:tools-doc`
- `pnpm build`
- `pnpm docs:build`

## Follow-up

After release, live MSI/EasyEDA test should verify:

- preview operation mix includes 8 placements, 22 connectPinToNet, 22 addWire, 0 createNetPort
- apply succeeds and rolls back newly-created wires if any operation fails
- manual DRC remains Fatal=0 / Error=0 / Warning=0 / Info=0
- screenshot looks more readable than 0.29.1, while still not claiming full long-wire orthogonal routing yet