### PR TITLE
feat(workflows): add RP2040 servo-module scaffold

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -103,6 +103,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_workflow_ne555_astable`        | `pro`   | `medium` | Create a deterministic NE555 astable LED flasher workflow using safe sheet-region planning, component-level layout offsets, explicit pin-to-net connectivity, and optional post-write QA. Caller supplies already-resolved EasyEDA device items; this tool does not guess catalog parts (confirmWrite required).                 |
 | `easyeda_workflow_place_block`          | `pro`   | `medium` | Place a group of components, wire their pin-to-net connections (new and/or pre-existing components), and create net ports for block-external nets — all as a single atomic transaction with rollback on partial failure (confirmWrite required).                                                                                 |
 | `easyeda_workflow_power_rail`           | `pro`   | `medium` | Place a regulator and its supporting passives and wire them to input/output/ground nets in a single atomic transaction, instead of one primitive call per component. Caller supplies already-resolved device items and pin connections; this tool does not select parts (confirmWrite required).                                 |
+| `easyeda_workflow_rp2040_servo_module`  | `pro`   | `medium` | Create a deterministic functional-block scaffold for the RP2040 servo-module reference design. This first milestone places BOM components by block and returns explicit missing-netlist warnings; it does not infer exact pin-to-net wiring from screenshot+BOM alone (confirmWrite required).                                   |
 
 ---
 
@@ -3334,6 +3335,51 @@ Returns a JSON object matching the schema:
   rollback_notes: string[];
   error: string (optional);
   verification: object (optional);
+}
+```
+
+---
+
+## `easyeda_workflow_rp2040_servo_module`
+
+**Profile:** `pro` | **Risk Level:** `medium`
+
+> Create a deterministic functional-block scaffold for the RP2040 servo-module reference design. This first milestone places BOM components by block and returns explicit missing-netlist warnings; it does not infer exact pin-to-net wiring from screenshot+BOM alone (confirmWrite required).
+
+### Input Parameters
+
+| Parameter         | Type                 | Required       | Description   |
+| ----------------- | -------------------- | -------------- | ------------- |
+| `projectId`       | `string`             | Yes            |               |
+| `mode`            | `'preview'           | 'apply'`       | Yes           |               |
+| `devices`         | `object`             | Yes            |               |
+| `anchor`          | `object (optional)`  | No             |               |
+| `preferredRegion` | `'upper-left'        | 'upper-center' | 'upper-right' | 'center-left' | 'center' | 'center-right' | 'lower-left' | 'lower-center' | 'lower-right'` | Yes |     |
+| `margin`          | `number (optional)`  | No             |               |
+| `confirmWrite`    | `boolean (optional)` | No             |               |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  success: boolean;
+  project_id: string;
+  transaction_id: string;
+  mode: string;
+  applied: boolean;
+  blocked: boolean;
+  rolled_back: boolean;
+  placements: object[];
+  operations: object[];
+  apply_results: object[] (optional);
+  issues: object[];
+  summary: string;
+  rollback_notes: string[];
+  error: string (optional);
+  safe_region: object;
+  scaffold: object;
 }
 ```
 

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -22,7 +22,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Pro',
     description:
       'Adds pick-and-place, PDF, netlist export, compound transactional workflow tools, autorouting, route-context export, and offline SPICE verification for manufacturing workflows',
-    approxToolCount: '79',
+    approxToolCount: '80',
     isDefault: false,
   },
   full: {
@@ -30,7 +30,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls and CircuitIR-driven floorplanning for full runtime control without raw JavaScript execution',
-    approxToolCount: '91',
+    approxToolCount: '92',
     isDefault: false,
   },
   dev: {
@@ -38,14 +38,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '96',
+    approxToolCount: '97',
     isDefault: false,
   },
   experimental: {
     name: 'experimental',
     label: 'Experimental',
     description: 'MCP Apps, Tasks, AI action plans',
-    approxToolCount: '96',
+    approxToolCount: '97',
     isDefault: false,
   },
 };

--- a/src/tools/L2_workflows.ts
+++ b/src/tools/L2_workflows.ts
@@ -8,6 +8,7 @@ import {
   collectNativeRuleRunsForPostWriteQa,
 } from '../workflows/schematic-post-write-qa.js';
 import { buildNe555AstableTemplate } from '../workflows/ne555-astable-template.js';
+import { buildRp2040ServoModuleScaffold } from '../workflows/rp2040-servo-module-scaffold.js';
 import {
   computeSectionBounds,
   findOverlappingRectangles,
@@ -473,6 +474,65 @@ const postWriteQaOutputSchema = z.object({
   summary: z.string(),
 });
 
+const rp2040ServoDevicesSchema = z.object({
+  resistor0402: deviceItemSchema,
+  capacitor0402: deviceItemSchema,
+  capacitor0603: deviceItemSchema,
+  capacitorPolarized: deviceItemSchema,
+  rp2040: deviceItemSchema,
+  drv8244: deviceItemSchema,
+  w25q16: deviceItemSchema,
+  txs0102: deviceItemSchema,
+  regulator3v3: deviceItemSchema,
+  usbC: deviceItemSchema,
+  ws2812b: deviceItemSchema,
+  conn01x10: deviceItemSchema,
+  conn01x06: deviceItemSchema,
+  conn01x03: deviceItemSchema,
+  crystal: deviceItemSchema,
+  switchSmd: deviceItemSchema,
+  fuse: deviceItemSchema,
+  diode: deviceItemSchema,
+});
+
+const rp2040ServoInputSchema = z.object({
+  projectId: z.string().min(1),
+  mode: z.enum(['preview', 'apply']).default('preview'),
+  devices: rp2040ServoDevicesSchema,
+  anchor: pointSchema.optional(),
+  preferredRegion: schematicRegionPreferenceSchema.default('upper-left'),
+  margin: z.number().positive().optional(),
+  confirmWrite: z.boolean().optional(),
+});
+
+const rp2040ServoOutputSchema = workflowOutputSchema.extend({
+  safe_region: safeRegionOutputSchema,
+  scaffold: z.object({
+    blocks: z.array(
+      z.object({
+        id: z.string(),
+        title: z.string(),
+        origin: pointSchema,
+        size: z.object({ width: z.number(), height: z.number() }),
+        refs: z.array(z.string()),
+      }),
+    ),
+    bom: z.object({
+      expectedRefs: z.array(z.string()),
+      referenceCount: z.number().int().nonnegative(),
+      symbolGroups: z.array(
+        z.object({
+          symbol: z.string(),
+          refs: z.array(z.string()),
+          count: z.number().int().nonnegative(),
+        }),
+      ),
+    }),
+    warnings: z.array(z.string()),
+    notes: z.array(z.string()),
+  }),
+});
+
 const ne555OutputSchema = workflowOutputSchema.extend({
   safe_region: safeRegionOutputSchema,
   design: z.object({
@@ -650,6 +710,93 @@ function registerWorkflowTools(
   registry: { register: (def: ToolDefinition) => void },
   _config: EnvConfig,
 ) {
+  registry.register({
+    name: 'easyeda_workflow_rp2040_servo_module',
+    title: 'Plan or apply an RP2040 servo-module complex schematic scaffold',
+    description:
+      'Create a deterministic functional-block scaffold for the RP2040 servo-module reference design. ' +
+      'This first milestone places BOM components by block and returns explicit missing-netlist warnings; ' +
+      'it does not infer exact pin-to-net wiring from screenshot+BOM alone (confirmWrite required).',
+    profile: 'pro',
+    evidence: ['inferred', 'runtime-probe'],
+    risk: 'medium',
+    confirmWrite: true,
+    group: 'workflows',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
+    inputSchema: rp2040ServoInputSchema,
+    outputSchema: rp2040ServoOutputSchema,
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const p = rp2040ServoInputSchema.parse(params ?? {});
+      let sheetInfo: unknown;
+      try {
+        sheetInfo = await ctx.bridge.call('schematic.getSheetInfo', { projectId: p.projectId });
+      } catch {
+        sheetInfo = undefined;
+      }
+
+      const scaffold = buildRp2040ServoModuleScaffold({ ...p, sheetInfo });
+      const result = (await runWorkflow(
+        ctx,
+        scaffold.workflowInput,
+        'wf_rp2040_servo_module',
+        p.confirmWrite,
+        (plan) => {
+          for (const warning of scaffold.safeRegion.warnings) {
+            pushIssue(plan, {
+              code: 'WORKFLOW_SAFE_REGION',
+              severity: 'warning',
+              message: warning,
+              remediationHint:
+                'Review the returned safe_region bounds and choose a larger sheet or explicit anchor if needed.',
+            });
+          }
+          for (const issue of scaffold.safeRegion.issues) {
+            pushIssue(plan, {
+              code: 'WORKFLOW_SAFE_REGION',
+              severity: 'error',
+              message: `${issue.code}: ${issue.message}`,
+              remediationHint:
+                'Reduce scaffold size, choose another preferredRegion, or provide an explicit anchor.',
+            });
+          }
+          for (const warning of scaffold.warnings) {
+            pushIssue(plan, {
+              code: 'WORKFLOW_EMPTY_PIN_CONNECTIONS',
+              severity: 'warning',
+              message: warning,
+              remediationHint:
+                'Add block-level netlist workflows before treating apply output as an electrically complete schematic.',
+            });
+          }
+        },
+      )) as Record<string, unknown>;
+
+      return {
+        ...result,
+        scaffold: {
+          blocks: scaffold.blocks,
+          bom: scaffold.bom,
+          warnings: scaffold.warnings,
+          notes: scaffold.notes,
+        },
+        safe_region: {
+          blocked: scaffold.safeRegion.blocked,
+          preferred_region: scaffold.safeRegion.preferredRegion,
+          sheet: scaffold.safeRegion.sheet,
+          bounds: scaffold.safeRegion.bounds,
+          anchor: scaffold.workflowInput.anchor,
+          warnings: scaffold.safeRegion.warnings,
+          issues: scaffold.safeRegion.issues,
+        },
+      };
+    },
+  });
+
   registry.register({
     name: 'easyeda_workflow_ne555_astable',
     title: 'Plan or apply a professional NE555 astable LED flasher template',

--- a/src/workflows/rp2040-servo-module-scaffold.ts
+++ b/src/workflows/rp2040-servo-module-scaffold.ts
@@ -1,0 +1,347 @@
+import {
+  planSafeSchematicRegion,
+  type SchematicRegionPreference,
+} from './schematic-safe-region.js';
+import type { WorkflowBlockInput, WorkflowDeviceItem } from './types.js';
+
+export type ServoModuleBlockId =
+  | 'power_usb'
+  | 'rp2040_core'
+  | 'decoupling'
+  | 'motor_driver'
+  | 'leds'
+  | 'connectors'
+  | 'level_shifter';
+
+export interface ServoModuleBlockPlan {
+  id: ServoModuleBlockId;
+  title: string;
+  origin: { x: number; y: number };
+  size: { width: number; height: number };
+  refs: string[];
+}
+
+export interface Rp2040ServoModuleDevices {
+  resistor0402: WorkflowDeviceItem;
+  capacitor0402: WorkflowDeviceItem;
+  capacitor0603: WorkflowDeviceItem;
+  capacitorPolarized: WorkflowDeviceItem;
+  rp2040: WorkflowDeviceItem;
+  drv8244: WorkflowDeviceItem;
+  w25q16: WorkflowDeviceItem;
+  txs0102: WorkflowDeviceItem;
+  regulator3v3: WorkflowDeviceItem;
+  usbC: WorkflowDeviceItem;
+  ws2812b: WorkflowDeviceItem;
+  conn01x10: WorkflowDeviceItem;
+  conn01x06: WorkflowDeviceItem;
+  conn01x03: WorkflowDeviceItem;
+  crystal: WorkflowDeviceItem;
+  switchSmd: WorkflowDeviceItem;
+  fuse: WorkflowDeviceItem;
+  diode: WorkflowDeviceItem;
+}
+
+export interface Rp2040ServoModuleInput {
+  projectId: string;
+  mode?: 'preview' | 'apply';
+  devices: Rp2040ServoModuleDevices;
+  sheetInfo?: unknown;
+  anchor?: { x: number; y: number };
+  preferredRegion?: SchematicRegionPreference;
+  margin?: number;
+}
+
+export interface Rp2040ServoModulePlan {
+  workflowInput: WorkflowBlockInput;
+  safeRegion: ReturnType<typeof planSafeSchematicRegion>;
+  blocks: ServoModuleBlockPlan[];
+  bom: {
+    expectedRefs: string[];
+    referenceCount: number;
+    symbolGroups: Array<{ symbol: string; refs: string[]; count: number }>;
+  };
+  warnings: string[];
+  notes: string[];
+}
+
+const CONTENT = { width: 1260, height: 760 } as const;
+
+const BLOCK_DEFS: Array<
+  Omit<ServoModuleBlockPlan, 'origin'> & { offset: { dx: number; dy: number } }
+> = [
+  {
+    id: 'power_usb',
+    title: 'power and usb',
+    offset: { dx: 0, dy: -40 },
+    size: { width: 390, height: 290 },
+    refs: ['P1', 'FH1', 'D1', 'U2', 'C5', 'C7', 'C9', 'C10', 'R1', 'R2', 'R3', 'R4'],
+  },
+  {
+    id: 'rp2040_core',
+    title: 'rp2040 and reqs',
+    offset: { dx: 440, dy: -40 },
+    size: { width: 500, height: 460 },
+    refs: ['U3', 'U1', 'X1', 'SW1', 'SW2', 'R5', 'R6', 'R7', 'R8', 'R9', 'C1', 'C2', 'C3', 'C4'],
+  },
+  {
+    id: 'decoupling',
+    title: 'decoupling and rails',
+    offset: { dx: 955, dy: -40 },
+    size: { width: 305, height: 270 },
+    refs: ['C6', 'C8', 'C11', 'C12', 'C13', 'C14', 'C15', 'C16', 'C19', 'C20', 'C21', 'C22'],
+  },
+  {
+    id: 'motor_driver',
+    title: 'motor driver',
+    offset: { dx: 0, dy: -385 },
+    size: { width: 390, height: 210 },
+    refs: ['U4', 'R10', 'R11', 'R12', 'C17', 'C18'],
+  },
+  {
+    id: 'level_shifter',
+    title: 'level shifter',
+    offset: { dx: 520, dy: -535 },
+    size: { width: 210, height: 160 },
+    refs: ['U5'],
+  },
+  {
+    id: 'leds',
+    title: 'LEDs',
+    offset: { dx: 440, dy: -625 },
+    size: { width: 430, height: 135 },
+    refs: ['LED1', 'LED2', 'LED3', 'LED4'],
+  },
+  {
+    id: 'connectors',
+    title: 'connectors',
+    offset: { dx: 0, dy: -720 },
+    size: { width: 900, height: 160 },
+    refs: ['J1', 'J2', 'J3', 'J4'],
+  },
+];
+
+const SYMBOL_GROUPS = [
+  {
+    symbol: 'symbols_R',
+    refs: [
+      'R1',
+      'R2',
+      'R3',
+      'R4',
+      'R5',
+      'R6',
+      'R7',
+      'R8',
+      'R9',
+      'R10',
+      'R11',
+      'R12',
+      'R13',
+      'R14',
+      'R15',
+    ],
+  },
+  {
+    symbol: 'symbols_C',
+    refs: [
+      'C1',
+      'C2',
+      'C3',
+      'C4',
+      'C5',
+      'C6',
+      'C8',
+      'C9',
+      'C10',
+      'C11',
+      'C12',
+      'C13',
+      'C14',
+      'C15',
+      'C16',
+      'C17',
+      'C18',
+      'C19',
+      'C20',
+      'C21',
+      'C22',
+    ],
+  },
+  { symbol: 'symbols_C_Polarized', refs: ['C7'] },
+  { symbol: 'symbols_DRV8244SQRYJRQ1', refs: ['U4'] },
+  { symbol: 'symbols_WS2812B-2020', refs: ['LED1', 'LED2', 'LED3', 'LED4'] },
+  { symbol: 'symbols_W25Q16JVSS', refs: ['U1'] },
+  { symbol: 'symbols_RP2040', refs: ['U3'] },
+  { symbol: 'symbols_TXS0102DCU', refs: ['U5'] },
+  { symbol: 'symbols_USB_C_Plug_USB2.0', refs: ['P1'] },
+  { symbol: 'symbols_ME6211A33M3G-N', refs: ['U2'] },
+  { symbol: 'symbols_ABM8-272-T3_C20625731', refs: ['X1'] },
+  { symbol: 'symbols_TS-1088-AR02016', refs: ['SW1', 'SW2'] },
+  { symbol: 'symbols_Conn_01x10', refs: ['J1', 'J2'] },
+  { symbol: 'symbols_Conn_01x06', refs: ['J4'] },
+  { symbol: 'symbols_Conn_01x03', refs: ['J3'] },
+  { symbol: 'symbols_01550900M', refs: ['FH1'] },
+  { symbol: 'symbols_MBR1020VL', refs: ['D1'] },
+] as const;
+
+function devFor(ref: string, devices: Rp2040ServoModuleDevices): WorkflowDeviceItem {
+  if (ref.startsWith('R')) return devices.resistor0402;
+  if (ref === 'C7') return devices.capacitorPolarized;
+  if (['C5', 'C9'].includes(ref)) return devices.capacitor0603;
+  if (ref.startsWith('C')) return devices.capacitor0402;
+  if (ref === 'U3') return devices.rp2040;
+  if (ref === 'U4') return devices.drv8244;
+  if (ref === 'U1') return devices.w25q16;
+  if (ref === 'U5') return devices.txs0102;
+  if (ref === 'U2') return devices.regulator3v3;
+  if (ref === 'P1') return devices.usbC;
+  if (ref.startsWith('LED')) return devices.ws2812b;
+  if (ref === 'J1' || ref === 'J2') return devices.conn01x10;
+  if (ref === 'J4') return devices.conn01x06;
+  if (ref === 'J3') return devices.conn01x03;
+  if (ref === 'X1') return devices.crystal;
+  if (ref === 'SW1' || ref === 'SW2') return devices.switchSmd;
+  if (ref === 'FH1') return devices.fuse;
+  if (ref === 'D1') return devices.diode;
+  return devices.resistor0402;
+}
+
+const REF_OFFSETS: Record<string, { dx: number; dy: number; rotation?: number }> = {
+  P1: { dx: 90, dy: -170 },
+  FH1: { dx: 45, dy: -260 },
+  D1: { dx: 235, dy: -110 },
+  U2: { dx: 270, dy: -125 },
+  R1: { dx: 40, dy: -60, rotation: 180 },
+  R2: { dx: 45, dy: -105, rotation: 180 },
+  R3: { dx: 160, dy: -60, rotation: 180 },
+  R4: { dx: 160, dy: -105, rotation: 180 },
+  C5: { dx: 315, dy: -70 },
+  C7: { dx: 170, dy: -200 },
+  C9: { dx: 270, dy: -185 },
+  C10: { dx: 340, dy: -185 },
+
+  U3: { dx: 720, dy: -220 },
+  U1: { dx: 565, dy: -170 },
+  X1: { dx: 565, dy: -330 },
+  SW1: { dx: 610, dy: -250 },
+  SW2: { dx: 800, dy: -85 },
+  R5: { dx: 540, dy: -250, rotation: 270 },
+  R6: { dx: 505, dy: -85, rotation: 180 },
+  R7: { dx: 630, dy: -335 },
+  R8: { dx: 640, dy: -150, rotation: 180 },
+  R9: { dx: 675, dy: -150, rotation: 180 },
+  C1: { dx: 455, dy: -270 },
+  C2: { dx: 540, dy: -390 },
+  C3: { dx: 490, dy: -275 },
+  C4: { dx: 645, dy: -390 },
+
+  C6: { dx: 980, dy: -115 },
+  C8: { dx: 1110, dy: -225 },
+  C11: { dx: 965, dy: -35 },
+  C12: { dx: 990, dy: -185 },
+  C13: { dx: 1030, dy: -185 },
+  C14: { dx: 1070, dy: -205 },
+  C15: { dx: 1060, dy: -35 },
+  C16: { dx: 1055, dy: -80 },
+  C19: { dx: 1145, dy: -35 },
+  C20: { dx: 1155, dy: -120 },
+  C21: { dx: 1195, dy: -165 },
+  C22: { dx: 1235, dy: -35 },
+  R13: { dx: 1125, dy: -145 },
+  R14: { dx: 960, dy: -145 },
+  R15: { dx: 960, dy: -185 },
+
+  U4: { dx: 220, dy: -485 },
+  R10: { dx: 155, dy: -485, rotation: 90 },
+  R11: { dx: 255, dy: -485, rotation: 90 },
+  R12: { dx: 45, dy: -505 },
+  C17: { dx: 45, dy: -545 },
+  C18: { dx: 110, dy: -545 },
+
+  U5: { dx: 590, dy: -545 },
+  LED1: { dx: 450, dy: -675 },
+  LED2: { dx: 550, dy: -675 },
+  LED3: { dx: 650, dy: -675 },
+  LED4: { dx: 750, dy: -675 },
+
+  J1: { dx: 95, dy: -790 },
+  J2: { dx: 340, dy: -790 },
+  J3: { dx: 540, dy: -815 },
+  J4: { dx: 700, dy: -790 },
+};
+
+function expectedRefs(): string[] {
+  return [...new Set(SYMBOL_GROUPS.flatMap((group) => [...group.refs]))].sort((a, b) =>
+    a.localeCompare(b, 'en'),
+  );
+}
+
+function buildBlocks(anchor: { x: number; y: number }): ServoModuleBlockPlan[] {
+  return BLOCK_DEFS.map((block) => ({
+    id: block.id,
+    title: block.title,
+    size: block.size,
+    refs: block.refs,
+    origin: { x: anchor.x + block.offset.dx, y: anchor.y + block.offset.dy },
+  }));
+}
+
+export function buildRp2040ServoModuleScaffold(
+  input: Rp2040ServoModuleInput,
+): Rp2040ServoModulePlan {
+  const safeRegion = planSafeSchematicRegion({
+    sheetInfo: input.sheetInfo,
+    contentWidth: CONTENT.width,
+    contentHeight: CONTENT.height,
+    preferredRegion: input.preferredRegion ?? 'upper-left',
+    margin: input.margin,
+  });
+  const anchor = input.anchor ?? safeRegion.anchor;
+  const refs = expectedRefs();
+  const components = refs.map((ref) => {
+    const offset = REF_OFFSETS[ref] ?? { dx: 0, dy: 0 };
+    return {
+      ref,
+      role: `servo-module:${ref}`,
+      deviceItem: devFor(ref, input.devices),
+      placementOffset: { dx: offset.dx, dy: offset.dy },
+      rotation: offset.rotation,
+      pinConnections: [],
+    };
+  });
+
+  const workflowInput: WorkflowBlockInput = {
+    projectId: input.projectId,
+    mode: input.mode ?? 'preview',
+    anchor,
+    spacing: 50,
+    components,
+    netPorts: [],
+    wires: [],
+  };
+
+  return {
+    workflowInput,
+    safeRegion,
+    blocks: buildBlocks(anchor),
+    bom: {
+      expectedRefs: refs,
+      referenceCount: refs.length,
+      symbolGroups: SYMBOL_GROUPS.map((group) => ({
+        symbol: group.symbol,
+        refs: [...group.refs],
+        count: group.refs.length,
+      })),
+    },
+    warnings: [
+      'This scaffold intentionally places BOM blocks only; exact pin-to-net wiring is not inferred from screenshot+BOM.',
+      'Use follow-up block workflows for power/USB, RP2040 core, motor driver, LEDs, connectors, and level shifter netlists.',
+      'Apply mode will place components without electrical connectivity, so ERC warnings are expected until block netlists are added.',
+    ],
+    notes: [
+      'Functional blocks mirror the user-provided servo-module reference: power and usb, rp2040 and reqs, motor driver, LEDs, connectors, decoupling, and level shifter.',
+      'Detached netports are disabled by default; future netlist milestones should add visible wiring per block.',
+    ],
+  };
+}

--- a/src/workflows/schematic-safe-region.ts
+++ b/src/workflows/schematic-safe-region.ts
@@ -73,6 +73,11 @@ const DEFAULT_A4_LANDSCAPE = {
   unit: 'easyeda-coordinate',
 } as const;
 
+const TITLE_BLOCK_PAGE_SIZES = {
+  A4: { width: 1189, height: 841 },
+  A3: { width: 1682, height: 1189 },
+} as const;
+
 const DEFAULT_MARGIN = 80;
 
 const REGION_ROWS: Record<SchematicRegionPreference, 'upper' | 'center' | 'lower'> = {
@@ -125,6 +130,20 @@ function readString(record: Record<string, unknown>, keys: readonly string[]): s
   return undefined;
 }
 
+function readTitleBlockPageSize(
+  root: Record<string, unknown>,
+  currentOrRoot: Record<string, unknown>,
+) {
+  const titleBlock = readRecord(currentOrRoot.titleBlockData ?? root.titleBlockData);
+  const sizeRecord = readRecord(titleBlock.Size);
+  const sizeValue = String(sizeRecord.value ?? '')
+    .replace(/[^A-Za-z0-9]/g, '')
+    .toUpperCase();
+  if (sizeValue === 'A3') return TITLE_BLOCK_PAGE_SIZES.A3;
+  if (sizeValue === 'A4') return TITLE_BLOCK_PAGE_SIZES.A4;
+  return undefined;
+}
+
 export function inferSchematicSheetGeometry(sheetInfo: unknown): SchematicSheetGeometry {
   const root = readRecord(sheetInfo);
   const current = readRecord(root.currentPage);
@@ -148,6 +167,17 @@ export function inferSchematicSheetGeometry(sheetInfo: unknown): SchematicSheetG
 
   if (width !== undefined && height !== undefined) {
     return { width, height, unit, origin: 'bottom-left', source: 'sheet-info' };
+  }
+
+  const titleBlockSize = readTitleBlockPageSize(root, currentOrRoot);
+  if (titleBlockSize !== undefined) {
+    return {
+      width: titleBlockSize.width,
+      height: titleBlockSize.height,
+      unit,
+      origin: 'bottom-left',
+      source: 'sheet-info',
+    };
   }
 
   return {

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -43,10 +43,10 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('79');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('80');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('91');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('92');
   });
 });

--- a/tests/unit/tools/workflows.test.ts
+++ b/tests/unit/tools/workflows.test.ts
@@ -143,6 +143,54 @@ describe('Workflow Tools', () => {
     });
   });
 
+  describe('easyeda_workflow_rp2040_servo_module', () => {
+    const servoDevices = {
+      resistor0402: deviceItem,
+      capacitor0402: deviceItem,
+      capacitor0603: deviceItem,
+      capacitorPolarized: deviceItem,
+      rp2040: deviceItem,
+      drv8244: deviceItem,
+      w25q16: deviceItem,
+      txs0102: deviceItem,
+      regulator3v3: deviceItem,
+      usbC: deviceItem,
+      ws2812b: deviceItem,
+      conn01x10: deviceItem,
+      conn01x06: deviceItem,
+      conn01x03: deviceItem,
+      crystal: deviceItem,
+      switchSmd: deviceItem,
+      fuse: deviceItem,
+      diode: deviceItem,
+    };
+
+    it('previews the RP2040 servo-module scaffold without writing to EasyEDA', async () => {
+      bridgeCall.mockResolvedValueOnce({ currentPage: { width: 1682, height: 1189 } });
+      const tool = registry.get('easyeda_workflow_rp2040_servo_module');
+      const result = (await tool?.handler(context, {
+        projectId: 'servo',
+        mode: 'preview',
+        devices: servoDevices,
+      })) as any;
+
+      expect(result.applied).toBe(false);
+      expect(result.blocked).toBe(false);
+      expect(result.placements).toHaveLength(56);
+      expect(result.operations).toHaveLength(56);
+      expect(result.operations.every((op: any) => op.kind === 'placeComponent')).toBe(true);
+      expect(result.scaffold.bom.referenceCount).toBe(56);
+      expect(result.scaffold.blocks).toHaveLength(7);
+      expect(result.scaffold.warnings.join('\n')).toContain(
+        'exact pin-to-net wiring is not inferred',
+      );
+      expect(
+        result.issues.some((issue: any) => issue.code === 'WORKFLOW_EMPTY_PIN_CONNECTIONS'),
+      ).toBe(true);
+      expect(bridgeCall).toHaveBeenCalledWith('schematic.getSheetInfo', { projectId: 'servo' });
+    });
+  });
+
   describe('easyeda_workflow_power_rail', () => {
     const basePowerRailInput = () => ({
       projectId: 'proj-1',

--- a/tests/unit/workflows/rp2040-servo-module-scaffold.test.ts
+++ b/tests/unit/workflows/rp2040-servo-module-scaffold.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { buildRp2040ServoModuleScaffold } from '../../../src/workflows/rp2040-servo-module-scaffold.js';
+
+const deviceItem = { libraryUuid: 'lib', uuid: 'dev' };
+const devices = {
+  resistor0402: deviceItem,
+  capacitor0402: deviceItem,
+  capacitor0603: deviceItem,
+  capacitorPolarized: deviceItem,
+  rp2040: deviceItem,
+  drv8244: deviceItem,
+  w25q16: deviceItem,
+  txs0102: deviceItem,
+  regulator3v3: deviceItem,
+  usbC: deviceItem,
+  ws2812b: deviceItem,
+  conn01x10: deviceItem,
+  conn01x06: deviceItem,
+  conn01x03: deviceItem,
+  crystal: deviceItem,
+  switchSmd: deviceItem,
+  fuse: deviceItem,
+  diode: deviceItem,
+};
+
+describe('RP2040 servo-module scaffold', () => {
+  it('builds the expected BOM scaffold without netlist wiring', () => {
+    const result = buildRp2040ServoModuleScaffold({
+      projectId: 'servo',
+      devices,
+      sheetInfo: { currentPage: { width: 1682, height: 1189 } },
+    });
+
+    expect(result.safeRegion.blocked).toBe(false);
+    expect(result.blocks.map((block) => block.id)).toEqual([
+      'power_usb',
+      'rp2040_core',
+      'decoupling',
+      'motor_driver',
+      'level_shifter',
+      'leds',
+      'connectors',
+    ]);
+    expect(result.bom.referenceCount).toBe(56);
+    expect(result.workflowInput.components).toHaveLength(56);
+    expect(result.workflowInput.netPorts).toEqual([]);
+    expect(result.workflowInput.wires).toEqual([]);
+    expect(result.warnings.join('\n')).toContain('exact pin-to-net wiring is not inferred');
+  });
+
+  it('places major components in deterministic functional blocks', () => {
+    const result = buildRp2040ServoModuleScaffold({
+      projectId: 'servo',
+      devices,
+      anchor: { x: 100, y: 900 },
+    });
+    const byRef = new Map(
+      result.workflowInput.components?.map((component) => [component.ref, component]),
+    );
+
+    expect(byRef.get('P1')?.placementOffset).toEqual({ dx: 90, dy: -170 });
+    expect(byRef.get('U3')?.placementOffset).toEqual({ dx: 720, dy: -220 });
+    expect(byRef.get('U4')?.placementOffset).toEqual({ dx: 220, dy: -485 });
+    expect(byRef.get('LED4')?.placementOffset).toEqual({ dx: 750, dy: -675 });
+    expect(byRef.get('J4')?.placementOffset).toEqual({ dx: 700, dy: -790 });
+
+    expect(result.blocks.find((block) => block.id === 'power_usb')).toMatchObject({
+      title: 'power and usb',
+      origin: { x: 100, y: 860 },
+    });
+    expect(result.blocks.find((block) => block.id === 'rp2040_core')?.refs).toContain('U3');
+  });
+
+  it('maps representative references to the correct device buckets', () => {
+    const unique = (uuid: string) => ({ libraryUuid: 'lib', uuid });
+    const result = buildRp2040ServoModuleScaffold({
+      projectId: 'servo',
+      devices: {
+        ...devices,
+        resistor0402: unique('res'),
+        capacitor0402: unique('cap0402'),
+        capacitor0603: unique('cap0603'),
+        capacitorPolarized: unique('cap-pol'),
+        rp2040: unique('rp2040'),
+        usbC: unique('usb-c'),
+      },
+    });
+    const byRef = new Map(
+      result.workflowInput.components?.map((component) => [component.ref, component]),
+    );
+
+    expect(byRef.get('R10')?.deviceItem.uuid).toBe('res');
+    expect(byRef.get('C11')?.deviceItem.uuid).toBe('cap0402');
+    expect(byRef.get('C5')?.deviceItem.uuid).toBe('cap0603');
+    expect(byRef.get('C7')?.deviceItem.uuid).toBe('cap-pol');
+    expect(byRef.get('U3')?.deviceItem.uuid).toBe('rp2040');
+    expect(byRef.get('P1')?.deviceItem.uuid).toBe('usb-c');
+  });
+});


### PR DESCRIPTION
## Summary

- add `easyeda_workflow_rp2040_servo_module`
- add deterministic functional block placement for the user-provided RP2040 servo-module reference
- model 56 expected BOM references across power/USB, RP2040 core, decoupling, motor driver, level shifter, LEDs, and connectors
- keep pin-to-net wiring intentionally absent and return explicit missing-netlist warnings
- infer A3 sheet geometry from EasyEDA title-block `Size=A3` when runtime page size is missing
- update tool counts and generated docs

Partially addresses #258.

## Verification

- `pnpm test -- tests/unit/workflows/rp2040-servo-module-scaffold.test.ts tests/unit/tools/workflows.test.ts`
- `pnpm typecheck`
- `pnpm verify:tool-coverage`
- `pnpm test -- tests/unit/config/profiles.test.ts`
- `pnpm format:check`
- `pnpm lint`
- `pnpm lint:tools`
- `pnpm generate:tools-doc`
- `pnpm build`
- `pnpm docs:build`

## Follow-up

Next #258 milestones are block-by-block netlists: power/USB, RP2040 core, motor driver, LED chain, connectors, and visual QA.