### PR TITLE
fix(remote): complete relay routing error taxonomy

### DIFF
--- a/docs/REMOTE_GATEWAY_DESIGN.md
+++ b/docs/REMOTE_GATEWAY_DESIGN.md
@@ -24,14 +24,13 @@ document.
 
 ## Request flow
 
-> **Status: target design, not yet wired.** The steps below describe the intended flow
-> once tool execution is bridged to the relay. Today, a real `POST /mcp` tool call never
-> reaches the session router, policy/approval gate, or relay dispatch — it always
-> dispatches through the local-loopback `BridgeManager` WebSocket instead (see
-> `docs/REMOTE_RELEASE_READINESS.md` for the current-status writeup). The session
-> router, approval policy, and relay dispatch steps below exist and are tested only via
-> the separate `/remote/*` REST/WebSocket surface, which nothing in the `/mcp` tool-call
-> path currently calls.
+> **Status: experimental and wired behind explicit configuration.** With the default
+> `MCP_BRIDGE_BACKEND=local_bridge`, `/mcp` tool calls continue to use the local
+> `BridgeManager`. With `MCP_BRIDGE_BACKEND=remote_relay`, the ToolRegistry replaces the
+> per-request bridge call path with `RemoteGateway.routeToolRequest(...)`, so existing MCP
+> tool handlers route through the paired extension session without being rewritten. The
+> routing foundation is CI-tested, but production identity/session UX, approval creation,
+> and live hosted relay dogfood are still required before Beta status.
 
 ```text
 remote MCP request
@@ -72,17 +71,21 @@ OAUTH_REQUIRED_SCOPES=easyeda.read
 The existing safe production guardrails should remain active. Public binding must require OAuth and
 an explicit origin allowlist.
 
-## Planned remote relay configuration
+## Experimental remote relay configuration
 
-These variables are design targets for the hosted relay runtime and must not be documented as
-production-ready until the relay runtime is implemented:
+The routed MCP path is enabled explicitly. Local bridge mode remains the default.
 
 ```env
-REMOTE_MODE=hosted
-PAIRING_REQUIRED=true
-REQUIRE_APPROVAL_FOR_WRITE=true
-REQUIRE_APPROVAL_FOR_EXPORT=true
+TRANSPORT=http
+MCP_BRIDGE_BACKEND=remote_relay
+MCP_REMOTE_SESSION_ID=session-id-if-fixed
+OAUTH_ENABLED=true
 ```
+
+`MCP_REMOTE_SESSION_ID` is optional when the MCP request supplies `remoteSessionId`.
+Write/export/destructive bridge calls require a valid `remoteApprovalId` that matches the
+user, session, method, and input hash. The `/remote/*` pairing, approval, audit, and relay
+endpoints are mounted by the HTTP transport.
 
 ## Route responsibilities
 
@@ -108,6 +111,8 @@ The gateway must return safe, actionable errors for:
 - missing active project,
 - approval required,
 - approval rejected or timed out,
+- unsupported extension method,
+- remote extension deadline timeout,
 - unsupported relay protocol version.
 
 ## Non-goals for MVP

--- a/docs/REMOTE_MCP_TEST_PLAN.md
+++ b/docs/REMOTE_MCP_TEST_PLAN.md
@@ -15,9 +15,9 @@ Remote MCP tests should validate security boundaries before implementation is co
 
 ## Integration smoke tests
 
-The integration smoke suite should be able to run without live EasyEDA credentials by using a fake extension relay fixture.
+The integration smoke suite runs without live EasyEDA credentials by using a fake extension relay fixture. Coverage is implemented in `tests/unit/remote/fake-extension-integration.test.ts`, `tests/unit/remote/gateway.test.ts`, and `tests/unit/tools/registry.test.ts`.
 
-Recommended scenarios:
+Required scenarios:
 
 1. User pairs fake extension session.
 2. Remote read tool routes and returns a fixture response.
@@ -28,10 +28,9 @@ Recommended scenarios:
 
 ## Manual validation
 
-**Not yet achievable:** every scenario below assumes a real MCP tool call can be routed
-through the pairing/session-router/relay subsystem. That integration does not exist yet
-(see `docs/REMOTE_RELEASE_READINESS.md`), so none of these can currently be executed
-end-to-end. Keep this section as the target validation checklist for when that lands.
+The CI-safe `/mcp`-to-relay routing foundation is implemented. The remaining manual
+validation is a live hosted end-to-end run with a real EasyEDA extension, production identity,
+session selection, and approval UX. Keep the checklist below as the Beta gate.
 
 Before public beta:
 

--- a/docs/REMOTE_OBSERVABILITY.md
+++ b/docs/REMOTE_OBSERVABILITY.md
@@ -48,18 +48,22 @@ Prefer hashes, counts, sizes, and structured status codes.
 
 ## Error taxonomy
 
-| Code                        | Meaning                                       |
-| --------------------------- | --------------------------------------------- |
-| `AUTH_MISSING`              | No valid remote auth context.                 |
-| `AUTH_INSUFFICIENT_SCOPE`   | Token lacks the required scope.               |
-| `SESSION_UNPAIRED`          | User has no paired extension session.         |
-| `SESSION_DISCONNECTED`      | Extension session is not connected.           |
-| `PROJECT_INACTIVE`          | EasyEDA project cannot be detected.           |
-| `APPROVAL_REQUIRED`         | Action requires approval.                     |
-| `APPROVAL_REJECTED`         | User rejected the action.                     |
-| `APPROVAL_TIMEOUT`          | Approval window expired.                      |
-| `RELAY_VERSION_UNSUPPORTED` | Relay protocol version mismatch.              |
-| `BRIDGE_EXECUTION_FAILED`   | EasyEDA bridge returned an execution failure. |
+| Code                        | Meaning                                                    |
+| --------------------------- | ---------------------------------------------------------- |
+| `IDENTITY_MISSING`          | No valid remote identity was propagated.                   |
+| `IDENTITY_EXPIRED`          | Remote identity is expired.                                |
+| `SCOPE_MISSING`             | Identity lacks the scope required by the risk level.       |
+| `SESSION_UNPAIRED`          | User has no matching paired extension session.             |
+| `SESSION_DISCONNECTED`      | Paired extension session is no longer connected.           |
+| `SESSION_EXPIRED`           | Paired extension session exceeded its TTL.                 |
+| `SESSION_AMBIGUOUS`         | Multiple sessions match and no explicit session was given. |
+| `PROJECT_INACTIVE`          | A risky call has no confirmed active EasyEDA project.      |
+| `APPROVAL_REQUIRED`         | Action requires an explicit approval id.                   |
+| `APPROVAL_NOT_APPROVED`     | Approval is absent, invalid, expired, or already consumed. |
+| `REMOTE_TOOL_UNSUPPORTED`   | Extension rejected the requested method as unsupported.    |
+| `REMOTE_EXTENSION_TIMEOUT`  | Extension did not answer before the request deadline.      |
+| `REMOTE_EXTENSION_ERROR`    | Extension or relay failed for a non-timeout reason.        |
+| `RELAY_VERSION_UNSUPPORTED` | Relay protocol version mismatch.                           |
 
 ## Acceptance baseline
 

--- a/docs/REMOTE_RELEASE_READINESS.md
+++ b/docs/REMOTE_RELEASE_READINESS.md
@@ -32,6 +32,8 @@ support yet. This means:
   `remoteSessionId` or `MCP_REMOTE_SESSION_ID` identifies the session.
 - Write/export calls can pass `remoteApprovalId` into the gateway and fail closed if the
   approval is absent, rejected, expired, or mismatched.
+- Remote dispatch enforces the bridge-call deadline for every dispatcher and reports
+  unsupported extension methods separately from generic extension failures.
 - The extension's `RemoteRelayClient` (Remote Relay Mode) genuinely connects to a relay
   URL, includes reconnect/backoff and heartbeat liveness, and can execute real EasyEDA
   API calls when driven directly.

--- a/src/remote/gateway.ts
+++ b/src/remote/gateway.ts
@@ -51,6 +51,7 @@ export type RemoteGatewayErrorCode =
   | 'APPROVAL_REQUIRED'
   | 'APPROVAL_NOT_APPROVED'
   | 'REMOTE_EXTENSION_ERROR'
+  | 'REMOTE_TOOL_UNSUPPORTED'
   | 'REMOTE_EXTENSION_TIMEOUT';
 
 export type RemoteGatewayToolResult =
@@ -107,6 +108,39 @@ function gatewayError(
   message: string,
 ): RemoteGatewayToolResult {
   return { ok: false, status, code, message };
+}
+
+class RemoteDispatchTimeoutError extends Error {
+  constructor(readonly timeoutMs: number) {
+    super(`Remote extension did not respond within ${timeoutMs}ms.`);
+    this.name = 'RemoteDispatchTimeoutError';
+  }
+}
+
+async function dispatchWithDeadline(
+  dispatch: RemoteToolDispatcher,
+  request: ToolRequestMessage,
+): Promise<ToolResponseMessage> {
+  const timeoutMs = request.deadlineMs ?? 30_000;
+  return await new Promise<ToolResponseMessage>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new RemoteDispatchTimeoutError(timeoutMs)), timeoutMs);
+    void Promise.resolve()
+      .then(() => dispatch(request))
+      .then(
+        (response) => {
+          clearTimeout(timeout);
+          resolve(response);
+        },
+        (error: unknown) => {
+          clearTimeout(timeout);
+          reject(error instanceof Error ? error : new Error(String(error)));
+        },
+      );
+  });
+}
+
+function isUnsupportedRemoteMethod(code: string | undefined): boolean {
+  return code === 'METHOD_NOT_ALLOWED' || code === 'METHOD_NOT_FOUND';
 }
 
 function scopeStringToList(value: unknown): string[] {
@@ -352,7 +386,9 @@ export class RemoteGateway {
         riskLevel: input.riskLevel,
         inputHash,
       });
-      const response = ToolResponseMessageSchema.parse(await connection.dispatch(request));
+      const response = ToolResponseMessageSchema.parse(
+        await dispatchWithDeadline(connection.dispatch, request),
+      );
       if (!response.ok) {
         this.audit.record({
           event: 'remote.tool.failed',
@@ -366,6 +402,14 @@ export class RemoteGateway {
           errorCode: response.error?.code ?? 'REMOTE_EXTENSION_ERROR',
           durationMs: Date.now() - startedAt,
         });
+        const extensionCode = response.error?.code;
+        if (isUnsupportedRemoteMethod(extensionCode)) {
+          return gatewayError(
+            422,
+            'REMOTE_TOOL_UNSUPPORTED',
+            `${extensionCode}: ${response.error?.message ?? 'Remote extension does not support this method.'}`,
+          );
+        }
         return gatewayError(
           502,
           'REMOTE_EXTENSION_ERROR',
@@ -391,6 +435,10 @@ export class RemoteGateway {
         durationMs: response.durationMs,
       };
     } catch (error) {
+      const timedOut = error instanceof RemoteDispatchTimeoutError;
+      const errorCode: RemoteGatewayErrorCode = timedOut
+        ? 'REMOTE_EXTENSION_TIMEOUT'
+        : 'REMOTE_EXTENSION_ERROR';
       this.audit.record({
         event: 'remote.tool.failed',
         mode: route.session.mode,
@@ -400,12 +448,12 @@ export class RemoteGateway {
         riskLevel: input.riskLevel,
         inputHash,
         status: 'error',
-        errorCode: 'REMOTE_EXTENSION_TIMEOUT',
+        errorCode,
         durationMs: Date.now() - startedAt,
       });
       return gatewayError(
-        504,
-        'REMOTE_EXTENSION_TIMEOUT',
+        timedOut ? 504 : 502,
+        errorCode,
         error instanceof Error ? error.message : String(error),
       );
     }

--- a/tests/unit/remote/gateway.test.ts
+++ b/tests/unit/remote/gateway.test.ts
@@ -217,4 +217,117 @@ describe('RemoteGateway', () => {
       }),
     ).resolves.toMatchObject({ ok: true });
   });
+
+  it('distinguishes unsupported extension methods from generic extension failures', async () => {
+    const { gateway } = makeGateway();
+    const session = gateway.registerExtension({
+      connectionId: 'conn-unsupported',
+      mode: 'hosted',
+      extensionVersion: '0.32.0',
+      activeProject: { projectName: 'Demo', documentType: 'schematic' },
+      dispatch: async (request) => ({
+        protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+        type: 'tool_response',
+        messageId: 'response-unsupported',
+        sessionId: request.sessionId,
+        requestMessageId: request.messageId,
+        timestamp: new Date('2026-07-04T00:00:00.000Z').toISOString(),
+        ok: false,
+        error: {
+          code: 'METHOD_NOT_ALLOWED',
+          message: 'Method is not in the extension allowlist.',
+        },
+        durationMs: 1,
+      }),
+    });
+    const code = gateway.createPairingCode({
+      identity: readIdentity,
+      sessionId: session.sessionId,
+    });
+    expect(
+      gateway.completePairing({ identity: readIdentity, code, sessionId: session.sessionId }),
+    ).toBe(true);
+
+    await expect(
+      gateway.routeToolRequest({
+        identity: readIdentity,
+        sessionId: session.sessionId,
+        toolName: 'schematic.unsupportedMethod',
+        riskLevel: 'read',
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 422,
+      code: 'REMOTE_TOOL_UNSUPPORTED',
+      message: expect.stringContaining('METHOD_NOT_ALLOWED'),
+    });
+  });
+
+  it('enforces the request deadline for every dispatcher', async () => {
+    const { gateway } = makeGateway();
+    const session = gateway.registerExtension({
+      connectionId: 'conn-timeout',
+      mode: 'hosted',
+      extensionVersion: '0.32.0',
+      activeProject: { projectName: 'Demo', documentType: 'schematic' },
+      dispatch: async () => await new Promise(() => undefined),
+    });
+    const code = gateway.createPairingCode({
+      identity: readIdentity,
+      sessionId: session.sessionId,
+    });
+    expect(
+      gateway.completePairing({ identity: readIdentity, code, sessionId: session.sessionId }),
+    ).toBe(true);
+
+    await expect(
+      gateway.routeToolRequest({
+        identity: readIdentity,
+        sessionId: session.sessionId,
+        toolName: 'schematic.getDocument',
+        riskLevel: 'read',
+        deadlineMs: 5,
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 504,
+      code: 'REMOTE_EXTENSION_TIMEOUT',
+      message: expect.stringContaining('5ms'),
+    });
+  });
+
+  it('keeps non-timeout dispatcher failures in the extension error category', async () => {
+    const { gateway } = makeGateway();
+    const session = gateway.registerExtension({
+      connectionId: 'conn-error',
+      mode: 'hosted',
+      extensionVersion: '0.32.0',
+      activeProject: { projectName: 'Demo', documentType: 'schematic' },
+      dispatch: () => {
+        throw new Error('Remote relay socket closed unexpectedly.');
+      },
+    });
+    const code = gateway.createPairingCode({
+      identity: readIdentity,
+      sessionId: session.sessionId,
+    });
+    expect(
+      gateway.completePairing({ identity: readIdentity, code, sessionId: session.sessionId }),
+    ).toBe(true);
+
+    await expect(
+      gateway.routeToolRequest({
+        identity: readIdentity,
+        sessionId: session.sessionId,
+        toolName: 'schematic.getDocument',
+        riskLevel: 'read',
+        deadlineMs: 100,
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 502,
+      code: 'REMOTE_EXTENSION_ERROR',
+      message: 'Remote relay socket closed unexpectedly.',
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- enforce Remote Relay request deadlines for every dispatcher, including fake/in-process dispatchers
- distinguish unsupported extension methods from generic extension or relay failures
- stop classifying every dispatcher rejection as a timeout
- align Remote Relay design, test-plan, observability, and readiness documentation with the implemented MCP routing path

## Validation
- main tests: 1257/1257 passed
- extension tests: 90/90 passed
- main and extension typechecks passed
- ESLint, tool metadata lint, tool coverage, builds, extension verification, metadata check, and docs build passed
- targeted Remote Relay and registry suite: 83/83 passed

Closes #234