### PR TITLE
fix(config): anchor default storage paths to user home

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,12 +467,14 @@ For Remote Relay experiments, run `npx easyeda-mcp-pro doctor --fix` after setti
 
 ### Storage
 
-| Variable       | Default                                   | Description                                 |
-| -------------- | ----------------------------------------- | ------------------------------------------- |
-| `DATA_DIR`     | `.easyeda-mcp-pro`                        | Data directory (cache, database, artifacts) |
-| `SQLITE_PATH`  | `.easyeda-mcp-pro/easyeda-mcp-pro.sqlite` | SQLite database path                        |
-| `ARTIFACT_DIR` | `.easyeda-mcp-pro/artifacts`              | Artifact export directory                   |
-| `CACHE_DIR`    | `.easyeda-mcp-pro/cache`                  | Cache directory                             |
+| Variable       | Default                                     | Description                                 |
+| -------------- | ------------------------------------------- | ------------------------------------------- |
+| `DATA_DIR`     | `~/.easyeda-mcp-pro`                        | Data directory (cache, database, artifacts) |
+| `SQLITE_PATH`  | `~/.easyeda-mcp-pro/easyeda-mcp-pro.sqlite` | SQLite database path                        |
+| `ARTIFACT_DIR` | `~/.easyeda-mcp-pro/artifacts`              | Artifact export directory                   |
+| `CACHE_DIR`    | `~/.easyeda-mcp-pro/cache`                  | Cache directory                             |
+
+These defaults are resolved with the operating system user home directory, not the MCP process working directory. Explicitly configured paths keep their supplied absolute or relative semantics.
 
 ### Supplier integration
 

--- a/docs/security-architecture.md
+++ b/docs/security-architecture.md
@@ -338,12 +338,12 @@ Every unsafe configuration override has a safe default. The following table docu
 
 ## 8. Data at Rest
 
-| Data Type           | Location                                                          | Protection                                      |
-| :------------------ | :---------------------------------------------------------------- | :---------------------------------------------- |
-| Configuration       | `.env` file                                                       | File system permissions; never committed to git |
-| SQLite database     | `SQLITE_PATH` (default `.easyeda-mcp-pro/easyeda-mcp-pro.sqlite`) | File system permissions                         |
-| Artifacts (exports) | `ARTIFACT_DIR` (default `.easyeda-mcp-pro/artifacts/`)            | Path traversal validation at the tool level     |
-| Cache               | `CACHE_DIR` (default `.easyeda-mcp-pro/cache/`)                   | File system permissions                         |
+| Data Type           | Location                                                            | Protection                                      |
+| :------------------ | :------------------------------------------------------------------ | :---------------------------------------------- |
+| Configuration       | `.env` file                                                         | File system permissions; never committed to git |
+| SQLite database     | `SQLITE_PATH` (default `~/.easyeda-mcp-pro/easyeda-mcp-pro.sqlite`) | File system permissions                         |
+| Artifacts (exports) | `ARTIFACT_DIR` (default `~/.easyeda-mcp-pro/artifacts/`)            | Path traversal validation at the tool level     |
+| Cache               | `CACHE_DIR` (default `~/.easyeda-mcp-pro/cache/`)                   | File system permissions                         |
 
 Path traversal protection is enforced in all export tools — artifact paths are validated against the configured `ARTIFACT_DIR` before read or write operations.
 
@@ -516,7 +516,7 @@ Path traversal protection is enforced in all export tools — artifact paths are
 
 ### 11.3 Handling Generated Design & Export Files
 
-- [ ] Set `ARTIFACT_DIR` to a dedicated directory (default `.easyeda-mcp-pro/artifacts/`).
+- [ ] Set `ARTIFACT_DIR` to a dedicated directory (default `~/.easyeda-mcp-pro/artifacts/`).
 - [ ] Verify that export tools write to the artifact directory.
 - [ ] Verify path traversal protection: a tool call with `../../../etc/passwd` should be rejected.
 - [ ] Clean up the artifact directory periodically (exports are not auto-deleted).

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,4 +1,11 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 import { z } from 'zod';
+
+const DEFAULT_DATA_DIR = join(homedir(), '.easyeda-mcp-pro');
+const DEFAULT_SQLITE_PATH = join(DEFAULT_DATA_DIR, 'easyeda-mcp-pro.sqlite');
+const DEFAULT_ARTIFACT_DIR = join(DEFAULT_DATA_DIR, 'artifacts');
+const DEFAULT_CACHE_DIR = join(DEFAULT_DATA_DIR, 'cache');
 
 function envBoolean() {
   return z.preprocess((val) => {
@@ -52,10 +59,10 @@ export const EnvSchema = z.object({
   BRIDGE_HOT_SWAP_WATCH: z.string().default(''),
   BRIDGE_HOT_SWAP_CHUNK_BYTES: z.coerce.number().int().min(4096).max(1048576).default(65536),
 
-  DATA_DIR: z.string().default('.easyeda-mcp-pro'),
-  SQLITE_PATH: z.string().default('.easyeda-mcp-pro/easyeda-mcp-pro.sqlite'),
-  ARTIFACT_DIR: z.string().default('.easyeda-mcp-pro/artifacts'),
-  CACHE_DIR: z.string().default('.easyeda-mcp-pro/cache'),
+  DATA_DIR: z.string().default(DEFAULT_DATA_DIR),
+  SQLITE_PATH: z.string().default(DEFAULT_SQLITE_PATH),
+  ARTIFACT_DIR: z.string().default(DEFAULT_ARTIFACT_DIR),
+  CACHE_DIR: z.string().default(DEFAULT_CACHE_DIR),
 
   AI_PROVIDER: z.enum(['none', 'anthropic', 'openai', 'openrouter', 'local']).default('none'),
   AI_MODEL: z.string().default(''),

--- a/tests/unit/config/env.test.ts
+++ b/tests/unit/config/env.test.ts
@@ -1,3 +1,5 @@
+import { homedir } from 'node:os';
+import { isAbsolute, join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { EnvSchema, detectUnknownEnvVars, validateSafeConfig } from '../../../src/config/env.js';
 
@@ -13,6 +15,38 @@ describe('EnvSchema', () => {
     expect(result.JLCPCB_MODE).toBe('disabled');
     expect(result.JLCPCB_ENABLE_ORDERING).toBe(false);
     expect(result.AI_PROVIDER).toBe('none');
+  });
+
+  it('should anchor default writable paths in the user home directory', () => {
+    const result = EnvSchema.parse({});
+    const dataDir = join(homedir(), '.easyeda-mcp-pro');
+
+    expect(result.DATA_DIR).toBe(dataDir);
+    expect(result.SQLITE_PATH).toBe(join(dataDir, 'easyeda-mcp-pro.sqlite'));
+    expect(result.ARTIFACT_DIR).toBe(join(dataDir, 'artifacts'));
+    expect(result.CACHE_DIR).toBe(join(dataDir, 'cache'));
+    for (const path of [
+      result.DATA_DIR,
+      result.SQLITE_PATH,
+      result.ARTIFACT_DIR,
+      result.CACHE_DIR,
+    ]) {
+      expect(isAbsolute(path)).toBe(true);
+    }
+  });
+
+  it('should preserve explicitly configured relative paths', () => {
+    const result = EnvSchema.parse({
+      DATA_DIR: './custom-data',
+      SQLITE_PATH: './custom-data/database.sqlite',
+      ARTIFACT_DIR: './custom-artifacts',
+      CACHE_DIR: './custom-cache',
+    });
+
+    expect(result.DATA_DIR).toBe('./custom-data');
+    expect(result.SQLITE_PATH).toBe('./custom-data/database.sqlite');
+    expect(result.ARTIFACT_DIR).toBe('./custom-artifacts');
+    expect(result.CACHE_DIR).toBe('./custom-cache');
   });
 
   it('should parse production config', () => {


### PR DESCRIPTION
## Summary
- resolve the default data, SQLite, artifact, and cache paths under the operating-system user home directory instead of `process.cwd()`
- preserve explicitly configured absolute or relative path values unchanged
- document the home-anchored defaults in the README and security architecture
- add regression coverage for absolute home defaults and explicit relative overrides

## Validation
- `pnpm verify`
- main tests: 1259/1259 passed
- extension tests: 90/90 passed
- typecheck, ESLint, metadata lint, tool coverage, builds, package verification, metadata check, and docs build passed

Closes #265