### PR TITLE
feat(remote): productionize durable relay routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ easyeda-bridge-extension.eext
 
 # Extension release artifacts
 easyeda-bridge-extension.checksums.json
+
+# Local code-analysis metadata
+.serena/
+.codebase-memory/

--- a/.prettierignore
+++ b/.prettierignore
@@ -9,3 +9,7 @@ node_modules/
 CHANGELOG.md
 easyeda-bridge-extension/extension.json
 proje-ymlenmesi/
+
+# Local code-analysis metadata
+.serena/
+.codebase-memory/

--- a/docs/CHATGPT_APP_INTEGRATION.md
+++ b/docs/CHATGPT_APP_INTEGRATION.md
@@ -1,13 +1,12 @@
 # ChatGPT app integration plan
 
-**Current status: Planned.** Nothing in this document is implemented yet. The hosted
-gateway has no live deployment, and the pairing/session-router/relay subsystem it would
-depend on (`src/remote/`) is not wired to real MCP tool calls — see
-`docs/REMOTE_RELEASE_READINESS.md` for the tracked gap. This remains a target
-architecture and requirements list, not a usable integration path today. The self-hosted
-tunnel path in `docs/SELF_HOSTED_REMOTE_MCP.md` works with any MCP client that supports
-an arbitrary remote MCP URL, including ChatGPT's developer/custom-connector paths, and
-does not require anything described below.
+**Current status: Planned app, experimental runtime.** There is no live hosted gateway or
+published ChatGPT app. The underlying pairing/session-router/relay path is implemented behind
+`MCP_BRIDGE_BACKEND=remote_relay`; real Streamable HTTP MCP read/write calls and fail-closed
+approval behavior are CI-tested with a paired fake extension. Production account linking,
+app distribution, multi-session UX, hosted deployment, and live EasyEDA/ChatGPT validation
+remain open. The established self-hosted tunnel path in `docs/SELF_HOSTED_REMOTE_MCP.md`
+continues to work for clients that support an arbitrary remote MCP URL.
 
 ChatGPT integration should use the hosted Remote MCP architecture as the primary app path. Self-hosted endpoints remain an advanced/developer path for clients that can connect to arbitrary remote MCP URLs.
 
@@ -60,6 +59,6 @@ Self-hosted remote endpoints can be documented for developer workflows and MCP c
 
 - Final app distribution and review requirements.
 - Exact production auth provider and account-linking model.
-- UI surface for showing active EasyEDA project and approvals.
+- Polished UI for selecting the active EasyEDA session/project and reviewing approval history.
 - Handling multiple simultaneous EasyEDA tabs or projects.
 - Long-running export/manufacturing operations.

--- a/docs/CLAUDE_WEB_CONNECTOR.md
+++ b/docs/CLAUDE_WEB_CONNECTOR.md
@@ -2,14 +2,12 @@
 
 Claude Web can use EasyEDA MCP Pro through a public Remote MCP endpoint.
 
-**Current status:** there is no hosted gateway deployment today, and the pairing/relay
-flow described below as "target design" is not yet wired to real MCP tool calls — see
-`docs/REMOTE_RELEASE_READINESS.md` for the tracked gap. The setup that works today is
-the self-hosted tunnel path: run the MCP server and EasyEDA Pro on the same always-on
-machine, expose only the OAuth-protected HTTP transport through a tunnel/reverse proxy,
-and add that URL as a Claude Web connector. The bridge extension always talks to the MCP
-server over local loopback, so it does not need "pairing" in that setup — it just needs
-to be connected to the same EasyEDA Pro instance the server's bridge is listening for.
+**Current status:** there is no hosted gateway deployment today. The pairing/relay path is
+implemented behind `MCP_BRIDGE_BACKEND=remote_relay` and real Streamable HTTP MCP read/write
+routing is CI-tested with a paired fake extension, including two simultaneous MCP clients sharing one paired extension session, but live EasyEDA and Claude Web dogfood
+remain release gates. The established setup today is still the self-hosted tunnel path: run
+the MCP server and EasyEDA Pro on the same always-on machine, expose only the OAuth-protected
+HTTP transport, and use the local loopback bridge.
 
 ## Self-hosted mode (works today)
 
@@ -38,7 +36,7 @@ User flow:
    there is no separate "active project" pairing step — whatever project is open in
    EasyEDA Pro on that machine is what tools operate on.
 
-## Hosted mode (target design, not usable yet)
+## Hosted mode (experimental runtime, no public deployment)
 
 ```text
 Claude Web
@@ -47,13 +45,13 @@ https://mcp.example.com/mcp
   ↓
 Hosted Remote MCP Gateway
   ↓
-Paired EasyEDA extension session   ← not wired to real tool calls yet
+Paired EasyEDA extension session
 ```
 
-There is no hosted gateway deployment to connect to today. The pairing/session-router/
-approval-policy subsystem this diagram depends on exists in `src/remote/` and is
-unit/HTTP-tested in isolation, but no code path routes an actual `/mcp` tool call
-through it yet. Once that integration lands, the intended user flow is:
+There is no hosted gateway deployment to connect to today. The runtime path is implemented:
+`/mcp` can select a paired session, route read calls, and request an EasyEDA confirmation
+dialog before risky calls. The remaining work is deployment, production account linking,
+session/project UX, hosted multi-client load validation, and live EasyEDA/Claude Web validation. The intended user flow is:
 
 1. Install and activate the EasyEDA bridge extension.
 2. Open EasyEDA Web and the target project.

--- a/docs/EXTENSION_RELAY_PROTOCOL.md
+++ b/docs/EXTENSION_RELAY_PROTOCOL.md
@@ -1,13 +1,13 @@
 # Extension relay protocol
 
 **Current status:** the wire protocol and envelope shapes below are implemented
-(`src/remote/protocol.ts`, `easyeda-bridge-extension/src/remote-client.ts`) and unit
-tested. `RemoteRelayClient` genuinely connects and can execute real EasyEDA API calls
-when driven directly. What is missing is upstream of this protocol: no real MCP tool
-call (`/mcp`) currently produces a `tool_request` on this relay — see
-`docs/REMOTE_RELEASE_READINESS.md` for the tracked gap. `RemoteRelayClient` now includes
-client-side reconnect/backoff, heartbeat liveness tracking, and status diagnostics, but
-that resilience only helps once a relay URL is actually driving the extension.
+(`src/remote/protocol.ts`, `easyeda-bridge-extension/src/remote-client.ts`) and covered by
+unit and real Streamable HTTP MCP integration tests. In `remote_relay` mode, an `/mcp`
+tool call can produce `approval_request` and `tool_request` messages for a paired fake
+extension without starting the local bridge listener. `RemoteRelayClient` includes
+reconnect/backoff, heartbeat liveness, status diagnostics, EasyEDA bridge dispatch, and
+an explicit confirmation-dialog callback for approval decisions. Live EasyEDA relay
+dogfood and hosted deployment remain Beta gates.
 
 The relay protocol carries authenticated gateway requests to an opted-in EasyEDA bridge extension session. The extension uses an outbound connection and does not expose a local listener to the public internet.
 
@@ -62,6 +62,24 @@ Every relay message should include:
 | `session_closed`     | Both                        | Close a session intentionally.                                |
 | `error`              | Both                        | Return protocol, routing, or execution errors.                |
 
+## Approval handshake
+
+Risky operations are approved at the complete MCP tool-invocation boundary, not separately
+for each internal bridge call:
+
+1. The first MCP call omits `remoteApprovalId`.
+2. The gateway binds a pending approval to the authenticated user, paired session, MCP tool,
+   and hash of the effective parsed input.
+3. The gateway sends `approval_request`; the extension displays an EasyEDA confirmation
+   dialog and replies with `approval_result` (`approved`, `rejected`, or `timeout`).
+4. The MCP response remains fail-closed and includes the approval ID.
+5. The client retries the same MCP call with `remoteApprovalId`.
+6. An approved retry receives a private server-side grant for that handler invocation. The
+   grant is never accepted from public HTTP input and is revoked when the handler finishes.
+
+Changed input, wrong user/session, pending/rejected/timed-out decisions, replay, disconnect,
+or a missing approval UI must fail before any risky bridge dispatch.
+
 ## Tool request fields
 
 A `tool_request` should include:
@@ -81,7 +99,9 @@ The extension and gateway must reject:
 - unsupported protocol versions,
 - messages for unknown sessions,
 - tool requests before pairing,
-- approval-required actions without approval,
+- approval-required actions without a matching invocation grant or legacy direct approval,
+- rejected, timed-out, mismatched, or replayed approval IDs,
+- risky sessions whose extension exposes no approval UI,
 - messages with malformed envelopes,
 - requests after user disables Remote Relay Mode.
 

--- a/docs/REMOTE_GATEWAY_DESIGN.md
+++ b/docs/REMOTE_GATEWAY_DESIGN.md
@@ -10,8 +10,9 @@ extension session.
 https://mcp.example.com/mcp
 ```
 
-The endpoint should use the project's HTTP transport and remain separate from local-only stdio
-workflows.
+The endpoint uses the project's HTTP transport and remains separate from local-only stdio
+workflows. In `remote_relay` mode the process deliberately does not open the local EasyEDA
+bridge listener; `local_bridge` remains the independent fallback and default.
 
 OAuth protected-resource discovery is available at:
 
@@ -28,9 +29,11 @@ document.
 > `MCP_BRIDGE_BACKEND=local_bridge`, `/mcp` tool calls continue to use the local
 > `BridgeManager`. With `MCP_BRIDGE_BACKEND=remote_relay`, the ToolRegistry replaces the
 > per-request bridge call path with `RemoteGateway.routeToolRequest(...)`, so existing MCP
-> tool handlers route through the paired extension session without being rewritten. The
-> routing foundation is CI-tested, but production identity/session UX, approval creation,
-> and live hosted relay dogfood are still required before Beta status.
+> tool handlers route through the paired extension session without being rewritten. Risky
+> MCP invocations request a decision through the extension's EasyEDA confirmation dialog and
+> use a private invocation grant after approval. Real Streamable HTTP read/write routing is
+> CI-tested with a paired fake extension. The HTTP transport maintains a separate MCP server/transport per `Mcp-Session-Id`, and calls targeting one EasyEDA extension session are serialized before dispatch. Production account linking, polished session/project
+> UX, hosted deployment, and live EasyEDA relay dogfood remain required before Beta status.
 
 ```text
 remote MCP request
@@ -83,9 +86,17 @@ OAUTH_ENABLED=true
 ```
 
 `MCP_REMOTE_SESSION_ID` is optional when the MCP request supplies `remoteSessionId`.
-Write/export/destructive bridge calls require a valid `remoteApprovalId` that matches the
-user, session, method, and input hash. The `/remote/*` pairing, approval, audit, and relay
-endpoints are mounted by the HTTP transport.
+For write/export/destructive tools, the first call returns `APPROVAL_REQUIRED` plus an
+approval ID and asks the paired extension to show an EasyEDA confirmation dialog. The
+client retries the same MCP tool and effective input with `remoteApprovalId`; approved
+invocations receive a private, short-lived server-side grant that is revoked after the
+handler completes. Rejection, timeout, mismatch, and replay fail closed.
+
+The HTTP MCP endpoint multiplexes independent client sessions by `Mcp-Session-Id`. Closing one Claude/MCP client session does not close other clients or the paired EasyEDA extension session.
+
+The HTTP transport mounts pairing, direct tool-request, audit, and WebSocket relay surfaces
+under `/remote/*`. Approval requests and decisions travel over the versioned relay WebSocket;
+there is no anonymous public endpoint that can self-approve a tool call.
 
 ## Route responsibilities
 

--- a/docs/REMOTE_MCP_MODES.md
+++ b/docs/REMOTE_MCP_MODES.md
@@ -24,7 +24,9 @@ EasyEDA bridge extension
 Open EasyEDA Web project
 ```
 
-This mode must keep safe local defaults. It should bind to localhost unless the operator explicitly enables a public remote mode.
+This mode keeps safe local defaults and binds the EasyEDA bridge listener to loopback unless
+the operator explicitly configures otherwise. It is the default fallback and is not started
+when `MCP_BRIDGE_BACKEND=remote_relay` is selected.
 
 ## Hosted Remote Mode
 
@@ -76,7 +78,9 @@ Tunnels provide reachability only. They do not replace authentication, pairing, 
 4. The user pairs the extension session with the remote MCP client or hosted account.
 5. Remote tool calls route to the paired EasyEDA project.
 6. Read operations can run after auth and pairing.
-7. Write/export/destructive operations follow the approval policy.
+7. A write/export/destructive call first requests approval in an EasyEDA confirmation dialog.
+8. After approval, the client retries the identical MCP invocation with the returned
+   `remoteApprovalId`; rejection, timeout, changed input, and replay fail closed.
 
 ## Security responsibilities
 

--- a/docs/REMOTE_MCP_TEST_PLAN.md
+++ b/docs/REMOTE_MCP_TEST_PLAN.md
@@ -4,18 +4,23 @@ Remote MCP tests should validate security boundaries before implementation is co
 
 ## Unit test matrix
 
-| Area            | Required coverage                                                                     |
-| --------------- | ------------------------------------------------------------------------------------- |
-| Auth            | missing, invalid, expired, insufficient-scope tokens.                                 |
-| Pairing         | valid code, expired code, reused code, wrong user.                                    |
-| Session router  | paired session, no session, disconnected session, cross-user access.                  |
-| Relay protocol  | supported version, unsupported version, malformed envelope.                           |
-| Approval policy | read allowed, write blocked without approval, export approval, destructive rejection. |
-| Observability   | event shape, redaction, error code mapping.                                           |
+| Area              | Required coverage                                                                     |
+| ----------------- | ------------------------------------------------------------------------------------- |
+| Auth              | missing, invalid, expired, insufficient-scope tokens.                                 |
+| Pairing           | valid code, expired code, reused code, wrong user.                                    |
+| Session router    | paired session, no session, disconnected session, cross-user access.                  |
+| MCP HTTP sessions | two simultaneous clients, distinct session IDs, isolated close behavior.              |
+| Relay protocol    | supported version, unsupported version, malformed envelope.                           |
+| Approval policy   | read allowed, write blocked without approval, export approval, destructive rejection. |
+| Observability     | event shape, redaction, error code mapping.                                           |
 
 ## Integration smoke tests
 
-The integration smoke suite runs without live EasyEDA credentials by using a fake extension relay fixture. Coverage is implemented in `tests/unit/remote/fake-extension-integration.test.ts`, `tests/unit/remote/gateway.test.ts`, and `tests/unit/tools/registry.test.ts`.
+The integration smoke suite runs without live EasyEDA credentials by using a fake extension
+relay fixture. Coverage is implemented in `tests/unit/remote/fake-extension-integration.test.ts`,
+`tests/unit/remote/gateway.test.ts`, `tests/unit/tools/registry.test.ts`, and
+`tests/unit/remote/http-mcp-integration.test.ts`. The last file uses the real SDK
+Streamable HTTP client and `/mcp` transport rather than invoking registry callbacks directly.
 
 Required scenarios:
 
@@ -25,12 +30,16 @@ Required scenarios:
 4. Remote write tool fails after rejection.
 5. Cross-user session request is rejected.
 6. Disconnected extension returns a safe error.
+7. Two independent MCP clients can use the same paired extension session concurrently.
+8. Calls targeting one EasyEDA session are serialized before extension dispatch.
 
 ## Manual validation
 
-The CI-safe `/mcp`-to-relay routing foundation is implemented. The remaining manual
-validation is a live hosted end-to-end run with a real EasyEDA extension, production identity,
-session selection, and approval UX. Keep the checklist below as the Beta gate.
+The CI-safe `/mcp`-to-relay route, remote-only control schemas, EasyEDA confirmation
+callback, invocation-scoped grants, and rejection/timeout/replay behavior are implemented.
+The remaining manual validation is a live hosted end-to-end run with a real EasyEDA
+extension, production account linking, and polished project selection UX. Keep the
+checklist below as the Beta gate.
 
 Before public beta:
 

--- a/docs/REMOTE_RELEASE_READINESS.md
+++ b/docs/REMOTE_RELEASE_READINESS.md
@@ -19,30 +19,39 @@ unit/HTTP-tested in isolation, and its REST/WebSocket surface (`/remote/pairing-
 `/remote/pairings`, `/remote/tool-requests`, `/remote/audit`, `/remote/relay`) is mounted
 and reachable whenever `TRANSPORT=http` — no separate flag gates it.
 
-The MCP tool path now has an explicit backend selector. With the default
-`MCP_BRIDGE_BACKEND=local_bridge`, every real tool invocation keeps using the existing
-local-loopback `BridgeManager` WebSocket. With `MCP_BRIDGE_BACKEND=remote_relay`, the
-ToolRegistry creates a per-request bridge context that routes `ctx.bridge.call(...)`
-through `RemoteGateway.routeToolRequest(...)`, preserving the existing tool handlers
-without rewriting every tool. This is an integration foundation, not beta-ready remote
-support yet. This means:
+The MCP tool path has an explicit backend selector. With the default
+`MCP_BRIDGE_BACKEND=local_bridge`, tool invocations use the existing local-loopback
+`BridgeManager` WebSocket. With `MCP_BRIDGE_BACKEND=remote_relay`, the server does not
+open a local bridge listener; ToolRegistry routes bridge calls through the selected paired
+Remote Relay session instead. Existing tool handlers remain unchanged. This is a tested
+experimental path, not beta-ready remote support. In particular:
 
-- A read-only tool whose handler calls `ctx.bridge.call(...)` can route through a paired
-  Remote Relay session when the MCP request carries a remote identity and either
-  `remoteSessionId` or `MCP_REMOTE_SESSION_ID` identifies the session.
-- Write/export calls can pass `remoteApprovalId` into the gateway and fail closed if the
-  approval is absent, rejected, expired, or mismatched.
-- Remote dispatch enforces the bridge-call deadline for every dispatcher and reports
-  unsupported extension methods separately from generic extension failures.
-- The extension's `RemoteRelayClient` (Remote Relay Mode) genuinely connects to a relay
-  URL, includes reconnect/backoff and heartbeat liveness, and can execute real EasyEDA
-  API calls when driven directly.
-- Remaining gap: production identity propagation, UX/session selection, approval request
-  creation from MCP clients, and live EasyEDA relay dogfood still need end-to-end
-  validation before this should be described as Beta.
+- A read-only MCP tool can route through a paired Remote Relay session when the request
+  carries a remote identity and either `remoteSessionId` or `MCP_REMOTE_SESSION_ID`
+  identifies the session.
+- Remote-only MCP input schemas advertise `remoteSessionId` and `remoteApprovalId`; local
+  mode keeps the original public schemas unchanged.
+- A risky MCP tool invocation first returns a structured `APPROVAL_REQUIRED` result with
+  an approval ID and sends an `approval_request` to the paired extension. The extension
+  presents an EasyEDA confirmation dialog and returns approved, rejected, or timeout.
+- Approval is bound to the user, session, MCP tool, and effective parsed input. An approved
+  retry receives a private server-side invocation grant, allowing all bridge calls made by
+  that one handler; the grant is revoked when the handler completes. Rejection, timeout,
+  mismatch, and approval-ID replay fail closed before dispatch.
+- Remote dispatch enforces deadlines and reports unsupported extension methods separately
+  from generic extension failures.
+- The HTTP transport creates an isolated MCP server/transport for each `Mcp-Session-Id`; two simultaneous clients can route through the same paired extension, and closing one client leaves the other operational. Calls targeting one EasyEDA extension session are serialized before dispatch.
+- A real Streamable HTTP MCP client integration test covers one built-in read tool and one
+  approval-gated built-in write tool through a paired fake extension, including rejection,
+  timeout, and one-time approval behavior.
+- The extension's `RemoteRelayClient` connects to a relay URL, includes reconnect/backoff
+  and heartbeat liveness, and can execute EasyEDA API bridge methods.
+- Remaining Beta gates include production account linking and identity-provider validation,
+  polished project selection UX and hosted multi-client load validation, a deployed hosted broker, and live EasyEDA
+  relay dogfood against a disposable project.
 
 Given the status vocabulary above, the pairing/relay/approval-routing feature described
-in `REMOTE_GATEWAY_DESIGN.md`, `SELF_HOSTED_REMOTE_MCP.md`'s "Planned relay controls",
+in `REMOTE_GATEWAY_DESIGN.md`, `SELF_HOSTED_REMOTE_MCP.md`,
 `docs/CLAUDE_WEB_CONNECTOR.md`, and `docs/CHATGPT_APP_INTEGRATION.md` is **Experimental**
 behind explicit configuration, not Beta.
 
@@ -78,6 +87,8 @@ CI-safe integration tests should run without live EasyEDA credentials and prove 
 - Write and export requests wait for approval before dispatch.
 - Rejection, timeout, mismatched input hash, and disconnect cases fail closed.
 - User A cannot route a request to user B's session.
+- Two MCP clients receive distinct HTTP session IDs and one client can disconnect without affecting the other.
+- Concurrent calls to one extension session never overlap in the extension dispatcher.
 
 ## Live EasyEDA compatibility evidence
 

--- a/docs/SELF_HOSTED_REMOTE_MCP.md
+++ b/docs/SELF_HOSTED_REMOTE_MCP.md
@@ -4,14 +4,12 @@ Self-hosted Remote MCP lets an operator expose EasyEDA MCP Pro through their own
 VPS, or reverse proxy. This mode is for power users and private deployments that need a public MCP
 endpoint without using the hosted gateway.
 
-**Current status:** the setup below — tunneling the OAuth-protected HTTP transport out from a
-single always-on machine that also runs EasyEDA Pro and the bridge extension — works today with
-the existing HTTP/OAuth implementation. The bridge extension always connects to the MCP server
-over local loopback regardless of where the calling MCP client sits on the network, so this
-flow does not depend on the pairing/relay/approval subsystem described in "Planned relay
-controls" below. That subsystem exists and is tested in isolation but is not yet wired to real
-tool calls — see `docs/REMOTE_RELEASE_READINESS.md` for the tracked gap. Skip the "Planned relay
-controls" section and the pairing-related rows of the operator checklist until that lands.
+**Current status:** two distinct self-hosted paths exist. The established path tunnels the
+OAuth-protected HTTP transport from the same always-on machine that runs EasyEDA Pro and uses
+the local loopback bridge. The experimental relay path selects
+`MCP_BRIDGE_BACKEND=remote_relay`, pairs an outbound extension session, and does not start a
+local bridge listener. The relay path is covered by real Streamable HTTP MCP tests with a fake
+extension, including approval-gated writes, but still requires live EasyEDA dogfood before Beta.
 
 ## Architecture
 
@@ -54,17 +52,22 @@ https://mcp.user-domain.example/.well-known/oauth-protected-resource/mcp
 The local server should bind to localhost behind the tunnel or reverse proxy. Do not bind to all
 interfaces unless the host firewall, TLS, auth, and origin policy are explicitly configured.
 
-## Planned relay controls
+## Experimental relay configuration
 
-The following settings are remote-relay design targets and should remain documented as planned until
-the relay runtime is implemented:
+Use the explicit backend selector when testing the paired outbound relay path:
 
 ```env
-REMOTE_MODE=self_hosted
-PAIRING_REQUIRED=true
-REQUIRE_APPROVAL_FOR_WRITE=true
-REQUIRE_APPROVAL_FOR_EXPORT=true
+TRANSPORT=http
+MCP_BRIDGE_BACKEND=remote_relay
+MCP_REMOTE_SESSION_ID=
+OAUTH_ENABLED=true
 ```
+
+`MCP_REMOTE_SESSION_ID` may identify one fixed session, or the MCP request can provide
+`remoteSessionId`. Pairing is mandatory before routing. Risky MCP tools automatically request
+approval in the paired EasyEDA extension; the MCP client then retries the same call with the
+returned `remoteApprovalId`. Do not advertise this path as Beta until live EasyEDA relay
+validation and the remaining release-readiness gates are complete.
 
 ## Cloudflare Tunnel example
 
@@ -91,8 +94,9 @@ Before exposing a self-hosted endpoint:
 
 - [ ] TLS is enabled at the public endpoint.
 - [ ] Auth is enabled.
-- [ ] Pairing is required before write/export once relay mode is enabled.
-- [ ] Write/export approvals are enabled before relay write/export is advertised.
+- [ ] Pairing is required before any relay tool routing.
+- [ ] The approval dialog, rejected decision, timeout, changed-input rejection, and replay
+      rejection have been verified before relay write/export is advertised.
 - [ ] The local MCP server is not anonymously exposed.
 - [ ] The extension shows the active project before approving changes.
 - [ ] Logs are redacted and stored safely.

--- a/easyeda-bridge-extension/src/index.ts
+++ b/easyeda-bridge-extension/src/index.ts
@@ -12,7 +12,12 @@ import {
   reconnectDelayMs,
   shouldReconnectAfterSocketFailure,
 } from './connection-policy.js';
-import { RemoteRelayClient, type RemoteRelayMode } from './remote-client.js';
+import {
+  RemoteRelayClient,
+  type RemoteApprovalDecision,
+  type RemoteApprovalPrompt,
+  type RemoteRelayMode,
+} from './remote-client.js';
 import { createDispatcher } from './dispatcher.js';
 import type { Dispatcher, DispatcherToolkit } from './toolkit.js';
 import { isRecord, log, readPath, type JsonValue } from './utils.js';
@@ -94,6 +99,16 @@ interface EasyedaWebSocketApi {
 
 interface EasyedaMessageApi {
   showToastMessage?: (message: string, messageType?: string) => void;
+}
+
+interface EasyedaDialogApi {
+  showConfirmationMessage?: (
+    content: string,
+    title?: string,
+    mainButtonTitle?: string,
+    buttonTitle?: string,
+    callbackFn?: (mainButtonClicked: boolean) => void,
+  ) => void;
 }
 
 interface EasyedaToastApi {
@@ -537,6 +552,53 @@ async function handleLoaderMethod(
 
 let remoteRelayClient: RemoteRelayClient | null = null;
 
+function requestRemoteApproval(prompt: RemoteApprovalPrompt): Promise<RemoteApprovalDecision> {
+  const dialog = readPath<EasyedaDialogApi>(getGlobal(), 'sys_Dialog');
+  const expiresAtMs = Date.parse(prompt.expiresAt);
+  if (!Number.isFinite(expiresAtMs) || expiresAtMs <= Date.now()) {
+    return Promise.resolve('timeout');
+  }
+  const showConfirmationMessage = dialog?.showConfirmationMessage?.bind(dialog);
+  if (!showConfirmationMessage) {
+    log('Remote approval dialog unavailable', { toolName: prompt.toolName });
+    showToast('Remote approval dialog is unavailable; request rejected.');
+    return Promise.resolve('rejected');
+  }
+
+  return new Promise<RemoteApprovalDecision>((resolve) => {
+    let settled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const finish = (decision: RemoteApprovalDecision): void => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve(decision);
+    };
+    timer = setTimeout(() => finish('timeout'), Math.max(0, expiresAtMs - Date.now()));
+
+    const project = prompt.activeProject?.projectName ?? 'current EasyEDA project';
+    const summary = [
+      prompt.actionSummary,
+      `Method: ${prompt.toolName}`,
+      `Risk: ${prompt.riskLevel}`,
+      `Project: ${project}`,
+      `Input hash: ${prompt.inputHash.slice(0, 12)}`,
+    ].join('\n');
+    try {
+      showConfirmationMessage(
+        summary,
+        'Remote MCP Approval',
+        'Approve',
+        'Reject',
+        (mainButtonClicked) => finish(mainButtonClicked ? 'approved' : 'rejected'),
+      );
+    } catch (error) {
+      log('Remote approval dialog failed', error);
+      finish('rejected');
+    }
+  });
+}
+
 function getRemoteRelayClient(): RemoteRelayClient {
   remoteRelayClient ??= new RemoteRelayClient({
     extensionVersion: EXTENSION_INFO.extensionVersion,
@@ -545,6 +607,7 @@ function getRemoteRelayClient(): RemoteRelayClient {
     readActiveProject: readRemoteActiveProject,
     executeToolRequest: (toolName, input) =>
       dispatchViaActive(toolName, isRecord(input) ? input : {}),
+    requestApproval: requestRemoteApproval,
   });
   return remoteRelayClient;
 }

--- a/easyeda-bridge-extension/src/remote-client.ts
+++ b/easyeda-bridge-extension/src/remote-client.ts
@@ -22,12 +22,25 @@ export interface RemoteRelayStatus {
   nextReconnectDelayMs?: number;
 }
 
+export type RemoteApprovalDecision = 'approved' | 'rejected' | 'timeout';
+
+export interface RemoteApprovalPrompt {
+  approvalId: string;
+  toolName: string;
+  riskLevel: string;
+  actionSummary: string;
+  inputHash: string;
+  activeProject?: RemoteActiveProject;
+  expiresAt: string;
+}
+
 interface RemoteRelayClientOptions {
   extensionVersion: string;
   log: (message: string, data?: unknown) => void;
   showToast: (message: string) => void;
   readActiveProject: () => RemoteActiveProject | undefined;
   executeToolRequest?: (toolName: string, input: unknown) => Promise<unknown>;
+  requestApproval?: (request: RemoteApprovalPrompt) => Promise<RemoteApprovalDecision>;
 }
 
 interface RemoteRelayConnectInput {
@@ -88,6 +101,7 @@ export class RemoteRelayClient {
   private desiredConnection: RemoteRelayConnectInput | null = null;
   private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
   private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
+  private readonly pendingApprovalIds = new Set<string>();
 
   constructor(private readonly options: RemoteRelayClientOptions) {}
 
@@ -212,14 +226,55 @@ export class RemoteRelayClient {
       return;
     }
     if (message.type === 'approval_request') {
-      this.options.showToast(
-        `Remote approval requested: ${String(message.toolName ?? 'tool action')}`,
-      );
+      void this.handleApprovalRequest(message);
       return;
     }
     if (message.type === 'tool_request') {
       void this.handleToolRequest(message);
     }
+  }
+
+  private async handleApprovalRequest(message: RemoteEnvelope): Promise<void> {
+    const approvalId = typeof message.approvalId === 'string' ? message.approvalId : '';
+    const toolName = typeof message.toolName === 'string' ? message.toolName : '';
+    const actionSummary =
+      typeof message.actionSummary === 'string'
+        ? message.actionSummary
+        : toolName || 'Remote action';
+    const expiresAt = typeof message.expiresAt === 'string' ? message.expiresAt : nowIso();
+    if (!approvalId || !toolName || this.pendingApprovalIds.has(approvalId)) return;
+
+    this.pendingApprovalIds.add(approvalId);
+    let result: RemoteApprovalDecision = 'rejected';
+    try {
+      const requestApproval = this.options.requestApproval;
+      if (requestApproval) {
+        result = await requestApproval({
+          approvalId,
+          toolName,
+          riskLevel: typeof message.riskLevel === 'string' ? message.riskLevel : 'write',
+          actionSummary,
+          inputHash: typeof message.inputHash === 'string' ? message.inputHash : '',
+          activeProject: isRecord(message.activeProject)
+            ? (message.activeProject as unknown as RemoteActiveProject)
+            : undefined,
+          expiresAt,
+        });
+      } else {
+        this.options.showToast('Remote approval UI is unavailable; request rejected.');
+      }
+    } catch (error) {
+      this.options.log('Remote approval prompt failed', error);
+      result = 'rejected';
+    } finally {
+      this.pendingApprovalIds.delete(approvalId);
+    }
+
+    this.send({
+      type: 'approval_result',
+      approvalId,
+      result,
+    });
   }
 
   private async handleToolRequest(message: RemoteEnvelope): Promise<void> {

--- a/easyeda-bridge-extension/tests/build.test.ts
+++ b/easyeda-bridge-extension/tests/build.test.ts
@@ -141,6 +141,126 @@ describe('build.mjs hot-swap define', () => {
     expect(toastMessages.at(-1)).toContain('Auto-Connect: OFF');
   });
 
+  it('routes Remote Relay approval requests through the official EasyEDA confirmation dialog', async () => {
+    const outDir = mkdtempSync(join(tmpdir(), 'ext-build-remote-approval-'));
+    outDirs.push(outDir);
+    const bundle = buildInto(outDir, { MCP_DEV_HOTSWAP: '' });
+
+    const sent: Array<Record<string, unknown>> = [];
+    const confirmations: Array<{
+      content: string;
+      title?: string;
+      approveTitle?: string;
+      rejectTitle?: string;
+      callback?: (approved: boolean) => void;
+    }> = [];
+    let relaySocket: FakeRelaySocket | undefined;
+
+    class FakeRelaySocket {
+      static OPEN = 1;
+      readyState = 0;
+      onopen: (() => void) | null = null;
+      onmessage: ((event: { data: string }) => void) | null = null;
+      onerror: (() => void) | null = null;
+      onclose: (() => void) | null = null;
+
+      constructor(readonly url: string) {
+        relaySocket = this;
+        queueMicrotask(() => {
+          this.readyState = FakeRelaySocket.OPEN;
+          this.onopen?.();
+        });
+      }
+
+      send(payload: string): void {
+        sent.push(JSON.parse(payload) as Record<string, unknown>);
+      }
+
+      close(): void {
+        this.readyState = 3;
+        this.onclose?.();
+      }
+
+      receive(payload: Record<string, unknown>): void {
+        this.onmessage?.({ data: JSON.stringify(payload) });
+      }
+    }
+
+    const context = vm.createContext({
+      console,
+      crypto: webcrypto,
+      TextEncoder,
+      TextDecoder,
+      URL,
+      Promise,
+      setTimeout,
+      clearTimeout,
+      setInterval: () => 0,
+      clearInterval: () => undefined,
+      WebSocket: FakeRelaySocket,
+      localStorage: {
+        getItem: () => 'false',
+        setItem: () => undefined,
+      },
+      eda: {
+        sys_Message: { showToastMessage: () => undefined },
+        sys_Dialog: {
+          showConfirmationMessage: (
+            content: string,
+            title?: string,
+            approveTitle?: string,
+            rejectTitle?: string,
+            callback?: (approved: boolean) => void,
+          ) => confirmations.push({ content, title, approveTitle, rejectTitle, callback }),
+        },
+      },
+    });
+
+    vm.runInContext(bundle, context);
+    (context as any).edaEsbuildExportName.connectRemoteRelay(
+      'hosted',
+      'wss://relay.example/session',
+      '123456',
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    relaySocket?.receive({
+      protocolVersion: '2026-07-remote-relay-v1',
+      type: 'approval_request',
+      messageId: 'approval-message',
+      sessionId: 'session-1',
+      timestamp: new Date().toISOString(),
+      approvalId: 'approval-1',
+      toolName: 'easyeda_schematic_add_text',
+      riskLevel: 'write',
+      actionSummary: 'write MCP tool easyeda_schematic_add_text on Fixture',
+      inputHash: '1234567890abcdef',
+      activeProject: { projectName: 'Fixture', documentType: 'schematic' },
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    await Promise.resolve();
+
+    expect(confirmations).toHaveLength(1);
+    expect(confirmations[0]).toMatchObject({
+      title: 'Remote MCP Approval',
+      approveTitle: 'Approve',
+      rejectTitle: 'Reject',
+    });
+    expect(confirmations[0].content).toContain('easyeda_schematic_add_text');
+
+    confirmations[0].callback?.(true);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(sent).toContainEqual(
+      expect.objectContaining({
+        type: 'approval_result',
+        approvalId: 'approval-1',
+        result: 'approved',
+      }),
+    );
+  });
+
   it('publishes EasyEDA lifecycle and menu exports through the official IIFE global', () => {
     const outDir = mkdtempSync(join(tmpdir(), 'ext-build-lifecycle-'));
     outDirs.push(outDir);

--- a/easyeda-bridge-extension/tests/remote-client.test.ts
+++ b/easyeda-bridge-extension/tests/remote-client.test.ts
@@ -45,7 +45,7 @@ class FakeWebSocket {
   }
 }
 
-function makeClient() {
+function makeClient(requestApproval = vi.fn(async () => 'approved' as const)) {
   const log = vi.fn();
   const showToast = vi.fn();
   const executeToolRequest = vi.fn(async () => ({ ok: true }));
@@ -55,8 +55,9 @@ function makeClient() {
     showToast,
     readActiveProject: () => ({ projectName: 'Fixture', documentType: 'schematic' }),
     executeToolRequest,
+    requestApproval,
   });
-  return { client, log, showToast, executeToolRequest };
+  return { client, log, showToast, executeToolRequest, requestApproval };
 }
 
 function relayMessage(type: string, extra: Record<string, unknown> = {}) {
@@ -165,5 +166,79 @@ describe('RemoteRelayClient resilience', () => {
       sessionId: 'sess_1',
       pairingCode: '123456',
     });
+  });
+
+  it('returns the explicit user approval decision to the relay', async () => {
+    const { client, requestApproval } = makeClient();
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+
+    socket.receive(
+      relayMessage('approval_request', {
+        approvalId: 'appr_1',
+        toolName: 'schematic.addText',
+        riskLevel: 'write',
+        actionSummary: 'Add a schematic note',
+        inputHash: '1234567890abcdef',
+        activeProject: { projectName: 'Fixture', documentType: 'schematic' },
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(requestApproval).toHaveBeenCalledWith({
+      approvalId: 'appr_1',
+      toolName: 'schematic.addText',
+      riskLevel: 'write',
+      actionSummary: 'Add a schematic note',
+      inputHash: '1234567890abcdef',
+      activeProject: { projectName: 'Fixture', documentType: 'schematic' },
+      expiresAt: expect.any(String),
+    });
+    const approvalResult = socket.sent
+      .map((data) => JSON.parse(data) as Record<string, unknown>)
+      .find((message) => message.type === 'approval_result');
+    expect(approvalResult).toMatchObject({
+      type: 'approval_result',
+      approvalId: 'appr_1',
+      result: 'approved',
+    });
+  });
+
+  it('does not open duplicate approval prompts for the same approval id', async () => {
+    let resolveDecision: ((decision: 'rejected') => void) | undefined;
+    const requestApproval = vi.fn(
+      async () =>
+        await new Promise<'rejected'>((resolve) => {
+          resolveDecision = resolve;
+        }),
+    );
+    const { client } = makeClient(requestApproval);
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+    const request = relayMessage('approval_request', {
+      approvalId: 'appr_duplicate',
+      toolName: 'schematic.addText',
+      riskLevel: 'write',
+      actionSummary: 'Add a schematic note',
+      inputHash: 'hash',
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+
+    socket.receive(request);
+    socket.receive(request);
+    expect(requestApproval).toHaveBeenCalledTimes(1);
+
+    resolveDecision?.('rejected');
+    await Promise.resolve();
+    await Promise.resolve();
+    const decisions = socket.sent
+      .map((data) => JSON.parse(data) as Record<string, unknown>)
+      .filter((message) => message.type === 'approval_result');
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0]).toMatchObject({ approvalId: 'appr_duplicate', result: 'rejected' });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,10 +63,11 @@ async function main() {
   const instance = await createServer(config, { remoteGateway });
 
   if (config.TRANSPORT === 'http') {
-    const httpTransport = createHttpTransport(config, { gateway: remoteGateway });
+    const httpTransport = createHttpTransport(config, {
+      gateway: remoteGateway,
+      serverFactory: instance.createSessionServer,
+    });
     instance.httpTransport = httpTransport;
-    instance.transport = httpTransport.transport;
-    await instance.server.connect(httpTransport.transport);
     await httpTransport.start();
   } else {
     await instance.server.connect(instance.transport);

--- a/src/remote/approval-policy.ts
+++ b/src/remote/approval-policy.ts
@@ -42,8 +42,8 @@ export class ApprovalStore {
     now = new Date(),
   ): ApprovalRecord | undefined {
     const record = this.approvals.get(approvalId);
-    if (!record) return undefined;
-    record.decision = now.getTime() > record.expiresAt.getTime() ? 'timeout' : decision;
+    if (!record || record.decision !== undefined) return undefined;
+    record.decision = now.getTime() >= record.expiresAt.getTime() ? 'timeout' : decision;
     record.decidedAt = now;
     return record;
   }
@@ -72,5 +72,43 @@ export class ApprovalStore {
 
   get(approvalId: string): ApprovalRecord | undefined {
     return this.approvals.get(approvalId);
+  }
+
+  findPending(input: {
+    userId: string;
+    sessionId: string;
+    toolName: string;
+    inputHash: string;
+    now?: Date;
+  }): ApprovalRecord | undefined {
+    const now = input.now ?? new Date();
+    for (const [approvalId, record] of this.approvals) {
+      if (record.expiresAt.getTime() <= now.getTime()) {
+        this.approvals.delete(approvalId);
+        continue;
+      }
+      if (
+        record.userId === input.userId &&
+        record.sessionId === input.sessionId &&
+        record.toolName === input.toolName &&
+        record.inputHash === input.inputHash &&
+        record.decision === undefined
+      ) {
+        return record;
+      }
+    }
+    return undefined;
+  }
+
+  delete(approvalId: string): boolean {
+    return this.approvals.delete(approvalId);
+  }
+
+  deleteForSession(sessionId: string): number {
+    let deleted = 0;
+    for (const [approvalId, record] of this.approvals) {
+      if (record.sessionId === sessionId && this.approvals.delete(approvalId)) deleted += 1;
+    }
+    return deleted;
   }
 }

--- a/src/remote/gateway.ts
+++ b/src/remote/gateway.ts
@@ -4,11 +4,12 @@ import type { Express, Request, Response } from 'express';
 import { WebSocketServer, type WebSocket } from 'ws';
 import { z } from 'zod';
 import { type EnvConfig } from '../config/env.js';
-import { ApprovalStore, requiresApproval } from './approval-policy.js';
+import { ApprovalStore, requiresApproval, type ApprovalDecision } from './approval-policy.js';
 import { RemoteAuditLog } from './observability.js';
 import {
   REMOTE_RELAY_PROTOCOL_VERSION,
   RemoteRiskLevelSchema,
+  type ApprovalRequestMessage,
   type RemoteDeploymentMode,
   type RemoteRiskLevel,
   type ToolRequestMessage,
@@ -18,6 +19,7 @@ import {
 } from './protocol.js';
 import { type RemoteIdentity, checkRemoteScope } from './scope.js';
 import { type ExtensionSession, RemoteSessionRouter } from './session-router.js';
+import { SessionDispatchQueue } from './session-dispatch-queue.js';
 
 const RouteToolRequestSchema = z.object({
   sessionId: z.string().min(1).optional(),
@@ -50,9 +52,19 @@ export type RemoteGatewayErrorCode =
   | 'PROJECT_INACTIVE'
   | 'APPROVAL_REQUIRED'
   | 'APPROVAL_NOT_APPROVED'
+  | 'APPROVAL_UI_UNAVAILABLE'
   | 'REMOTE_EXTENSION_ERROR'
   | 'REMOTE_TOOL_UNSUPPORTED'
   | 'REMOTE_EXTENSION_TIMEOUT';
+
+export type RemoteGatewayFailure = {
+  ok: false;
+  status: number;
+  code: RemoteGatewayErrorCode;
+  message: string;
+  approvalId?: string;
+  approvalExpiresAt?: string;
+};
 
 export type RemoteGatewayToolResult =
   | {
@@ -62,19 +74,43 @@ export type RemoteGatewayToolResult =
       result: unknown;
       durationMs: number;
     }
+  | RemoteGatewayFailure;
+
+export type RemoteGatewayAuthorizationResult =
   | {
-      ok: false;
-      status: number;
-      code: RemoteGatewayErrorCode;
-      message: string;
-    };
+      ok: true;
+      sessionId: string;
+      grantId: string;
+    }
+  | RemoteGatewayFailure;
 
 export type RemoteToolDispatcher = (request: ToolRequestMessage) => Promise<ToolResponseMessage>;
+export type RemoteApprovalRequester = (request: ApprovalRequestMessage) => Promise<void> | void;
 
 interface RegisteredConnection {
   sessionId: string;
   dispatch: RemoteToolDispatcher;
+  requestApproval?: RemoteApprovalRequester;
+  closeConnection?: () => void;
 }
+
+interface RemoteInvocationGrantRecord {
+  grantId: string;
+  userId: string;
+  sessionId: string;
+  toolName: string;
+  riskLevel: RemoteRiskLevel;
+  inputHash: string;
+  expiresAt: Date;
+}
+
+type ResolvedRemoteConnection =
+  | {
+      ok: true;
+      session: ExtensionSession;
+      connection: RegisteredConnection;
+    }
+  | RemoteGatewayFailure;
 
 export interface RemoteGatewayOptions {
   router?: RemoteSessionRouter;
@@ -83,6 +119,8 @@ export interface RemoteGatewayOptions {
   now?: () => Date;
   makeId?: () => string;
   hashInput?: (value: unknown) => string;
+  approvalTtlMs?: number;
+  invocationGrantTtlMs?: number;
 }
 
 function stableStringify(value: unknown): string {
@@ -106,14 +144,22 @@ function gatewayError(
   status: number,
   code: RemoteGatewayErrorCode,
   message: string,
-): RemoteGatewayToolResult {
-  return { ok: false, status, code, message };
+  details: { approvalId?: string; approvalExpiresAt?: string } = {},
+): RemoteGatewayFailure {
+  return { ok: false, status, code, message, ...details };
 }
 
 class RemoteDispatchTimeoutError extends Error {
   constructor(readonly timeoutMs: number) {
     super(`Remote extension did not respond within ${timeoutMs}ms.`);
     this.name = 'RemoteDispatchTimeoutError';
+  }
+}
+
+class RemoteSessionUnavailableError extends Error {
+  constructor(readonly sessionId: string) {
+    super(`Remote extension session ${sessionId} disconnected before dispatch.`);
+    this.name = 'RemoteSessionUnavailableError';
   }
 }
 
@@ -199,15 +245,168 @@ export class RemoteGateway {
   private readonly now: () => Date;
   private readonly makeId: () => string;
   private readonly hashInput: (value: unknown) => string;
+  private readonly approvalTtlMs: number;
+  private readonly invocationGrantTtlMs: number;
+  private readonly invocationGrants = new Map<string, RemoteInvocationGrantRecord>();
+  private readonly dispatchQueue = new SessionDispatchQueue();
   private wsAttached = false;
 
   constructor(options: RemoteGatewayOptions = {}) {
     this.now = options.now ?? (() => new Date());
     this.makeId = options.makeId ?? (() => randomUUID());
     this.hashInput = options.hashInput ?? defaultHashInput;
+    this.approvalTtlMs = options.approvalTtlMs ?? 60_000;
+    this.invocationGrantTtlMs = options.invocationGrantTtlMs ?? 300_000;
     this.router = options.router ?? new RemoteSessionRouter(this.now, this.makeId);
     this.approvals = options.approvals ?? new ApprovalStore();
     this.audit = options.audit ?? new RemoteAuditLog();
+  }
+
+  private resolveConnection(input: {
+    identity: RemoteIdentity;
+    sessionId?: string;
+    riskLevel: RemoteRiskLevel;
+  }): ResolvedRemoteConnection {
+    const route = this.router.resolve({
+      userId: input.identity.userId,
+      riskLevel: input.riskLevel,
+      sessionId: input.sessionId,
+    });
+    if (!route.ok) {
+      const status =
+        route.code === 'SESSION_AMBIGUOUS' ? 409 : route.code === 'SESSION_EXPIRED' ? 410 : 404;
+      return gatewayError(status, route.code, route.message);
+    }
+
+    const connection = this.connections.get(route.session.sessionId);
+    if (!connection) {
+      this.router.disconnect(route.session.sessionId);
+      this.approvals.deleteForSession(route.session.sessionId);
+      return gatewayError(424, 'SESSION_DISCONNECTED', 'Paired EasyEDA extension is disconnected.');
+    }
+    return { ok: true, session: route.session, connection };
+  }
+
+  private async requestRemoteApproval(input: {
+    identity: RemoteIdentity;
+    session: ExtensionSession;
+    connection: RegisteredConnection;
+    toolName: string;
+    riskLevel: RemoteRiskLevel;
+    inputHash: string;
+    now: Date;
+    actionLabel: string;
+    retryMessage: string;
+  }): Promise<RemoteGatewayFailure> {
+    if (!input.connection.requestApproval) {
+      return gatewayError(
+        424,
+        'APPROVAL_UI_UNAVAILABLE',
+        'The paired EasyEDA extension does not expose an approval UI.',
+      );
+    }
+
+    const existing = this.approvals.findPending({
+      userId: input.identity.userId,
+      sessionId: input.session.sessionId,
+      toolName: input.toolName,
+      inputHash: input.inputHash,
+      now: input.now,
+    });
+    const approvalId = existing?.approvalId ?? `appr_${this.makeId()}`;
+    const expiresAt = existing?.expiresAt ?? new Date(input.now.getTime() + this.approvalTtlMs);
+
+    if (!existing) {
+      const actionSummary = `${input.riskLevel} ${input.actionLabel} ${input.toolName}${
+        input.session.activeProject?.projectName
+          ? ` on ${input.session.activeProject.projectName}`
+          : ''
+      }`;
+      this.approvals.request({
+        approvalId,
+        userId: input.identity.userId,
+        sessionId: input.session.sessionId,
+        toolName: input.toolName,
+        riskLevel: input.riskLevel,
+        inputHash: input.inputHash,
+        actionSummary,
+        activeProject: input.session.activeProject,
+        expiresAt,
+      });
+      const approvalRequest: ApprovalRequestMessage = {
+        protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+        type: 'approval_request',
+        messageId: `msg_${this.makeId()}`,
+        sessionId: input.session.sessionId,
+        timestamp: input.now.toISOString(),
+        approvalId,
+        toolName: input.toolName,
+        riskLevel: input.riskLevel,
+        actionSummary,
+        inputHash: input.inputHash,
+        activeProject: input.session.activeProject,
+        expiresAt: expiresAt.toISOString(),
+      };
+      try {
+        await input.connection.requestApproval(approvalRequest);
+      } catch (error) {
+        this.approvals.delete(approvalId);
+        return gatewayError(
+          502,
+          'REMOTE_EXTENSION_ERROR',
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      this.audit.record({
+        event: 'remote.approval.requested',
+        mode: input.session.mode,
+        userId: input.identity.userId,
+        sessionId: input.session.sessionId,
+        toolName: input.toolName,
+        riskLevel: input.riskLevel,
+        inputHash: input.inputHash,
+      });
+    }
+
+    return gatewayError(403, 'APPROVAL_REQUIRED', input.retryMessage, {
+      approvalId,
+      approvalExpiresAt: expiresAt.toISOString(),
+    });
+  }
+
+  private consumeRemoteApproval(input: {
+    approvalId: string;
+    identity: RemoteIdentity;
+    session: ExtensionSession;
+    toolName: string;
+    inputHash: string;
+    now: Date;
+    mismatchTarget: string;
+  }): RemoteGatewayFailure | undefined {
+    const record = this.approvals.get(input.approvalId);
+    const approved = this.approvals.consumeApproved({
+      approvalId: input.approvalId,
+      userId: input.identity.userId,
+      sessionId: input.session.sessionId,
+      toolName: input.toolName,
+      inputHash: input.inputHash,
+      now: input.now,
+    });
+    if (approved) return undefined;
+
+    const message = !record
+      ? 'Remote approval is missing or invalid.'
+      : record.expiresAt.getTime() <= input.now.getTime() || record.decision === 'timeout'
+        ? 'Remote approval expired.'
+        : record.decision === 'rejected'
+          ? 'Remote approval was rejected by the user.'
+          : record.decision === undefined
+            ? 'Remote approval is still pending user action.'
+            : `Remote approval does not match this user, session, ${input.mismatchTarget}, or input.`;
+    return gatewayError(403, 'APPROVAL_NOT_APPROVED', message, {
+      approvalId: input.approvalId,
+      approvalExpiresAt: record?.expiresAt.toISOString(),
+    });
   }
 
   registerExtension(input: {
@@ -217,12 +416,16 @@ export class RemoteGateway {
     activeProject?: ExtensionSession['activeProject'];
     ttlMs?: number;
     dispatch: RemoteToolDispatcher;
+    requestApproval?: RemoteApprovalRequester;
+    closeConnection?: () => void;
     pairingCode?: string;
   }): ExtensionSession {
     const session = this.router.registerSession(input);
     this.connections.set(session.sessionId, {
       sessionId: session.sessionId,
       dispatch: input.dispatch,
+      requestApproval: input.requestApproval,
+      closeConnection: input.closeConnection,
     });
     if (input.pairingCode) this.router.completePairingByCode(input.pairingCode, session.sessionId);
     this.audit.record({
@@ -276,6 +479,10 @@ export class RemoteGateway {
     const session = this.router.getSession(sessionId);
     this.router.disconnect(sessionId);
     this.connections.delete(sessionId);
+    this.approvals.deleteForSession(sessionId);
+    for (const [grantId, grant] of this.invocationGrants) {
+      if (grant.sessionId === sessionId) this.invocationGrants.delete(grantId);
+    }
     if (session) {
       this.audit.record({
         event: 'remote.session.disconnected',
@@ -286,6 +493,112 @@ export class RemoteGateway {
     }
   }
 
+  private quarantineSession(sessionId: string): void {
+    const closeConnection = this.connections.get(sessionId)?.closeConnection;
+    this.disconnect(sessionId);
+    try {
+      closeConnection?.();
+    } catch {
+      // The route is already removed. A socket-close failure must not make the
+      // quarantined session routable again.
+    }
+  }
+
+  resolveApprovalFromExtension(input: {
+    sessionId: string;
+    approvalId: string;
+    result: ApprovalDecision;
+  }): boolean {
+    const record = this.approvals.get(input.approvalId);
+    const session = this.router.getSession(input.sessionId);
+    if (!record || !session || record.sessionId !== input.sessionId) return false;
+    const resolved = this.approvals.resolve(input.approvalId, input.result, this.now());
+    if (!resolved) return false;
+    this.audit.record({
+      event: 'remote.approval.resolved',
+      mode: session.mode,
+      userId: record.userId,
+      sessionId: input.sessionId,
+      toolName: record.toolName,
+      riskLevel: record.riskLevel,
+      inputHash: record.inputHash,
+      status:
+        resolved.decision === 'approved'
+          ? 'ok'
+          : resolved.decision === 'timeout'
+            ? 'timeout'
+            : 'rejected',
+    });
+    return true;
+  }
+
+  async authorizeToolInvocation(input: {
+    identity?: RemoteIdentity;
+    sessionId?: string;
+    toolName: string;
+    riskLevel: Exclude<RemoteRiskLevel, 'read'>;
+    input?: unknown;
+    approvalId?: string;
+  }): Promise<RemoteGatewayAuthorizationResult> {
+    const scope = checkRemoteScope(input.identity, input.riskLevel, this.now());
+    if (!scope.ok) {
+      return gatewayError(scope.code === 'SCOPE_MISSING' ? 403 : 401, scope.code, scope.message);
+    }
+    const identity = input.identity;
+    if (!identity) return gatewayError(401, 'IDENTITY_MISSING', 'Remote identity is required.');
+
+    const route = this.resolveConnection({
+      identity,
+      riskLevel: input.riskLevel,
+      sessionId: input.sessionId,
+    });
+    if (!route.ok) return route;
+
+    const now = this.now();
+    const inputHash = this.hashInput(input.input);
+    if (!input.approvalId) {
+      return await this.requestRemoteApproval({
+        identity,
+        session: route.session,
+        connection: route.connection,
+        toolName: input.toolName,
+        riskLevel: input.riskLevel,
+        inputHash,
+        now,
+        actionLabel: 'MCP tool',
+        retryMessage:
+          'Approval was requested in EasyEDA. Retry the same MCP tool call with remoteApprovalId after the user decides.',
+      });
+    }
+
+    const approvalFailure = this.consumeRemoteApproval({
+      approvalId: input.approvalId,
+      identity,
+      session: route.session,
+      toolName: input.toolName,
+      inputHash,
+      now,
+      mismatchTarget: 'MCP tool',
+    });
+    if (approvalFailure) return approvalFailure;
+
+    const grantId = `grant_${this.makeId()}`;
+    this.invocationGrants.set(grantId, {
+      grantId,
+      userId: identity.userId,
+      sessionId: route.session.sessionId,
+      toolName: input.toolName,
+      riskLevel: input.riskLevel,
+      inputHash,
+      expiresAt: new Date(now.getTime() + this.invocationGrantTtlMs),
+    });
+    return { ok: true, sessionId: route.session.sessionId, grantId };
+  }
+
+  revokeInvocationGrant(grantId: string): boolean {
+    return this.invocationGrants.delete(grantId);
+  }
+
   async routeToolRequest(input: {
     identity?: RemoteIdentity;
     sessionId?: string;
@@ -293,6 +606,7 @@ export class RemoteGateway {
     riskLevel: RemoteRiskLevel;
     input?: unknown;
     approvalId?: string;
+    grantId?: string;
     deadlineMs?: number;
   }): Promise<RemoteGatewayToolResult> {
     const scope = checkRemoteScope(input.identity, input.riskLevel, this.now());
@@ -315,39 +629,66 @@ export class RemoteGateway {
       return gatewayError(401, 'IDENTITY_MISSING', 'Remote identity is required.');
     }
 
-    const route = this.router.resolve({
-      userId: identity.userId,
+    const route = this.resolveConnection({
+      identity,
       riskLevel: input.riskLevel,
       sessionId: input.sessionId,
     });
-    if (!route.ok) {
-      const status =
-        route.code === 'SESSION_AMBIGUOUS' ? 409 : route.code === 'SESSION_EXPIRED' ? 410 : 404;
-      return gatewayError(status, route.code, route.message);
-    }
+    if (!route.ok) return route;
+    const connection = route.connection;
 
+    const now = this.now();
     const inputHash = this.hashInput(input.input);
     if (requiresApproval(input.riskLevel)) {
-      if (!input.approvalId) {
-        return gatewayError(403, 'APPROVAL_REQUIRED', 'Remote tool request requires approval.');
+      if (input.grantId) {
+        const grant = this.invocationGrants.get(input.grantId);
+        const validGrant =
+          grant &&
+          grant.expiresAt.getTime() > now.getTime() &&
+          grant.userId === identity.userId &&
+          grant.sessionId === route.session.sessionId &&
+          grant.riskLevel === input.riskLevel;
+        if (!validGrant) {
+          if (grant && grant.expiresAt.getTime() <= now.getTime()) {
+            this.invocationGrants.delete(input.grantId);
+          }
+          return gatewayError(
+            403,
+            'APPROVAL_NOT_APPROVED',
+            'Remote invocation grant is missing, expired, or does not match this session.',
+          );
+        }
+      } else if (!input.approvalId) {
+        return await this.requestRemoteApproval({
+          identity,
+          session: route.session,
+          connection,
+          toolName: input.toolName,
+          riskLevel: input.riskLevel,
+          inputHash,
+          now,
+          actionLabel: 'action',
+          retryMessage:
+            'Approval was requested in EasyEDA. Retry with remoteApprovalId after the user decides.',
+        });
       }
-      const approved = this.approvals.consumeApproved({
-        approvalId: input.approvalId,
-        userId: identity.userId,
-        sessionId: route.session.sessionId,
-        toolName: input.toolName,
-        inputHash,
-        now: this.now(),
-      });
-      if (!approved) {
-        return gatewayError(403, 'APPROVAL_NOT_APPROVED', 'Remote approval is missing or invalid.');
-      }
-    }
 
-    const connection = this.connections.get(route.session.sessionId);
-    if (!connection) {
-      this.router.disconnect(route.session.sessionId);
-      return gatewayError(424, 'SESSION_DISCONNECTED', 'Paired EasyEDA extension is disconnected.');
+      if (!input.grantId) {
+        const approvalId = input.approvalId;
+        if (!approvalId) {
+          return gatewayError(403, 'APPROVAL_NOT_APPROVED', 'Remote approval id is required.');
+        }
+        const approvalFailure = this.consumeRemoteApproval({
+          approvalId,
+          identity,
+          session: route.session,
+          toolName: input.toolName,
+          inputHash,
+          now,
+          mismatchTarget: 'method',
+        });
+        if (approvalFailure) return approvalFailure;
+      }
     }
 
     const request: ToolRequestMessage = {
@@ -377,17 +718,32 @@ export class RemoteGateway {
 
     const startedAt = Date.now();
     try {
-      this.audit.record({
-        event: 'remote.tool.dispatched',
-        mode: route.session.mode,
-        userId: identity.userId,
-        sessionId: route.session.sessionId,
-        toolName: input.toolName,
-        riskLevel: input.riskLevel,
-        inputHash,
-      });
       const response = ToolResponseMessageSchema.parse(
-        await dispatchWithDeadline(connection.dispatch, request),
+        await this.dispatchQueue.run(route.session.sessionId, async () => {
+          if (this.connections.get(route.session.sessionId) !== connection) {
+            throw new RemoteSessionUnavailableError(route.session.sessionId);
+          }
+          this.audit.record({
+            event: 'remote.tool.dispatched',
+            mode: route.session.mode,
+            userId: identity.userId,
+            sessionId: route.session.sessionId,
+            toolName: input.toolName,
+            riskLevel: input.riskLevel,
+            inputHash,
+          });
+          try {
+            return await dispatchWithDeadline(connection.dispatch, request);
+          } catch (error) {
+            if (error instanceof RemoteDispatchTimeoutError) {
+              // The extension may still be executing after the caller's deadline. Quarantine
+              // this session before releasing the per-session queue so no later request can
+              // overlap with an operation whose final state is unknown.
+              this.quarantineSession(route.session.sessionId);
+            }
+            throw error;
+          }
+        }),
       );
       if (!response.ok) {
         this.audit.record({
@@ -436,9 +792,12 @@ export class RemoteGateway {
       };
     } catch (error) {
       const timedOut = error instanceof RemoteDispatchTimeoutError;
-      const errorCode: RemoteGatewayErrorCode = timedOut
-        ? 'REMOTE_EXTENSION_TIMEOUT'
-        : 'REMOTE_EXTENSION_ERROR';
+      const sessionUnavailable = error instanceof RemoteSessionUnavailableError;
+      const errorCode: RemoteGatewayErrorCode = sessionUnavailable
+        ? 'SESSION_DISCONNECTED'
+        : timedOut
+          ? 'REMOTE_EXTENSION_TIMEOUT'
+          : 'REMOTE_EXTENSION_ERROR';
       this.audit.record({
         event: 'remote.tool.failed',
         mode: route.session.mode,
@@ -452,7 +811,7 @@ export class RemoteGateway {
         durationMs: Date.now() - startedAt,
       });
       return gatewayError(
-        timedOut ? 504 : 502,
+        sessionUnavailable ? 424 : timedOut ? 504 : 502,
         errorCode,
         error instanceof Error ? error.message : String(error),
       );
@@ -604,6 +963,13 @@ export class RemoteGateway {
           extensionVersion: message.data.extensionVersion,
           activeProject: message.data.activeProject,
           dispatch,
+          requestApproval: async (request) => {
+            if (ws.readyState !== ws.OPEN) throw new Error('Remote relay socket is closed.');
+            ws.send(JSON.stringify(request));
+          },
+          closeConnection: () => {
+            if (ws.readyState === ws.OPEN) ws.close(1011, 'remote_dispatch_timeout');
+          },
           pairingCode: typeof record.pairingCode === 'string' ? record.pairingCode : undefined,
         });
         sessionId = session.sessionId;
@@ -627,6 +993,22 @@ export class RemoteGateway {
       if (message.data.type === 'heartbeat') {
         this.router.heartbeat(sessionId);
         send({ type: 'heartbeat' });
+        return;
+      }
+
+      if (message.data.type === 'approval_result') {
+        const resolved = this.resolveApprovalFromExtension({
+          sessionId,
+          approvalId: message.data.approvalId,
+          result: message.data.result,
+        });
+        if (!resolved) {
+          send({
+            type: 'error',
+            code: 'APPROVAL_NOT_FOUND',
+            message: 'Approval result did not match this relay session.',
+          });
+        }
         return;
       }
 

--- a/src/remote/session-dispatch-queue.ts
+++ b/src/remote/session-dispatch-queue.ts
@@ -1,0 +1,25 @@
+export class SessionDispatchQueue {
+  private readonly tails = new Map<string, Promise<void>>();
+
+  async run<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+    const previous = this.tails.get(sessionId) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.catch(() => undefined).then(() => current);
+    this.tails.set(sessionId, tail);
+
+    await previous.catch(() => undefined);
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.tails.get(sessionId) === tail) this.tails.delete(sessionId);
+    }
+  }
+
+  get pendingSessionCount(): number {
+    return this.tails.size;
+  }
+}

--- a/src/server/factory.ts
+++ b/src/server/factory.ts
@@ -37,6 +37,7 @@ export interface McpServerInstance {
   context: ToolContext;
   storage?: Storage;
   bridge: BridgeManager | CdpBridgeManager;
+  createSessionServer: () => McpServer;
   shutdown: () => Promise<void>;
 }
 
@@ -50,37 +51,30 @@ export async function createServer(
     options.remoteGateway ??
     (config.MCP_BRIDGE_BACKEND === 'remote_relay' ? new RemoteGateway() : undefined);
 
+  const localBridgeEnabled = config.MCP_BRIDGE_BACKEND !== 'remote_relay';
+
   logger.info(
     {
       profile: config.TOOL_PROFILE,
       transport: config.TRANSPORT,
       nodeVersion: process.version,
       flags: redactObject(flags),
-      bridgeMode: process.env.EASYEDA_BRIDGE === 'cdp' ? 'cdp' : 'extension',
+      bridgeMode: localBridgeEnabled
+        ? process.env.EASYEDA_BRIDGE === 'cdp'
+          ? 'cdp'
+          : 'extension'
+        : 'remote_relay',
     },
     'server initializing',
   );
 
-  const server = new McpServer(
-    {
-      name: 'easyeda-mcp-pro',
-      version: SERVER_VERSION,
-    },
-    {
-      capabilities: {
-        tools: {},
-        resources: {},
-        prompts: {},
-        ...(flags.mcpTasksEnabled ? {} : undefined),
-      },
-    },
-  );
-
   const bridge =
     process.env.EASYEDA_BRIDGE === 'cdp' ? new CdpBridgeManager(config) : new BridgeManager(config);
-  await bridge.connect();
+  if (localBridgeEnabled) await bridge.connect();
   const stopHotSwapWatcher =
-    bridge instanceof BridgeManager ? startHotSwapWatcher(bridge, config) : undefined;
+    localBridgeEnabled && bridge instanceof BridgeManager
+      ? startHotSwapWatcher(bridge, config)
+      : undefined;
 
   const registry = new ToolRegistry();
   registry.setProfile(config.TOOL_PROFILE as ToolProfile);
@@ -158,22 +152,49 @@ export async function createServer(
     storage,
   };
 
-  registry.registerAllOnServer(server, context);
-  registerProjectResourcesAndPrompts(server, context);
+  const createSessionServer = (): McpServer => {
+    const sessionServer = new McpServer(
+      {
+        name: 'easyeda-mcp-pro',
+        version: SERVER_VERSION,
+      },
+      {
+        capabilities: {
+          tools: {},
+          resources: {},
+          prompts: {},
+          ...(flags.mcpTasksEnabled ? {} : undefined),
+        },
+      },
+    );
 
-  server.server.onerror = (error) => {
-    logger.error({ err: error }, 'server error');
+    registry.registerAllOnServer(sessionServer, context);
+    registerProjectResourcesAndPrompts(sessionServer, context);
+    sessionServer.server.onerror = (error) => {
+      logger.error({ err: error }, 'server error');
+    };
+    return sessionServer;
   };
 
+  const server = createSessionServer();
   const transport = new StdioServerTransport();
 
   const shutdown = async () => {
     logger.info('server shutting down');
     stopHotSwapWatcher?.();
     storage.close();
-    bridge.disconnect('server shutdown');
+    if (localBridgeEnabled) bridge.disconnect('server shutdown');
     await server.close();
   };
 
-  return { server, registry, transport, context, storage, bridge, shutdown };
+  return {
+    server,
+    registry,
+    transport,
+    context,
+    storage,
+    bridge,
+    createSessionServer,
+    shutdown,
+  };
 }

--- a/src/server/transports/http.ts
+++ b/src/server/transports/http.ts
@@ -1,7 +1,9 @@
 import { randomUUID } from 'node:crypto';
 import { type Express, type Request, type Response, type NextFunction } from 'express';
 import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
+import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { type AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { type EnvConfig } from '../../config/env.js';
@@ -16,6 +18,7 @@ import { RemoteGateway } from '../../remote/gateway.js';
 export interface HttpTransportInstance {
   app: Express;
   transport: StreamableHTTPServerTransport;
+  readonly activeSessionCount: number;
   start: () => Promise<void>;
   close: () => Promise<void>;
   gateway: RemoteGateway;
@@ -23,11 +26,18 @@ export interface HttpTransportInstance {
 
 export interface HttpTransportOptions {
   gateway?: RemoteGateway;
+  serverFactory?: () => McpServer;
 }
 
 interface RateLimitEntry {
   count: number;
   resetAt: number;
+}
+
+interface McpHttpSession {
+  server: McpServer;
+  transport: StreamableHTTPServerTransport;
+  closing: boolean;
 }
 
 function createRateLimiter(windowMs: number, maxRequests: number) {
@@ -367,10 +377,10 @@ export function handleCorsPreflight(req: Request, res: Response, next: NextFunct
   if (req.method === 'OPTIONS') {
     // Vary: Origin tells caches that the response varies by the Origin header.
     res.setHeader('Vary', 'Origin');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
     res.setHeader(
       'Access-Control-Allow-Headers',
-      'Content-Type, Authorization, MCP-Protocol-Version',
+      'Content-Type, Authorization, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID',
     );
     res.setHeader('Access-Control-Max-Age', '86400');
     res.status(204).end();
@@ -422,13 +432,29 @@ function addSecurityHeaders(_req: Request, res: Response, next: NextFunction): v
   next();
 }
 
+function getMcpSessionId(req: Request): string | undefined {
+  const header = req.headers['mcp-session-id'];
+  return Array.isArray(header) ? header[0] : header;
+}
+
+function mcpSessionError(res: Response, status: number, message: string): void {
+  res.status(status).json({
+    jsonrpc: '2.0',
+    error: { code: -32000, message },
+    id: null,
+  });
+}
+
 export function createHttpTransport(
   config: EnvConfig,
   options: HttpTransportOptions = {},
 ): HttpTransportInstance {
   const logger = getLogger();
   const gateway = options.gateway ?? new RemoteGateway();
+  const sessions = new Map<string, McpHttpSession>();
 
+  // Retained for compatibility with callers that explicitly attach one MCP
+  // server. Production HTTP uses serverFactory and the session map below.
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: () => randomUUID(),
   });
@@ -456,12 +482,125 @@ export function createHttpTransport(
 
   app.use(validateOAuthToken(config));
 
-  app.post('/mcp', (req, res) => {
-    transport.handleRequest(req, res, req.body);
+  const forgetMcpSession = (session: McpHttpSession): void => {
+    const sessionId = session.transport.sessionId;
+    if (sessionId && sessions.get(sessionId) === session) {
+      sessions.delete(sessionId);
+      logger.debug({ sessionId, activeSessions: sessions.size }, 'MCP HTTP session closed');
+    }
+  };
+
+  const closeMcpSession = async (session: McpHttpSession): Promise<void> => {
+    if (session.closing) return;
+    session.closing = true;
+    forgetMcpSession(session);
+    await session.server.close();
+  };
+
+  const sessionForRequest = (req: Request, res: Response): McpHttpSession | undefined => {
+    const sessionId = getMcpSessionId(req);
+    if (!sessionId) {
+      mcpSessionError(res, 400, 'Bad Request: Missing MCP session ID');
+      return undefined;
+    }
+    const session = sessions.get(sessionId);
+    if (!session) {
+      mcpSessionError(res, 404, 'Session not found or expired');
+      return undefined;
+    }
+    return session;
+  };
+
+  const createMcpSession = async (req: Request, res: Response): Promise<void> => {
+    const serverFactory = options.serverFactory;
+    if (!serverFactory) {
+      await transport.handleRequest(req, res, req.body);
+      return;
+    }
+
+    const sessionTransport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (sessionId) => {
+        sessions.set(sessionId, session);
+        logger.debug({ sessionId, activeSessions: sessions.size }, 'MCP HTTP session initialized');
+      },
+    });
+    const sessionServer = serverFactory();
+    const session: McpHttpSession = {
+      server: sessionServer,
+      transport: sessionTransport,
+      closing: false,
+    };
+
+    sessionTransport.onclose = () => {
+      forgetMcpSession(session);
+      if (!session.closing) {
+        void closeMcpSession(session).catch((error: unknown) => {
+          logger.error(
+            { err: error instanceof Error ? error.message : String(error) },
+            'MCP HTTP session server close failed',
+          );
+        });
+      }
+    };
+
+    try {
+      await sessionServer.connect(sessionTransport);
+      await sessionTransport.handleRequest(req, res, req.body);
+      if (!sessionTransport.sessionId) {
+        await closeMcpSession(session);
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error({ err: message }, 'MCP HTTP session initialization failed');
+      await closeMcpSession(session).catch(() => undefined);
+      if (!res.headersSent) {
+        mcpSessionError(res, 500, 'Internal server error while initializing MCP session');
+      }
+    }
+  };
+
+  app.post('/mcp', async (req, res) => {
+    if (!options.serverFactory) {
+      await transport.handleRequest(req, res, req.body);
+      return;
+    }
+
+    const sessionId = getMcpSessionId(req);
+    if (sessionId) {
+      const session = sessions.get(sessionId);
+      if (!session) {
+        mcpSessionError(res, 404, 'Session not found or expired');
+        return;
+      }
+      await session.transport.handleRequest(req, res, req.body);
+      return;
+    }
+
+    if (!isInitializeRequest(req.body)) {
+      mcpSessionError(res, 400, 'Bad Request: No valid MCP session ID provided');
+      return;
+    }
+
+    await createMcpSession(req, res);
   });
 
-  app.get('/mcp', (req, res) => {
-    transport.handleRequest(req, res);
+  app.get('/mcp', async (req, res) => {
+    if (!options.serverFactory) {
+      await transport.handleRequest(req, res);
+      return;
+    }
+    const session = sessionForRequest(req, res);
+    if (session) await session.transport.handleRequest(req, res);
+  });
+
+  app.delete('/mcp', async (req, res) => {
+    if (!options.serverFactory) {
+      await transport.handleRequest(req, res);
+      return;
+    }
+    const session = sessionForRequest(req, res);
+    if (session) await session.transport.handleRequest(req, res);
   });
 
   app.get('/healthz', (_req, res) => {
@@ -488,6 +627,8 @@ export function createHttpTransport(
 
   const close = async () => {
     logger.info('HTTP transport closing');
+    const activeSessions = [...sessions.values()];
+    await Promise.allSettled(activeSessions.map(closeMcpSession));
     await transport.close();
     const s = server;
     if (s) {
@@ -495,5 +636,14 @@ export function createHttpTransport(
     }
   };
 
-  return { app, transport, start, close, gateway };
+  return {
+    app,
+    transport,
+    get activeSessionCount() {
+      return sessions.size;
+    },
+    start,
+    close,
+    gateway,
+  };
 }

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -9,11 +9,12 @@ import {
   type WriteMode,
 } from './transaction.js';
 import { type ToolProfile, getEnabledProfiles } from '../config/profiles.js';
-import { ZodError, type z } from 'zod';
+import { z, ZodError } from 'zod';
 import { SERVER_VERSION } from '../config/version.js';
 import { getGlobalMetricsCollector, type ObservabilityCategory } from '../observability/index.js';
 import { type RemoteIdentity } from '../remote/scope.js';
 import { type RemoteRiskLevel } from '../remote/protocol.js';
+import { type RemoteGatewayToolResult } from '../remote/gateway.js';
 
 // ── Structured error codes ────────────────────────────────────────────────
 
@@ -39,6 +40,36 @@ export interface StructuredError {
 
 const READ_ALL_SCOPE = 'easyeda:read';
 const WRITE_ALL_SCOPE = 'easyeda:write';
+
+const REMOTE_RELAY_CONTROL_SHAPE = {
+  remoteSessionId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Paired Remote Relay session id. Optional when MCP_REMOTE_SESSION_ID is configured.'),
+  remoteApprovalId: z
+    .string()
+    .min(1)
+    .optional()
+    .describe('Approved Remote Relay action id required for write, export, and destructive calls.'),
+};
+
+function registeredInputSchema(tool: ToolDefinition, context: ToolContext): z.ZodType {
+  if (context.config.MCP_BRIDGE_BACKEND !== 'remote_relay') return tool.inputSchema;
+  if (tool.inputSchema instanceof z.ZodObject) {
+    return tool.inputSchema.safeExtend(REMOTE_RELAY_CONTROL_SHAPE);
+  }
+  return z.intersection(tool.inputSchema, z.object(REMOTE_RELAY_CONTROL_SHAPE));
+}
+
+type RemoteGatewayFailure = Extract<RemoteGatewayToolResult, { ok: false }>;
+
+class RemoteRelayRouteError extends Error {
+  constructor(readonly failure: RemoteGatewayFailure) {
+    super(`Remote relay ${failure.code}: ${failure.message}`);
+    this.name = 'RemoteRelayRouteError';
+  }
+}
 
 function categoryForTool(tool: ToolDefinition): ObservabilityCategory {
   if (tool.group === 'diagnostics') return 'diagnostics';
@@ -252,20 +283,30 @@ function remoteRiskForTool(tool: ToolDefinition): RemoteRiskLevel {
   return 'read';
 }
 
-function contextForRemoteRelay(
+interface PreparedToolContext {
+  context: ToolContext;
+  release?: () => void;
+}
+
+async function contextForRemoteRelay(
   context: ToolContext,
   tool: ToolDefinition,
   raw: unknown,
   extra: unknown,
-): ToolContext {
-  if (context.config.MCP_BRIDGE_BACKEND !== 'remote_relay') return context;
+  parsed: unknown,
+): Promise<PreparedToolContext> {
+  if (context.config.MCP_BRIDGE_BACKEND !== 'remote_relay') return { context };
   const gateway = context.remote?.gateway;
+  if (!gateway) {
+    throw new Error('Remote relay backend requested but no RemoteGateway is configured.');
+  }
+
   const controls = rawRecord(raw);
   const configuredSessionId =
     typeof context.config.MCP_REMOTE_SESSION_ID === 'string'
       ? context.config.MCP_REMOTE_SESSION_ID
       : '';
-  const sessionId =
+  let sessionId =
     typeof controls.remoteSessionId === 'string'
       ? controls.remoteSessionId
       : configuredSessionId || undefined;
@@ -273,37 +314,50 @@ function contextForRemoteRelay(
     typeof controls.remoteApprovalId === 'string' ? controls.remoteApprovalId : undefined;
   const identity = remoteIdentityFromExtra(extra);
   const riskLevel = remoteRiskForTool(tool);
+  let grantId: string | undefined;
+
+  if (riskLevel !== 'read') {
+    const authorization = await gateway.authorizeToolInvocation({
+      identity,
+      sessionId,
+      toolName: tool.name,
+      riskLevel,
+      input: parsed,
+      approvalId,
+    });
+    if (!authorization.ok) throw new RemoteRelayRouteError(authorization);
+    sessionId = authorization.sessionId;
+    grantId = authorization.grantId;
+  }
 
   return {
-    ...context,
-    bridge: {
-      ...context.bridge,
-      get connected() {
-        return true;
-      },
-      call: async <TParams, TResult>(
-        method: string,
-        params?: TParams,
-        opts?: { timeoutMs?: number; traceparent?: string },
-      ): Promise<TResult> => {
-        if (!gateway) {
-          throw new Error('Remote relay backend requested but no RemoteGateway is configured.');
-        }
-        const result = await gateway.routeToolRequest({
-          identity,
-          sessionId,
-          toolName: method,
-          riskLevel,
-          input: params,
-          approvalId,
-          deadlineMs: opts?.timeoutMs,
-        });
-        if (!result.ok) {
-          throw new Error(`Remote relay ${result.code}: ${result.message}`);
-        }
-        return result.result as TResult;
+    context: {
+      ...context,
+      bridge: {
+        ...context.bridge,
+        get connected() {
+          return true;
+        },
+        call: async <TParams, TResult>(
+          method: string,
+          params?: TParams,
+          opts?: { timeoutMs?: number; traceparent?: string },
+        ): Promise<TResult> => {
+          const result = await gateway.routeToolRequest({
+            identity,
+            sessionId,
+            toolName: method,
+            riskLevel,
+            input: params,
+            grantId,
+            deadlineMs: opts?.timeoutMs,
+          });
+          if (!result.ok) throw new RemoteRelayRouteError(result);
+          return result.result as TResult;
+        },
       },
     },
+    release: grantId ? () => void gateway.revokeInvocationGrant(grantId) : undefined,
   };
 }
 
@@ -368,9 +422,10 @@ async function executeToolWithMetrics(
   parsed: unknown,
 ): Promise<unknown> {
   const startedAt = Date.now();
+  let prepared: PreparedToolContext | undefined;
   try {
-    const executionContext = contextForRemoteRelay(context, tool, raw, extra);
-    const result = await tool.handler(executionContext, parsed);
+    prepared = await contextForRemoteRelay(context, tool, raw, extra, parsed);
+    const result = await tool.handler(prepared.context, parsed);
     getGlobalMetricsCollector().recordTimed({
       category: categoryForTool(tool),
       name: tool.name,
@@ -386,6 +441,8 @@ async function executeToolWithMetrics(
       ok: false,
     });
     throw err;
+  } finally {
+    prepared?.release?.();
   }
 }
 
@@ -427,6 +484,20 @@ function toolFailureResponse(tool: ToolDefinition, context: ToolContext, err: un
       errorCode: ErrorCodes.INVALID_INPUT,
       message: `Invalid input for "${tool.name}": ${err.message}`,
       details: { toolName: tool.name, issues: err.issues },
+    });
+  }
+
+  if (err instanceof RemoteRelayRouteError) {
+    return structuredErrorResponse({
+      errorCode: ErrorCodes.REMOTE_RELAY,
+      message: err.message,
+      details: {
+        toolName: tool.name,
+        remoteCode: err.failure.code,
+        status: err.failure.status,
+        approvalId: err.failure.approvalId,
+        approvalExpiresAt: err.failure.approvalExpiresAt,
+      },
     });
   }
 
@@ -531,7 +602,7 @@ export class ToolRegistry {
         {
           title: tool.title,
           description: tool.description,
-          inputSchema: tool.inputSchema,
+          inputSchema: registeredInputSchema(tool, context),
           outputSchema: registeredOutputSchema(tool),
           annotations: tool.annotations,
         },

--- a/tests/unit/remote/gateway-concurrency.test.ts
+++ b/tests/unit/remote/gateway-concurrency.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from 'vitest';
+import { RemoteGateway } from '../../../src/remote/gateway.js';
+import {
+  REMOTE_RELAY_PROTOCOL_VERSION,
+  type ToolRequestMessage,
+  type ToolResponseMessage,
+} from '../../../src/remote/protocol.js';
+
+async function waitFor(check: () => boolean, timeoutMs = 1000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!check()) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for condition.');
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+describe('RemoteGateway session dispatch concurrency', () => {
+  it('serializes concurrent tool calls that target the same extension session', async () => {
+    const gateway = new RemoteGateway();
+    const identity = { userId: 'shared-user', scopes: ['easyeda.read'] as const };
+    const releases: Array<() => void> = [];
+    const started: string[] = [];
+    let activeDispatches = 0;
+    let maxActiveDispatches = 0;
+
+    const session = gateway.registerExtension({
+      connectionId: 'conn-serialized',
+      mode: 'hosted',
+      extensionVersion: '0.32.0',
+      activeProject: { projectName: 'Shared Project', documentType: 'schematic' },
+      dispatch: async (request: ToolRequestMessage): Promise<ToolResponseMessage> => {
+        activeDispatches += 1;
+        maxActiveDispatches = Math.max(maxActiveDispatches, activeDispatches);
+        started.push(request.toolName);
+        await new Promise<void>((resolve) => releases.push(resolve));
+        activeDispatches -= 1;
+        return {
+          protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+          type: 'tool_response',
+          messageId: `response-${request.messageId}`,
+          sessionId: request.sessionId,
+          requestMessageId: request.messageId,
+          timestamp: new Date().toISOString(),
+          ok: true,
+          result: { toolName: request.toolName },
+          durationMs: 1,
+        };
+      },
+    });
+
+    const pairingCode = gateway.createPairingCode({ identity, sessionId: session.sessionId });
+    expect(
+      gateway.completePairing({ identity, code: pairingCode, sessionId: session.sessionId }),
+    ).toBe(true);
+
+    const first = gateway.routeToolRequest({
+      identity,
+      sessionId: session.sessionId,
+      toolName: 'schematic.listComponents',
+      riskLevel: 'read',
+      input: { client: 'a' },
+      deadlineMs: 1000,
+    });
+    await waitFor(() => releases.length === 1);
+
+    const second = gateway.routeToolRequest({
+      identity,
+      sessionId: session.sessionId,
+      toolName: 'schematic.listWires',
+      riskLevel: 'read',
+      input: { client: 'b' },
+      deadlineMs: 1000,
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(releases).toHaveLength(1);
+    expect(activeDispatches).toBe(1);
+    expect(maxActiveDispatches).toBe(1);
+
+    releases[0]!();
+    await waitFor(() => releases.length === 2);
+    expect(activeDispatches).toBe(1);
+    expect(maxActiveDispatches).toBe(1);
+
+    releases[1]!();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult).toMatchObject({ ok: true, toolName: 'schematic.listComponents' });
+    expect(secondResult).toMatchObject({ ok: true, toolName: 'schematic.listWires' });
+    expect(started).toEqual(['schematic.listComponents', 'schematic.listWires']);
+    expect(activeDispatches).toBe(0);
+    expect(maxActiveDispatches).toBe(1);
+  });
+
+  it('quarantines a timed-out session before a queued request can dispatch', async () => {
+    const gateway = new RemoteGateway();
+    const identity = { userId: 'timeout-user', scopes: ['easyeda.read'] as const };
+    const started: string[] = [];
+    let closeConnectionCount = 0;
+    let releaseLateResponse: (() => void) | undefined;
+
+    const session = gateway.registerExtension({
+      connectionId: 'conn-timeout-quarantine',
+      mode: 'hosted',
+      extensionVersion: '0.32.0',
+      activeProject: { projectName: 'Timeout Project', documentType: 'schematic' },
+      closeConnection: () => {
+        closeConnectionCount += 1;
+      },
+      dispatch: async (request: ToolRequestMessage): Promise<ToolResponseMessage> => {
+        started.push(request.toolName);
+        return await new Promise<ToolResponseMessage>((resolve) => {
+          releaseLateResponse = () =>
+            resolve({
+              protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+              type: 'tool_response',
+              messageId: `late-response-${request.messageId}`,
+              sessionId: request.sessionId,
+              requestMessageId: request.messageId,
+              timestamp: new Date().toISOString(),
+              ok: true,
+              result: { toolName: request.toolName },
+              durationMs: 100,
+            });
+        });
+      },
+    });
+
+    const pairingCode = gateway.createPairingCode({ identity, sessionId: session.sessionId });
+    expect(
+      gateway.completePairing({ identity, code: pairingCode, sessionId: session.sessionId }),
+    ).toBe(true);
+
+    const first = gateway.routeToolRequest({
+      identity,
+      sessionId: session.sessionId,
+      toolName: 'schematic.listComponents',
+      riskLevel: 'read',
+      input: { client: 'first' },
+      deadlineMs: 25,
+    });
+    await waitFor(() => started.length === 1);
+
+    const queued = gateway.routeToolRequest({
+      identity,
+      sessionId: session.sessionId,
+      toolName: 'schematic.listWires',
+      riskLevel: 'read',
+      input: { client: 'queued' },
+      deadlineMs: 1000,
+    });
+
+    await expect(first).resolves.toMatchObject({
+      ok: false,
+      status: 504,
+      code: 'REMOTE_EXTENSION_TIMEOUT',
+    });
+    await expect(queued).resolves.toMatchObject({
+      ok: false,
+      status: 424,
+      code: 'SESSION_DISCONNECTED',
+    });
+    expect(started).toEqual(['schematic.listComponents']);
+    expect(closeConnectionCount).toBe(1);
+
+    releaseLateResponse?.();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(started).toEqual(['schematic.listComponents']);
+  });
+});

--- a/tests/unit/remote/gateway.test.ts
+++ b/tests/unit/remote/gateway.test.ts
@@ -37,6 +37,7 @@ function registerFakeExtension(gateway: RemoteGateway, dispatches: ToolRequestMe
     mode: 'hosted',
     extensionVersion: '0.19.0',
     activeProject: { projectName: 'Demo', documentType: 'schematic' },
+    requestApproval: () => undefined,
     dispatch: async (request) => {
       dispatches.push(request);
       return {
@@ -329,5 +330,301 @@ describe('RemoteGateway', () => {
       code: 'REMOTE_EXTENSION_ERROR',
       message: 'Remote relay socket closed unexpectedly.',
     });
+  });
+
+  it('authorizes a whole MCP invocation and rejects its private grant after revocation', async () => {
+    const { gateway } = makeGateway();
+    const approvalRequests: Array<{ approvalId: string }> = [];
+    const dispatches: ToolRequestMessage[] = [];
+    const session = gateway.registerExtension({
+      connectionId: 'conn-invocation-grant',
+      mode: 'hosted',
+      extensionVersion: '0.32.0',
+      activeProject: { projectName: 'Demo', documentType: 'schematic' },
+      requestApproval: (request) => {
+        approvalRequests.push(request);
+      },
+      dispatch: async (request) => {
+        dispatches.push(request);
+        return {
+          protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+          type: 'tool_response',
+          messageId: `response-${request.messageId}`,
+          sessionId: request.sessionId,
+          requestMessageId: request.messageId,
+          timestamp: new Date('2026-07-04T00:00:00.000Z').toISOString(),
+          ok: true,
+          result: { method: request.toolName },
+          durationMs: 1,
+        };
+      },
+    });
+    const code = gateway.createPairingCode({
+      identity: writeIdentity,
+      sessionId: session.sessionId,
+    });
+    gateway.completePairing({ identity: writeIdentity, code, sessionId: session.sessionId });
+
+    const invocation = {
+      identity: writeIdentity,
+      sessionId: session.sessionId,
+      toolName: 'easyeda_schematic_batch',
+      riskLevel: 'write' as const,
+      input: { operations: [{ kind: 'text' }, { kind: 'rectangle' }] },
+    };
+    const pending = await gateway.authorizeToolInvocation(invocation);
+    expect(pending).toMatchObject({
+      ok: false,
+      code: 'APPROVAL_REQUIRED',
+      approvalId: expect.stringMatching(/^appr_/),
+    });
+    if (pending.ok || !pending.approvalId) throw new Error('Expected an approval id.');
+    expect(approvalRequests).toHaveLength(1);
+    expect(approvalRequests[0]).toMatchObject({
+      toolName: 'easyeda_schematic_batch',
+      riskLevel: 'write',
+    });
+
+    expect(
+      gateway.resolveApprovalFromExtension({
+        sessionId: session.sessionId,
+        approvalId: pending.approvalId,
+        result: 'approved',
+      }),
+    ).toBe(true);
+    const authorized = await gateway.authorizeToolInvocation({
+      ...invocation,
+      approvalId: pending.approvalId,
+    });
+    expect(authorized).toMatchObject({
+      ok: true,
+      sessionId: session.sessionId,
+      grantId: expect.stringMatching(/^grant_/),
+    });
+    if (!authorized.ok) throw new Error('Expected an invocation grant.');
+
+    await expect(
+      gateway.routeToolRequest({
+        identity: writeIdentity,
+        sessionId: session.sessionId,
+        toolName: 'schematic.addText',
+        riskLevel: 'write',
+        input: { content: 'one' },
+        grantId: authorized.grantId,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    await expect(
+      gateway.routeToolRequest({
+        identity: writeIdentity,
+        sessionId: session.sessionId,
+        toolName: 'schematic.addRectangle',
+        riskLevel: 'write',
+        input: { width: 10, height: 5 },
+        grantId: authorized.grantId,
+      }),
+    ).resolves.toMatchObject({ ok: true });
+    expect(dispatches).toHaveLength(2);
+
+    expect(gateway.revokeInvocationGrant(authorized.grantId)).toBe(true);
+    await expect(
+      gateway.routeToolRequest({
+        identity: writeIdentity,
+        sessionId: session.sessionId,
+        toolName: 'schematic.addText',
+        riskLevel: 'write',
+        input: { content: 'late' },
+        grantId: authorized.grantId,
+      }),
+    ).resolves.toMatchObject({ ok: false, code: 'APPROVAL_NOT_APPROVED' });
+    expect(dispatches).toHaveLength(2);
+  });
+
+  it('fails closed when a risky connection has no approval UI', async () => {
+    const { gateway } = makeGateway();
+    const session = gateway.registerExtension({
+      connectionId: 'conn-no-approval-ui',
+      mode: 'hosted',
+      extensionVersion: '0.32.0',
+      activeProject: { projectName: 'Demo', documentType: 'schematic' },
+      dispatch: async () => {
+        throw new Error('dispatch must not run');
+      },
+    });
+    const code = gateway.createPairingCode({
+      identity: writeIdentity,
+      sessionId: session.sessionId,
+    });
+    gateway.completePairing({ identity: writeIdentity, code, sessionId: session.sessionId });
+
+    await expect(
+      gateway.authorizeToolInvocation({
+        identity: writeIdentity,
+        sessionId: session.sessionId,
+        toolName: 'easyeda_schematic_add_text',
+        riskLevel: 'write',
+        input: { content: 'blocked' },
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 424,
+      code: 'APPROVAL_UI_UNAVAILABLE',
+    });
+  });
+
+  it('requests approval once, binds the decision to the session, and consumes it once', async () => {
+    const { gateway } = makeGateway();
+    const approvalRequests: Array<{ approvalId: string }> = [];
+    const dispatches: ToolRequestMessage[] = [];
+    const session = gateway.registerExtension({
+      connectionId: 'conn-approval',
+      mode: 'hosted',
+      extensionVersion: '0.32.0',
+      activeProject: { projectName: 'Demo', documentType: 'schematic' },
+      requestApproval: (request) => {
+        approvalRequests.push(request);
+      },
+      dispatch: async (request) => {
+        dispatches.push(request);
+        return {
+          protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+          type: 'tool_response',
+          messageId: `response-${request.messageId}`,
+          sessionId: request.sessionId,
+          requestMessageId: request.messageId,
+          timestamp: new Date('2026-07-04T00:00:00.000Z').toISOString(),
+          ok: true,
+          result: { primitiveId: 'text-1' },
+          durationMs: 1,
+        };
+      },
+    });
+    const code = gateway.createPairingCode({
+      identity: writeIdentity,
+      sessionId: session.sessionId,
+    });
+    expect(
+      gateway.completePairing({ identity: writeIdentity, code, sessionId: session.sessionId }),
+    ).toBe(true);
+
+    const request = {
+      identity: writeIdentity,
+      sessionId: session.sessionId,
+      toolName: 'schematic.addText',
+      riskLevel: 'write' as const,
+      input: { x: 10, y: 20, content: 'Remote note' },
+    };
+    const first = await gateway.routeToolRequest(request);
+    expect(first).toMatchObject({
+      ok: false,
+      code: 'APPROVAL_REQUIRED',
+      approvalId: expect.stringMatching(/^appr_/),
+      approvalExpiresAt: expect.any(String),
+    });
+    if (first.ok || !first.approvalId) throw new Error('Expected an approval id.');
+
+    const duplicate = await gateway.routeToolRequest(request);
+    expect(duplicate).toMatchObject({ approvalId: first.approvalId });
+    expect(approvalRequests).toHaveLength(1);
+    expect(approvalRequests[0]).toMatchObject({
+      approvalId: first.approvalId,
+      sessionId: session.sessionId,
+      toolName: 'schematic.addText',
+      riskLevel: 'write',
+    });
+
+    expect(
+      gateway.resolveApprovalFromExtension({
+        sessionId: 'different-session',
+        approvalId: first.approvalId,
+        result: 'approved',
+      }),
+    ).toBe(false);
+    expect(
+      gateway.resolveApprovalFromExtension({
+        sessionId: session.sessionId,
+        approvalId: first.approvalId,
+        result: 'approved',
+      }),
+    ).toBe(true);
+
+    await expect(
+      gateway.routeToolRequest({ ...request, approvalId: first.approvalId }),
+    ).resolves.toMatchObject({ ok: true, result: { primitiveId: 'text-1' } });
+    expect(dispatches).toHaveLength(1);
+
+    await expect(
+      gateway.routeToolRequest({ ...request, approvalId: first.approvalId }),
+    ).resolves.toMatchObject({ ok: false, code: 'APPROVAL_NOT_APPROVED' });
+    expect(dispatches).toHaveLength(1);
+  });
+
+  it('reports rejected and expired approvals and clears pending records on disconnect', async () => {
+    const harness = makeGateway();
+    const session = harness.gateway.registerExtension({
+      connectionId: 'conn-approval-state',
+      mode: 'hosted',
+      extensionVersion: '0.32.0',
+      activeProject: { projectName: 'Demo', documentType: 'schematic' },
+      requestApproval: () => undefined,
+      dispatch: async () => {
+        throw new Error('Dispatch must not run without approval.');
+      },
+    });
+    const code = harness.gateway.createPairingCode({
+      identity: writeIdentity,
+      sessionId: session.sessionId,
+    });
+    harness.gateway.completePairing({
+      identity: writeIdentity,
+      code,
+      sessionId: session.sessionId,
+    });
+
+    const base = {
+      identity: writeIdentity,
+      sessionId: session.sessionId,
+      toolName: 'schematic.addText',
+      riskLevel: 'write' as const,
+    };
+    const rejected = await harness.gateway.routeToolRequest({
+      ...base,
+      input: { content: 'reject-me' },
+    });
+    if (rejected.ok || !rejected.approvalId) throw new Error('Expected rejected approval id.');
+    harness.gateway.resolveApprovalFromExtension({
+      sessionId: session.sessionId,
+      approvalId: rejected.approvalId,
+      result: 'rejected',
+    });
+    await expect(
+      harness.gateway.routeToolRequest({
+        ...base,
+        input: { content: 'reject-me' },
+        approvalId: rejected.approvalId,
+      }),
+    ).resolves.toMatchObject({ message: 'Remote approval was rejected by the user.' });
+
+    const expiring = await harness.gateway.routeToolRequest({
+      ...base,
+      input: { content: 'expire-me' },
+    });
+    if (expiring.ok || !expiring.approvalId) throw new Error('Expected expiring approval id.');
+    harness.advance(60_001);
+    await expect(
+      harness.gateway.routeToolRequest({
+        ...base,
+        input: { content: 'expire-me' },
+        approvalId: expiring.approvalId,
+      }),
+    ).resolves.toMatchObject({ message: 'Remote approval expired.' });
+
+    const pending = await harness.gateway.routeToolRequest({
+      ...base,
+      input: { content: 'disconnect-me' },
+    });
+    if (pending.ok || !pending.approvalId) throw new Error('Expected pending approval id.');
+    expect(harness.gateway.approvals.get(pending.approvalId)).toBeDefined();
+    harness.gateway.disconnect(session.sessionId);
+    expect(harness.gateway.approvals.get(pending.approvalId)).toBeUndefined();
   });
 });

--- a/tests/unit/remote/http-mcp-integration.test.ts
+++ b/tests/unit/remote/http-mcp-integration.test.ts
@@ -1,0 +1,471 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { createServer, type McpServerInstance } from '../../../src/server/factory.js';
+import {
+  createHttpTransport,
+  type HttpTransportInstance,
+} from '../../../src/server/transports/http.js';
+import { EnvSchema } from '../../../src/config/env.js';
+import { RemoteGateway } from '../../../src/remote/gateway.js';
+import {
+  REMOTE_RELAY_PROTOCOL_VERSION,
+  type ApprovalRequestMessage,
+  type ToolRequestMessage,
+  type ToolResponseMessage,
+} from '../../../src/remote/protocol.js';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createServer as createNetServer } from 'node:net';
+
+async function reservePort(): Promise<number> {
+  const server = createNetServer();
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('Failed to reserve a loopback test port.');
+  }
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+  return address.port;
+}
+
+async function waitFor(check: () => boolean, timeoutMs = 1000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!check()) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for condition.');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+interface RemoteHttpHarness {
+  identity: {
+    userId: string;
+    scopes: readonly ['easyeda.read', 'easyeda.write'];
+  };
+  gateway: RemoteGateway;
+  remoteSessionId: string;
+  dispatched: ToolRequestMessage[];
+  approvalRequests: ApprovalRequestMessage[];
+  readonly closedSessionServerCount: number;
+  instance: McpServerInstance;
+  httpTransport: HttpTransportInstance;
+  createClient: (name: string) => {
+    client: Client;
+    transport: StreamableHTTPClientTransport;
+  };
+  close: () => Promise<void>;
+}
+
+async function createHarness(): Promise<RemoteHttpHarness> {
+  const port = await reservePort();
+  const dataDir = await mkdtemp(join(tmpdir(), 'easyeda-remote-http-'));
+  const config = EnvSchema.parse({
+    NODE_ENV: 'test',
+    LOG_LEVEL: 'silent',
+    TOOL_PROFILE: 'core',
+    TRANSPORT: 'http',
+    HTTP_HOST: '127.0.0.1',
+    HTTP_PORT: port,
+    HTTP_AUTH_DISABLED: true,
+    MCP_BRIDGE_BACKEND: 'remote_relay',
+    BRIDGE_TIMEOUT_MS: 1000,
+    JLCSEARCH_ENABLED: false,
+    DATA_DIR: dataDir,
+    SQLITE_PATH: join(dataDir, 'test.sqlite'),
+    ARTIFACT_DIR: join(dataDir, 'artifacts'),
+    CACHE_DIR: join(dataDir, 'cache'),
+  });
+
+  const identity = {
+    userId: 'http-user',
+    scopes: ['easyeda.read', 'easyeda.write'] as const,
+  };
+  const dispatched: ToolRequestMessage[] = [];
+  const approvalRequests: ApprovalRequestMessage[] = [];
+  const gateway = new RemoteGateway();
+  const remoteSession = gateway.registerExtension({
+    connectionId: 'fake-http-extension',
+    mode: 'hosted',
+    extensionVersion: '0.32.0',
+    activeProject: { projectName: 'HTTP Test', documentType: 'schematic' },
+    requestApproval: (request) => {
+      approvalRequests.push(request);
+    },
+    dispatch: async (request): Promise<ToolResponseMessage> => {
+      dispatched.push(request);
+      const result =
+        request.toolName === 'schematic.listComponents'
+          ? {
+              total: 1,
+              items: [
+                {
+                  primitiveId: 'component-1',
+                  reference: 'R1',
+                  value: '10k',
+                  footprint: '0603',
+                },
+              ],
+            }
+          : { primitiveId: 'text-http-1' };
+      return {
+        protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+        type: 'tool_response',
+        messageId: `fake-http-response-${dispatched.length}`,
+        sessionId: request.sessionId,
+        requestMessageId: request.messageId,
+        timestamp: new Date().toISOString(),
+        ok: true,
+        result,
+        durationMs: 1,
+      };
+    },
+  });
+  const pairingCode = gateway.createPairingCode({
+    identity,
+    sessionId: remoteSession.sessionId,
+  });
+  expect(
+    gateway.completePairing({
+      identity,
+      code: pairingCode,
+      sessionId: remoteSession.sessionId,
+    }),
+  ).toBe(true);
+
+  const instance = await createServer(config, { remoteGateway: gateway });
+  expect(instance.bridge.connected).toBe(false);
+  expect(instance.bridge.activePort).toBe(0);
+
+  let closedSessionServerCount = 0;
+  const httpTransport = createHttpTransport(config, {
+    gateway,
+    serverFactory: () => {
+      const sessionServer = instance.createSessionServer();
+      const close = sessionServer.close.bind(sessionServer);
+      let counted = false;
+      sessionServer.close = async () => {
+        if (!counted) {
+          counted = true;
+          closedSessionServerCount += 1;
+        }
+        await close();
+      };
+      return sessionServer;
+    },
+  });
+  instance.httpTransport = httpTransport;
+  await httpTransport.start();
+
+  const clients = new Set<Client>();
+  const createClient = (name: string) => {
+    const client = new Client({ name, version: '1.0.0' });
+    const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), {
+      requestInit: {
+        headers: {
+          'x-remote-user-id': identity.userId,
+          'x-remote-scopes': identity.scopes.join(' '),
+        },
+      },
+    });
+    clients.add(client);
+    return { client, transport };
+  };
+
+  const close = async () => {
+    await Promise.allSettled([...clients].map(async (client) => client.close()));
+    await httpTransport.close();
+    await instance.shutdown();
+    await rm(dataDir, { recursive: true, force: true });
+  };
+
+  return {
+    identity,
+    gateway,
+    remoteSessionId: remoteSession.sessionId,
+    dispatched,
+    approvalRequests,
+    get closedSessionServerCount() {
+      return closedSessionServerCount;
+    },
+    instance,
+    httpTransport,
+    createClient,
+    close,
+  };
+}
+
+describe('Remote Relay MCP HTTP integration', () => {
+  const cleanup: Array<() => Promise<void>> = [];
+
+  afterEach(async () => {
+    while (cleanup.length > 0) {
+      const task = cleanup.pop();
+      if (task) await task();
+    }
+  });
+
+  it('routes read calls and approval-gated write calls through a paired fake extension without a local bridge listener', async () => {
+    const harness = await createHarness();
+    cleanup.push(harness.close);
+    const { client, transport } = harness.createClient('remote-http-test');
+    await client.connect(transport);
+
+    expect(harness.httpTransport.activeSessionCount).toBe(1);
+
+    const listed = await client.listTools();
+    const readTool = listed.tools.find(
+      (candidate) => candidate.name === 'easyeda_schematic_components',
+    );
+    const writeTool = listed.tools.find(
+      (candidate) => candidate.name === 'easyeda_schematic_add_text',
+    );
+    expect(readTool?.inputSchema.properties).toMatchObject({
+      remoteSessionId: expect.any(Object),
+      remoteApprovalId: expect.any(Object),
+    });
+    expect(writeTool?.inputSchema.properties).toMatchObject({
+      remoteSessionId: expect.any(Object),
+      remoteApprovalId: expect.any(Object),
+    });
+
+    const readResult = await client.callTool({
+      name: 'easyeda_schematic_components',
+      arguments: {
+        projectId: 'project-http',
+        remoteSessionId: harness.remoteSessionId,
+      },
+    });
+
+    expect(readResult.isError).not.toBe(true);
+    expect(readResult.structuredContent).toMatchObject({
+      project_id: 'project-http',
+      total: 1,
+      components: [
+        {
+          primitiveId: 'component-1',
+          reference: 'R1',
+          value: '10k',
+          footprint: '0603',
+        },
+      ],
+    });
+    expect(harness.dispatched).toHaveLength(1);
+    expect(harness.dispatched[0]).toMatchObject({
+      sessionId: harness.remoteSessionId,
+      toolName: 'schematic.listComponents',
+      riskLevel: 'read',
+      input: { projectId: 'project-http', limit: 100, offset: 0 },
+    });
+
+    const writeArguments = {
+      x: 100,
+      y: 200,
+      content: 'Approved remote note',
+      confirmWrite: true,
+      remoteSessionId: harness.remoteSessionId,
+    };
+    const approvalRequired = await client.callTool({
+      name: 'easyeda_schematic_add_text',
+      arguments: writeArguments,
+    });
+    expect(approvalRequired.isError).toBe(true);
+    expect(approvalRequired.structuredContent).toMatchObject({
+      errorCode: 'ERR_REMOTE_RELAY',
+      details: {
+        remoteCode: 'APPROVAL_REQUIRED',
+        approvalId: expect.stringMatching(/^appr_/),
+        approvalExpiresAt: expect.any(String),
+      },
+    });
+    const approvalId = (
+      approvalRequired.structuredContent as {
+        details?: { approvalId?: string };
+      }
+    ).details?.approvalId;
+    expect(approvalId).toBeDefined();
+    expect(harness.approvalRequests).toHaveLength(1);
+    expect(harness.approvalRequests[0]).toMatchObject({
+      approvalId,
+      sessionId: harness.remoteSessionId,
+      toolName: 'easyeda_schematic_add_text',
+      riskLevel: 'write',
+    });
+    expect(harness.dispatched).toHaveLength(1);
+
+    expect(
+      harness.gateway.resolveApprovalFromExtension({
+        sessionId: harness.remoteSessionId,
+        approvalId: approvalId!,
+        result: 'approved',
+      }),
+    ).toBe(true);
+
+    const writeResult = await client.callTool({
+      name: 'easyeda_schematic_add_text',
+      arguments: { ...writeArguments, remoteApprovalId: approvalId },
+    });
+    expect(writeResult.isError).not.toBe(true);
+    expect(writeResult.structuredContent).toMatchObject({
+      success: true,
+      text: { primitiveId: 'text-http-1' },
+    });
+    expect(harness.dispatched).toHaveLength(2);
+    expect(harness.dispatched[1]).toMatchObject({
+      sessionId: harness.remoteSessionId,
+      toolName: 'schematic.addText',
+      riskLevel: 'write',
+      input: { x: 100, y: 200, content: 'Approved remote note' },
+    });
+
+    const replay = await client.callTool({
+      name: 'easyeda_schematic_add_text',
+      arguments: { ...writeArguments, remoteApprovalId: approvalId },
+    });
+    expect(replay.isError).toBe(true);
+    expect(replay.structuredContent).toMatchObject({
+      errorCode: 'ERR_REMOTE_RELAY',
+      details: { remoteCode: 'APPROVAL_NOT_APPROVED', approvalId },
+    });
+    expect(harness.dispatched).toHaveLength(2);
+
+    const rejectedArguments = { ...writeArguments, content: 'Rejected remote note' };
+    const rejectionRequired = await client.callTool({
+      name: 'easyeda_schematic_add_text',
+      arguments: rejectedArguments,
+    });
+    const rejectedApprovalId = (
+      rejectionRequired.structuredContent as { details?: { approvalId?: string } }
+    ).details?.approvalId;
+    expect(rejectedApprovalId).toBeDefined();
+    expect(harness.approvalRequests).toHaveLength(2);
+    expect(
+      harness.gateway.resolveApprovalFromExtension({
+        sessionId: harness.remoteSessionId,
+        approvalId: rejectedApprovalId!,
+        result: 'rejected',
+      }),
+    ).toBe(true);
+    const rejected = await client.callTool({
+      name: 'easyeda_schematic_add_text',
+      arguments: { ...rejectedArguments, remoteApprovalId: rejectedApprovalId },
+    });
+    expect(rejected.isError).toBe(true);
+    expect(rejected.structuredContent).toMatchObject({
+      errorCode: 'ERR_REMOTE_RELAY',
+      details: {
+        remoteCode: 'APPROVAL_NOT_APPROVED',
+        approvalId: rejectedApprovalId,
+      },
+    });
+    expect(rejected.content[0]?.text).toContain('rejected by the user');
+    expect(harness.dispatched).toHaveLength(2);
+
+    const timeoutArguments = { ...writeArguments, content: 'Timed out remote note' };
+    const timeoutRequired = await client.callTool({
+      name: 'easyeda_schematic_add_text',
+      arguments: timeoutArguments,
+    });
+    const timeoutApprovalId = (
+      timeoutRequired.structuredContent as { details?: { approvalId?: string } }
+    ).details?.approvalId;
+    expect(timeoutApprovalId).toBeDefined();
+    expect(harness.approvalRequests).toHaveLength(3);
+    expect(
+      harness.gateway.resolveApprovalFromExtension({
+        sessionId: harness.remoteSessionId,
+        approvalId: timeoutApprovalId!,
+        result: 'timeout',
+      }),
+    ).toBe(true);
+    const timedOut = await client.callTool({
+      name: 'easyeda_schematic_add_text',
+      arguments: { ...timeoutArguments, remoteApprovalId: timeoutApprovalId },
+    });
+    expect(timedOut.isError).toBe(true);
+    expect(timedOut.structuredContent).toMatchObject({
+      errorCode: 'ERR_REMOTE_RELAY',
+      details: {
+        remoteCode: 'APPROVAL_NOT_APPROVED',
+        approvalId: timeoutApprovalId,
+      },
+    });
+    expect(timedOut.content[0]?.text).toContain('expired');
+    expect(harness.dispatched).toHaveLength(2);
+  });
+
+  it('keeps two independent MCP clients connected to the same paired extension session', async () => {
+    const harness = await createHarness();
+    cleanup.push(harness.close);
+    const first = harness.createClient('remote-http-client-a');
+    const second = harness.createClient('remote-http-client-b');
+
+    await Promise.all([
+      first.client.connect(first.transport),
+      second.client.connect(second.transport),
+    ]);
+
+    expect(first.transport.sessionId).toBeDefined();
+    expect(second.transport.sessionId).toBeDefined();
+    expect(first.transport.sessionId).not.toBe(second.transport.sessionId);
+    expect(harness.httpTransport.activeSessionCount).toBe(2);
+    expect(harness.closedSessionServerCount).toBe(0);
+
+    const [firstResult, secondResult] = await Promise.all([
+      first.client.callTool({
+        name: 'easyeda_schematic_components',
+        arguments: {
+          projectId: 'project-client-a',
+          remoteSessionId: harness.remoteSessionId,
+        },
+      }),
+      second.client.callTool({
+        name: 'easyeda_schematic_components',
+        arguments: {
+          projectId: 'project-client-b',
+          remoteSessionId: harness.remoteSessionId,
+        },
+      }),
+    ]);
+
+    expect(firstResult.isError).not.toBe(true);
+    expect(secondResult.isError).not.toBe(true);
+    expect(harness.dispatched).toHaveLength(2);
+    expect(harness.dispatched.map((request) => request.input)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ projectId: 'project-client-a' }),
+        expect.objectContaining({ projectId: 'project-client-b' }),
+      ]),
+    );
+    expect(
+      harness.dispatched.every((request) => request.sessionId === harness.remoteSessionId),
+    ).toBe(true);
+
+    await first.transport.terminateSession();
+    await first.client.close();
+    await waitFor(
+      () =>
+        harness.httpTransport.activeSessionCount === 1 && harness.closedSessionServerCount === 1,
+    );
+
+    const survivingResult = await second.client.callTool({
+      name: 'easyeda_schematic_components',
+      arguments: {
+        projectId: 'project-client-b-after-a-closed',
+        remoteSessionId: harness.remoteSessionId,
+      },
+    });
+
+    expect(survivingResult.isError).not.toBe(true);
+    expect(harness.closedSessionServerCount).toBe(1);
+    expect(harness.dispatched).toHaveLength(3);
+    expect(harness.dispatched[2]).toMatchObject({
+      sessionId: harness.remoteSessionId,
+      input: { projectId: 'project-client-b-after-a-closed' },
+    });
+  });
+});

--- a/tests/unit/remote/policy-observability.test.ts
+++ b/tests/unit/remote/policy-observability.test.ts
@@ -46,6 +46,97 @@ describe('remote approval policy', () => {
       }),
     ).toBe(true);
   });
+
+  it('accepts only the first decision and treats the exact expiry instant as timeout', () => {
+    const store = new ApprovalStore();
+    store.request({
+      approvalId: 'approval_first_decision',
+      userId: 'user_1',
+      sessionId: 'sess_1',
+      toolName: 'easyeda_schematic_add_text',
+      riskLevel: 'write',
+      inputHash: 'hash_1',
+      actionSummary: 'Add text',
+      expiresAt: new Date('2026-07-03T00:01:00.000Z'),
+    });
+
+    expect(
+      store.resolve('approval_first_decision', 'approved', new Date('2026-07-03T00:01:00.000Z')),
+    ).toMatchObject({ decision: 'timeout' });
+    expect(
+      store.resolve('approval_first_decision', 'approved', new Date('2026-07-03T00:01:01.000Z')),
+    ).toBeUndefined();
+    expect(store.get('approval_first_decision')).toMatchObject({ decision: 'timeout' });
+  });
+
+  it('reuses only an exact unexpired pending approval and removes expired records', () => {
+    const store = new ApprovalStore();
+    store.request({
+      approvalId: 'pending_exact',
+      userId: 'user_1',
+      sessionId: 'sess_1',
+      toolName: 'easyeda_schematic_add_text',
+      riskLevel: 'write',
+      inputHash: 'hash_exact',
+      actionSummary: 'Add text',
+      expiresAt: new Date('2026-07-03T00:02:00.000Z'),
+    });
+    store.request({
+      approvalId: 'pending_expired',
+      userId: 'user_1',
+      sessionId: 'sess_1',
+      toolName: 'easyeda_schematic_add_text',
+      riskLevel: 'write',
+      inputHash: 'hash_expired',
+      actionSummary: 'Add old text',
+      expiresAt: new Date('2026-07-03T00:00:30.000Z'),
+    });
+
+    expect(
+      store.findPending({
+        userId: 'user_1',
+        sessionId: 'sess_1',
+        toolName: 'easyeda_schematic_add_text',
+        inputHash: 'hash_exact',
+        now: new Date('2026-07-03T00:01:00.000Z'),
+      }),
+    ).toMatchObject({ approvalId: 'pending_exact' });
+    expect(
+      store.findPending({
+        userId: 'user_1',
+        sessionId: 'sess_1',
+        toolName: 'easyeda_schematic_add_text',
+        inputHash: 'hash_expired',
+        now: new Date('2026-07-03T00:01:00.000Z'),
+      }),
+    ).toBeUndefined();
+    expect(store.get('pending_expired')).toBeUndefined();
+  });
+
+  it('deletes all approval records for a disconnected session only', () => {
+    const store = new ApprovalStore();
+    for (const [approvalId, sessionId] of [
+      ['approval_a', 'sess_1'],
+      ['approval_b', 'sess_1'],
+      ['approval_c', 'sess_2'],
+    ] as const) {
+      store.request({
+        approvalId,
+        userId: 'user_1',
+        sessionId,
+        toolName: 'easyeda_schematic_add_text',
+        riskLevel: 'write',
+        inputHash: approvalId,
+        actionSummary: 'Add text',
+        expiresAt: new Date('2026-07-03T00:02:00.000Z'),
+      });
+    }
+
+    expect(store.deleteForSession('sess_1')).toBe(2);
+    expect(store.get('approval_a')).toBeUndefined();
+    expect(store.get('approval_b')).toBeUndefined();
+    expect(store.get('approval_c')).toBeDefined();
+  });
 });
 
 describe('remote scope checks', () => {

--- a/tests/unit/server/factory.test.ts
+++ b/tests/unit/server/factory.test.ts
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   registerAll: vi.fn(),
   registerTools: vi.fn(),
   registerResources: vi.fn(),
+  startHotSwapWatcher: vi.fn(() => vi.fn()),
   vendor: vi.fn(),
 }));
 
@@ -56,6 +57,9 @@ vi.mock('../../../src/bridge/manager.js', () => ({
     extensionVersion = '0.20.0';
     extensionVersionMismatch = true;
   },
+}));
+vi.mock('../../../src/bridge/hotswap-watcher.js', () => ({
+  startHotSwapWatcher: mocks.startHotSwapWatcher,
 }));
 vi.mock('../../../src/tools/registry.js', () => ({
   ToolRegistry: class MockToolRegistry {
@@ -114,6 +118,21 @@ describe('createServer', () => {
 
     expect(mocks.storageClose).toHaveBeenCalledTimes(1);
     expect(mocks.disconnect).toHaveBeenCalledWith('server shutdown');
+    expect(mocks.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open the local bridge or hot-swap watcher in Remote Relay mode', async () => {
+    const instance = await createServer(
+      config({ TRANSPORT: 'http', MCP_BRIDGE_BACKEND: 'remote_relay' }),
+    );
+
+    expect(mocks.connect).not.toHaveBeenCalled();
+    expect(mocks.startHotSwapWatcher).not.toHaveBeenCalled();
+    expect(instance.context.remote?.gateway).toBeDefined();
+
+    await instance.shutdown();
+
+    expect(mocks.disconnect).not.toHaveBeenCalled();
     expect(mocks.close).toHaveBeenCalledTimes(1);
   });
 

--- a/tests/unit/server/transports/http-remote-gateway.test.ts
+++ b/tests/unit/server/transports/http-remote-gateway.test.ts
@@ -134,4 +134,61 @@ describe('HTTP remote gateway endpoints', () => {
       await expect(unpaired.json()).resolves.toMatchObject({ ok: false, code: 'SESSION_UNPAIRED' });
     });
   });
+
+  it('does not accept a caller-supplied private invocation grant over public HTTP', async () => {
+    await withRemoteServer(3933, async (baseUrl, transport) => {
+      let dispatchCount = 0;
+      const approvalIds: string[] = [];
+      const session = transport.gateway.registerExtension({
+        connectionId: 'conn-private-grant',
+        mode: 'hosted',
+        extensionVersion: '0.32.0',
+        activeProject: { projectName: 'Demo', documentType: 'schematic' },
+        requestApproval: (request) => {
+          approvalIds.push(request.approvalId);
+        },
+        dispatch: async (request) => {
+          dispatchCount += 1;
+          return {
+            protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+            type: 'tool_response' as const,
+            messageId: `response-${request.messageId}`,
+            sessionId: request.sessionId,
+            requestMessageId: request.messageId,
+            timestamp: new Date('2026-07-04T00:00:00.000Z').toISOString(),
+            ok: true,
+            result: {},
+            durationMs: 1,
+          };
+        },
+      });
+
+      const identity = { userId: 'user-a', scopes: ['easyeda.write'] as const };
+      const code = transport.gateway.createPairingCode({ identity, sessionId: session.sessionId });
+      expect(
+        transport.gateway.completePairing({ identity, code, sessionId: session.sessionId }),
+      ).toBe(true);
+
+      const response = await fetch(`${baseUrl}/remote/tool-requests`, {
+        method: 'POST',
+        headers: headers('easyeda.write'),
+        body: JSON.stringify({
+          sessionId: session.sessionId,
+          toolName: 'schematic.addText',
+          riskLevel: 'write',
+          input: { content: 'must not dispatch' },
+          grantId: 'caller-supplied-value',
+        }),
+      });
+
+      expect(response.status).toBe(403);
+      await expect(response.json()).resolves.toMatchObject({
+        ok: false,
+        code: 'APPROVAL_REQUIRED',
+        approvalId: expect.stringMatching(/^appr_/),
+      });
+      expect(approvalIds).toHaveLength(1);
+      expect(dispatchCount).toBe(0);
+    });
+  });
 });

--- a/tests/unit/server/transports/http.test.ts
+++ b/tests/unit/server/transports/http.test.ts
@@ -241,9 +241,9 @@ describe('createHttpTransport', () => {
     try {
       const res = await fetch('http://127.0.0.1:3897/healthz', { method: 'OPTIONS' });
       expect(res.status).toBe(204);
-      expect(res.headers.get('access-control-allow-methods')).toBe('GET, POST, OPTIONS');
+      expect(res.headers.get('access-control-allow-methods')).toBe('GET, POST, DELETE, OPTIONS');
       expect(res.headers.get('access-control-allow-headers')).toBe(
-        'Content-Type, Authorization, MCP-Protocol-Version',
+        'Content-Type, Authorization, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID',
       );
       expect(res.headers.get('access-control-max-age')).toBe('86400');
       expect(res.headers.get('vary')).toBe('Origin');
@@ -583,11 +583,11 @@ describe('handleCorsPreflight', () => {
     expect(res.setHeader).toHaveBeenCalledWith('Vary', 'Origin');
     expect(res.setHeader).toHaveBeenCalledWith(
       'Access-Control-Allow-Methods',
-      'GET, POST, OPTIONS',
+      'GET, POST, DELETE, OPTIONS',
     );
     expect(res.setHeader).toHaveBeenCalledWith(
       'Access-Control-Allow-Headers',
-      'Content-Type, Authorization, MCP-Protocol-Version',
+      'Content-Type, Authorization, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID',
     );
     expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Max-Age', '86400');
     expect(res.end).toHaveBeenCalled();
@@ -649,7 +649,7 @@ describe('createHttpTransport — OAuth/JWKS validation', () => {
       });
       expect(res.status).toBe(204);
       expect(res.headers.get('access-control-allow-origin')).toBe('http://localhost:5173');
-      expect(res.headers.get('access-control-allow-methods')).toBe('GET, POST, OPTIONS');
+      expect(res.headers.get('access-control-allow-methods')).toBe('GET, POST, DELETE, OPTIONS');
     } finally {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }

--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -733,6 +733,110 @@ describe('registered output schema compatibility', () => {
 });
 
 describe('ToolRegistry remote relay backend', () => {
+  it('advertises relay session and approval controls in remote MCP tool schemas', async () => {
+    const routeToolRequest = vi.fn(async () => ({
+      ok: true as const,
+      sessionId: 'sess_schema',
+      toolName: 'schematic.getDocument',
+      result: { ok: true },
+      durationMs: 1,
+    }));
+    const domainHandler = vi.fn(async (ctx: ToolContext, input: { query: string }) => {
+      await ctx.bridge.call('schematic.getDocument', input);
+      return { ok: true };
+    });
+    const registry = new ToolRegistry();
+    registry.register(
+      createMockTool('remote_schema_tool', 'core', {
+        inputSchema: z.object({ query: z.string() }),
+        handler: domainHandler as ToolDefinition['handler'],
+      }),
+    );
+
+    let registeredDefinition: { inputSchema: z.ZodType } | undefined;
+    let registeredHandler:
+      ((input: unknown, extra: unknown) => Promise<Record<string, unknown>>) | undefined;
+    registry.registerAllOnServer(
+      {
+        registerTool: (
+          _name: string,
+          definition: { inputSchema: z.ZodType },
+          handler: (input: unknown, extra: unknown) => Promise<Record<string, unknown>>,
+        ) => {
+          registeredDefinition = definition;
+          registeredHandler = handler;
+        },
+      } as any,
+      mockContext({
+        config: {
+          bridgeTimeoutMs: 1000,
+          artifactDir: '.easyeda-mcp-pro/artifacts',
+          bridgeHost: '127.0.0.1',
+          bridgePort: 49620,
+          MCP_BRIDGE_BACKEND: 'remote_relay',
+        },
+        remote: { gateway: { routeToolRequest } as any },
+      }),
+    );
+
+    const parsed = registeredDefinition?.inputSchema.parse({
+      query: 'current',
+      remoteSessionId: 'sess_schema',
+      remoteApprovalId: 'appr_schema',
+    }) as Record<string, unknown>;
+    expect(parsed).toEqual({
+      query: 'current',
+      remoteSessionId: 'sess_schema',
+      remoteApprovalId: 'appr_schema',
+    });
+
+    await registeredHandler?.(parsed, {
+      authInfo: {
+        clientId: 'client-schema',
+        scopes: ['easyeda:read'],
+        extra: { sub: 'user-schema' },
+      },
+    });
+
+    expect(domainHandler).toHaveBeenCalledWith(expect.any(Object), { query: 'current' });
+    expect(routeToolRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'sess_schema',
+        input: { query: 'current' },
+      }),
+    );
+    expect(routeToolRequest.mock.calls[0]?.[0]).not.toHaveProperty('approvalId');
+  });
+
+  it('does not advertise Remote Relay controls in local bridge mode', () => {
+    const registry = new ToolRegistry();
+    registry.register(
+      createMockTool('local_schema_tool', 'core', {
+        inputSchema: z.object({ query: z.string() }),
+      }),
+    );
+    let registeredInput: z.ZodType | undefined;
+    registry.registerAllOnServer(
+      {
+        registerTool: (_name: string, definition: { inputSchema: z.ZodType }) => {
+          registeredInput = definition.inputSchema;
+        },
+      } as any,
+      mockContext({
+        config: {
+          bridgeTimeoutMs: 1000,
+          artifactDir: '.easyeda-mcp-pro/artifacts',
+          bridgeHost: '127.0.0.1',
+          bridgePort: 49620,
+          MCP_BRIDGE_BACKEND: 'local_bridge',
+        },
+      }),
+    );
+
+    expect(registeredInput).toBeInstanceOf(z.ZodObject);
+    expect((registeredInput as z.ZodObject).shape).not.toHaveProperty('remoteSessionId');
+    expect((registeredInput as z.ZodObject).shape).not.toHaveProperty('remoteApprovalId');
+  });
   it('routes bridge calls through RemoteGateway when MCP_BRIDGE_BACKEND=remote_relay', async () => {
     const routeToolRequest = vi.fn(async () => ({
       ok: true as const,
@@ -793,26 +897,32 @@ describe('ToolRegistry remote relay backend', () => {
     });
   });
 
-  it('passes remote approval controls for write/export remote bridge calls', async () => {
-    const routeToolRequest = vi.fn(async () => ({
+  it('authorizes a risky MCP invocation once and reuses its private grant for every bridge call', async () => {
+    const authorizeToolInvocation = vi.fn(async () => ({
       ok: true as const,
       sessionId: 'sess_2',
-      toolName: 'board.exportGerbers',
+      grantId: 'grant_1',
+    }));
+    const routeToolRequest = vi.fn(async (input: { toolName: string }) => ({
+      ok: true as const,
+      sessionId: 'sess_2',
+      toolName: input.toolName,
       result: { ok: true },
       durationMs: 7,
     }));
+    const revokeInvocationGrant = vi.fn(() => true);
     const registry = new ToolRegistry();
     registry.register(
       createMockTool('remote_export_tool', 'core', {
         group: 'export',
         risk: 'high',
         confirmWrite: true,
-        inputSchema: z.object({
-          confirmWrite: z.boolean(),
-          remoteSessionId: z.string().optional(),
-          remoteApprovalId: z.string().optional(),
-        }),
-        handler: async (ctx) => await ctx.bridge.call('board.exportGerbers', { format: 'zip' }),
+        inputSchema: z.object({ confirmWrite: z.boolean() }),
+        handler: async (ctx) => {
+          await ctx.bridge.call('board.prepareExport', { format: 'zip' });
+          await ctx.bridge.call('board.exportGerbers', { format: 'zip' });
+          return { ok: true };
+        },
       }),
     );
     const { server, handlers } = mockMcpServer();
@@ -826,7 +936,13 @@ describe('ToolRegistry remote relay backend', () => {
           bridgePort: 49620,
           MCP_BRIDGE_BACKEND: 'remote_relay',
         },
-        remote: { gateway: { routeToolRequest } as any },
+        remote: {
+          gateway: {
+            authorizeToolInvocation,
+            routeToolRequest,
+            revokeInvocationGrant,
+          } as any,
+        },
       }),
     );
 
@@ -846,15 +962,35 @@ describe('ToolRegistry remote relay backend', () => {
     );
 
     expect(response.isError).toBeFalsy();
-    expect(routeToolRequest).toHaveBeenCalledWith(
+    expect(authorizeToolInvocation).toHaveBeenCalledWith(
       expect.objectContaining({
         sessionId: 'sess_2',
-        toolName: 'board.exportGerbers',
+        toolName: 'remote_export_tool',
         riskLevel: 'export',
-        input: { format: 'zip' },
+        input: { confirmWrite: true },
         approvalId: 'appr_1',
       }),
     );
+    expect(routeToolRequest).toHaveBeenCalledTimes(2);
+    expect(routeToolRequest).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        sessionId: 'sess_2',
+        toolName: 'board.prepareExport',
+        riskLevel: 'export',
+        input: { format: 'zip' },
+        grantId: 'grant_1',
+      }),
+    );
+    expect(routeToolRequest).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        sessionId: 'sess_2',
+        toolName: 'board.exportGerbers',
+        grantId: 'grant_1',
+      }),
+    );
+    expect(revokeInvocationGrant).toHaveBeenCalledWith('grant_1');
     expect(routeToolRequest.mock.calls[0]?.[0].identity).toMatchObject({
       userId: 'user-a',
       scopes: ['easyeda.export'],
@@ -902,9 +1038,9 @@ describe('ToolRegistry remote relay backend', () => {
   it('surfaces Remote Relay routing failures as structured tool errors', async () => {
     const routeToolRequest = vi.fn(async () => ({
       ok: false as const,
-      code: 'REMOTE_SESSION_NOT_FOUND',
-      message: 'No paired session matched the request.',
-      suggestion: 'Pair an extension session first.',
+      status: 424,
+      code: 'SESSION_DISCONNECTED' as const,
+      message: 'Paired EasyEDA extension is disconnected.',
     }));
     const registry = new ToolRegistry();
     registry.register(
@@ -932,10 +1068,14 @@ describe('ToolRegistry remote relay backend', () => {
 
     expect(response.isError).toBe(true);
     expect(response.structuredContent).toMatchObject({
-      errorCode: ErrorCodes.TOOL_EXECUTION,
-      details: { toolName: 'remote_failure_tool' },
+      errorCode: ErrorCodes.REMOTE_RELAY,
+      details: {
+        toolName: 'remote_failure_tool',
+        remoteCode: 'SESSION_DISCONNECTED',
+        status: 424,
+      },
     });
-    expect(response.content[0].text).toContain('REMOTE_SESSION_NOT_FOUND');
+    expect(response.content[0].text).toContain('SESSION_DISCONNECTED');
   });
 
   it('surfaces a missing RemoteGateway when remote backend is enabled', async () => {


### PR DESCRIPTION
## Summary
- route real MCP tool calls through paired Remote Relay sessions without a local bridge listener
- require EasyEDA-side approval for write, export, and destructive calls with one-time invocation grants
- multiplex independent Streamable HTTP MCP clients by `Mcp-Session-Id`
- isolate and close per-client MCP server sessions without affecting other clients
- serialize calls targeting the same EasyEDA extension session before dispatcher execution
- quarantine an extension session after a timed-out operation so queued mutations cannot overlap unknown state
- add extension approval handling, structured relay errors, updated operational docs, and CI-safe fake-extension end-to-end coverage

## Validation
- `pnpm verify`
- main tests: 1274/1274 passed
- extension tests: 93/93 passed
- format, main and extension typecheck, ESLint, tool metadata lint, tool coverage, builds, extension packaging, metadata check, and docs build passed
- two simultaneous MCP clients can share one paired extension session; closing one releases only its server and leaves the other operational
- concurrent calls targeting one extension session are serialized
- a timed-out extension session is disconnected before queued work can dispatch

Closes #232