### PR TITLE
feat(workflows): add visible RP2040 scaffold sections

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -111,7 +111,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_workflow_ne555_astable`                   | `pro`   | `medium` | Create a deterministic NE555 astable LED flasher workflow using safe sheet-region planning, component-level layout offsets, explicit pin-to-net connectivity, and optional post-write QA. Caller supplies already-resolved EasyEDA device items; this tool does not guess catalog parts (confirmWrite required).                 |
 | `easyeda_workflow_place_block`                     | `pro`   | `medium` | Place a group of components, wire their pin-to-net connections (new and/or pre-existing components), and create net ports for block-external nets — all as a single atomic transaction with rollback on partial failure (confirmWrite required).                                                                                 |
 | `easyeda_workflow_power_rail`                      | `pro`   | `medium` | Place a regulator and its supporting passives and wire them to input/output/ground nets in a single atomic transaction, instead of one primitive call per component. Caller supplies already-resolved device items and pin connections; this tool does not select parts (confirmWrite required).                                 |
-| `easyeda_workflow_rp2040_servo_module`             | `pro`   | `medium` | Create a deterministic functional-block scaffold for the RP2040 servo-module reference design. This first milestone places BOM components by block and returns explicit missing-netlist warnings; it does not infer exact pin-to-net wiring from screenshot+BOM alone (confirmWrite required).                                   |
+| `easyeda_workflow_rp2040_servo_module`             | `pro`   | `medium` | Plan or apply an RP2040 servo-module scaffold: 56 BOM parts in seven visible rollback-backed sections with deterministic titles and completeness diagnostics. Exact pin-to-net wiring stays intentionally absent until later block netlists supply it (confirmWrite required).                                                   |
 
 ---
 
@@ -3625,7 +3625,7 @@ Returns a JSON object matching the schema:
 
 **Profile:** `pro` | **Risk Level:** `medium`
 
-> Create a deterministic functional-block scaffold for the RP2040 servo-module reference design. This first milestone places BOM components by block and returns explicit missing-netlist warnings; it does not infer exact pin-to-net wiring from screenshot+BOM alone (confirmWrite required).
+> Plan or apply an RP2040 servo-module scaffold: 56 BOM parts in seven visible rollback-backed sections with deterministic titles and completeness diagnostics. Exact pin-to-net wiring stays intentionally absent until later block netlists supply it (confirmWrite required).
 
 ### Input Parameters
 

--- a/src/tools/L2_workflows.ts
+++ b/src/tools/L2_workflows.ts
@@ -26,6 +26,7 @@ import { buildSpiceDeck } from '../simulation/netlist.js';
 import { detectNgspice, runNgspiceDeck } from '../simulation/runner.js';
 import { parseOperatingPointOutput } from '../simulation/parser.js';
 import { verifyRailAgainstSpec } from '../simulation/verify.js';
+import { listPrimitiveIds } from '../transactions/index.js';
 import type { SimCircuit } from '../simulation/types.js';
 
 const deviceItemSchema = z.object({
@@ -179,8 +180,9 @@ interface ApplyOutcome {
 
 /**
  * Execute a workflow plan's operations in order against the bridge. Stops at the first
- * failure and best-effort rolls back every newly-created primitive (placed components and
- * net ports) from this same transaction — see `WorkflowPlan.rollbackNotes` for what cannot
+ * failure and best-effort rolls back every newly-created primitive (placed components,
+ * net ports, wires, rectangles, and text) from this same transaction — see
+ * `WorkflowPlan.rollbackNotes` for what cannot
  * be rolled back (pin connections applied to pre-existing components).
  */
 interface OperationOutcome {
@@ -198,22 +200,81 @@ function extractResultPrimitiveId(result: unknown): string | undefined {
   return typeof data === 'string' ? data : (data?.primitiveId ?? data?.result ?? undefined);
 }
 
+const WORKFLOW_CREATE_RECONCILE_ATTEMPTS = 30;
+const WORKFLOW_CREATE_RECONCILE_FAILURE_ATTEMPTS = 10;
+const WORKFLOW_CREATE_RECONCILE_DELAY_MS = 100;
+
+type ReconciledWorkflowPrimitiveKind = 'rectangle' | 'text';
+
+function reconciledPrimitiveKind(
+  operation: WorkflowOperation,
+): ReconciledWorkflowPrimitiveKind | undefined {
+  if (operation.kind === 'addRectangle') return 'rectangle';
+  if (operation.kind === 'addText') return 'text';
+  return undefined;
+}
+
+async function pollWorkflowAddedPrimitiveIds(
+  ctx: ToolContext,
+  primitiveKind: ReconciledWorkflowPrimitiveKind,
+  beforeIds: ReadonlySet<string>,
+  attempts: number,
+): Promise<string[]> {
+  for (let attempt = 0; attempt < attempts; attempt += 1) {
+    const afterIds = await listPrimitiveIds(ctx.bridge, primitiveKind);
+    const added = afterIds.filter((primitiveId) => !beforeIds.has(primitiveId));
+    if (added.length > 0 || attempt === attempts - 1) return added;
+    await new Promise<void>((resolve) => setTimeout(resolve, WORKFLOW_CREATE_RECONCILE_DELAY_MS));
+  }
+  return [];
+}
+
+function requireUniqueWorkflowPrimitiveId(
+  primitiveKind: ReconciledWorkflowPrimitiveKind,
+  addedIds: string[],
+): string {
+  if (addedIds.length === 1) return addedIds[0] as string;
+  if (addedIds.length > 1) {
+    throw new Error(
+      `Workflow create reconciliation is ambiguous: ${addedIds.length} new ${primitiveKind} primitives`,
+    );
+  }
+  throw new Error(`Workflow create did not expose a unique new ${primitiveKind} primitive`);
+}
+
 /** Apply one operation, resolving `$ref:` placeholders against already-applied refs. */
 async function applySingleOperation(
   ctx: ToolContext,
   op: WorkflowOperation,
   refToPrimitiveId: Map<string, string>,
 ): Promise<{ outcome: OperationOutcome; newPrimitiveId?: string }> {
+  const expectedKind = reconciledPrimitiveKind(op);
+  let beforeIds: ReadonlySet<string> | undefined;
   try {
+    if (expectedKind) beforeIds = new Set(await listPrimitiveIds(ctx.bridge, expectedKind));
     const params = resolveOperationParams(op.params, refToPrimitiveId);
     const result = await ctx.bridge.call<Record<string, unknown>, unknown>(op.method, params);
-    const primitiveId = extractResultPrimitiveId(result);
+    const primitiveId = expectedKind
+      ? requireUniqueWorkflowPrimitiveId(
+          expectedKind,
+          await pollWorkflowAddedPrimitiveIds(
+            ctx,
+            expectedKind,
+            beforeIds ?? new Set<string>(),
+            WORKFLOW_CREATE_RECONCILE_ATTEMPTS,
+          ),
+        )
+      : extractResultPrimitiveId(result);
 
     if (op.kind === 'placeComponent' && primitiveId) {
       refToPrimitiveId.set(op.ref, primitiveId);
     }
     const createsNewPrimitive =
-      (op.kind === 'placeComponent' || op.kind === 'createNetPort' || op.kind === 'addWire') &&
+      (op.kind === 'placeComponent' ||
+        op.kind === 'createNetPort' ||
+        op.kind === 'addWire' ||
+        op.kind === 'addRectangle' ||
+        op.kind === 'addText') &&
       Boolean(primitiveId);
 
     return {
@@ -221,13 +282,30 @@ async function applySingleOperation(
       newPrimitiveId: createsNewPrimitive ? primitiveId : undefined,
     };
   } catch (err) {
+    let reconciledPrimitiveId: string | undefined;
+    if (expectedKind && beforeIds) {
+      try {
+        const added = await pollWorkflowAddedPrimitiveIds(
+          ctx,
+          expectedKind,
+          beforeIds,
+          WORKFLOW_CREATE_RECONCILE_FAILURE_ATTEMPTS,
+        );
+        if (added.length === 1) reconciledPrimitiveId = added[0];
+      } catch {
+        // Preserve the original operation failure. Without one unambiguous expected-kind
+        // inventory delta there is no primitive that can be deleted safely.
+      }
+    }
     return {
       outcome: {
         method: op.method,
         ref: operationRef(op),
         success: false,
+        primitiveId: reconciledPrimitiveId,
         error: err instanceof Error ? err.message : String(err),
       },
+      newPrimitiveId: reconciledPrimitiveId,
     };
   }
 }
@@ -514,6 +592,13 @@ const rp2040ServoOutputSchema = workflowOutputSchema.extend({
         title: z.string(),
         origin: pointSchema,
         size: z.object({ width: z.number(), height: z.number() }),
+        frame: z.object({
+          x: z.number(),
+          y: z.number(),
+          width: z.number(),
+          height: z.number(),
+        }),
+        titlePosition: pointSchema,
         refs: z.array(z.string()),
       }),
     ),
@@ -527,6 +612,21 @@ const rp2040ServoOutputSchema = workflowOutputSchema.extend({
           count: z.number().int().nonnegative(),
         }),
       ),
+    }),
+    diagnostics: z.object({
+      mode: z.literal('placement-scaffold'),
+      electricalCompleteness: z.literal('intentionally-incomplete'),
+      sectionFrameCount: z.number().int().nonnegative(),
+      sectionTitleCount: z.number().int().nonnegative(),
+      detachedNetPortCount: z.number().int().nonnegative(),
+      wireCount: z.number().int().nonnegative(),
+      allExpectedRefsAssigned: z.boolean(),
+      duplicateBlockRefs: z.array(z.string()),
+      missingBlockRefs: z.array(z.string()),
+      blocksNonOverlapping: z.boolean(),
+      placementAnchorsInsideBlocks: z.boolean(),
+      drcExpectation: z.string(),
+      ercExpectation: z.string(),
     }),
     warnings: z.array(z.string()),
     notes: z.array(z.string()),
@@ -714,15 +814,15 @@ function registerWorkflowTools(
     name: 'easyeda_workflow_rp2040_servo_module',
     title: 'Plan or apply an RP2040 servo-module complex schematic scaffold',
     description:
-      'Create a deterministic functional-block scaffold for the RP2040 servo-module reference design. ' +
-      'This first milestone places BOM components by block and returns explicit missing-netlist warnings; ' +
-      'it does not infer exact pin-to-net wiring from screenshot+BOM alone (confirmWrite required).',
+      'Plan or apply an RP2040 servo-module scaffold: 56 BOM parts in seven visible rollback-backed ' +
+      'sections with deterministic titles and completeness diagnostics. Exact pin-to-net wiring stays ' +
+      'intentionally absent until later block netlists supply it (confirmWrite required).',
     profile: 'pro',
     evidence: ['inferred', 'runtime-probe'],
     risk: 'medium',
     confirmWrite: true,
     group: 'workflows',
-    version: '1.0.0',
+    version: '1.1.0',
     annotations: {
       readOnlyHint: false,
       destructiveHint: false,
@@ -781,6 +881,7 @@ function registerWorkflowTools(
         scaffold: {
           blocks: scaffold.blocks,
           bom: scaffold.bom,
+          diagnostics: scaffold.diagnostics,
           warnings: scaffold.warnings,
           notes: scaffold.notes,
         },

--- a/src/workflows/index.ts
+++ b/src/workflows/index.ts
@@ -14,5 +14,8 @@ export type {
   WorkflowPinConnection,
   WorkflowPlan,
   WorkflowPlannedComponent,
+  WorkflowRectangleInput,
   WorkflowSeverity,
+  WorkflowTextInput,
+  WorkflowWireInput,
 } from './types.js';

--- a/src/workflows/planner.ts
+++ b/src/workflows/planner.ts
@@ -23,6 +23,8 @@ import type {
   WorkflowIssue,
   WorkflowNetPortInput,
   WorkflowOperation,
+  WorkflowRectangleInput,
+  WorkflowTextInput,
   WorkflowWireInput,
   WorkflowPlan,
   WorkflowPlannedComponent,
@@ -52,16 +54,26 @@ function validateWorkflowInputs(
   components: WorkflowComponentInput[],
   existingComponents: WorkflowExistingComponentInput[],
   netPorts: WorkflowNetPortInput[],
+  wires: WorkflowWireInput[],
+  rectangles: WorkflowRectangleInput[],
+  texts: WorkflowTextInput[],
 ): WorkflowIssue[] {
   const issues: WorkflowIssue[] = [];
 
-  if (components.length === 0 && existingComponents.length === 0 && netPorts.length === 0) {
+  if (
+    components.length === 0 &&
+    existingComponents.length === 0 &&
+    netPorts.length === 0 &&
+    wires.length === 0 &&
+    rectangles.length === 0 &&
+    texts.length === 0
+  ) {
     issues.push(
       issue(
         'WORKFLOW_NO_COMPONENTS',
         'error',
-        'The workflow has no components, existing-component references, or net ports to act on.',
-        'Provide at least one component, existingComponent, or netPort.',
+        'The workflow has no components, wires, net ports, rectangles, or text to act on.',
+        'Provide at least one component, existingComponent, wire, netPort, rectangle, or text entry.',
       ),
     );
   }
@@ -136,6 +148,8 @@ function workflowPlanSummary(
   existingComponents: WorkflowExistingComponentInput[],
   netPorts: WorkflowNetPortInput[],
   wires: WorkflowWireInput[],
+  rectangles: WorkflowRectangleInput[],
+  texts: WorkflowTextInput[],
   operations: WorkflowOperation[],
 ): string {
   if (blocked) {
@@ -145,7 +159,8 @@ function workflowPlanSummary(
   const verb = mode === 'apply' ? 'Applying' : 'Planned';
   return (
     `${verb} ${components.length} new component(s), ${existingComponents.length} existing-component wiring, ` +
-    `${netPorts.length} net port(s), and ${wires.length} wire(s) across ${operations.length} operation(s).`
+    `${netPorts.length} net port(s), ${wires.length} wire(s), ${rectangles.length} rectangle(s), and ` +
+    `${texts.length} text label(s) across ${operations.length} operation(s).`
   );
 }
 
@@ -158,8 +173,17 @@ export function planWorkflowBlock(
   const existingComponents = input.existingComponents ?? [];
   const netPorts = input.netPorts ?? [];
   const wires = input.wires ?? [];
+  const rectangles = input.rectangles ?? [];
+  const texts = input.texts ?? [];
   const spacing = input.spacing ?? 10;
-  const issues = validateWorkflowInputs(components, existingComponents, netPorts);
+  const issues = validateWorkflowInputs(
+    components,
+    existingComponents,
+    netPorts,
+    wires,
+    rectangles,
+    texts,
+  );
   const blocked = issues.some((entry) => entry.severity === 'error');
 
   const placements: WorkflowPlannedComponent[] = components.map((component, index) => ({
@@ -266,8 +290,52 @@ export function planWorkflowBlock(
     });
   }
 
+  for (const rectangle of rectangles) {
+    operations.push({
+      kind: 'addRectangle',
+      ref: rectangle.ref,
+      role: rectangle.role,
+      method: 'schematic.addRectangle',
+      params: {
+        x: input.anchor.x + rectangle.placementOffset.dx,
+        y: input.anchor.y + rectangle.placementOffset.dy,
+        width: rectangle.width,
+        height: rectangle.height,
+        cornerRadius: rectangle.cornerRadius,
+        rotation: rectangle.rotation,
+        color: rectangle.color,
+        fillColor: rectangle.fillColor,
+        lineWidth: rectangle.lineWidth,
+        lineType: rectangle.lineType,
+        fillStyle: rectangle.fillStyle,
+      },
+    });
+  }
+
+  for (const text of texts) {
+    operations.push({
+      kind: 'addText',
+      ref: text.ref,
+      role: text.role,
+      method: 'schematic.addText',
+      params: {
+        x: input.anchor.x + text.placementOffset.dx,
+        y: input.anchor.y + text.placementOffset.dy,
+        content: text.content,
+        rotation: text.rotation,
+        color: text.color,
+        fontName: text.fontName,
+        fontSize: text.fontSize,
+        bold: text.bold,
+        italic: text.italic,
+        underline: text.underline,
+        alignMode: text.alignMode,
+      },
+    });
+  }
+
   const rollbackNotes = [
-    'Newly-created primitives (placed components, net ports, and wires created in this transaction) are deleted on rollback.',
+    'Newly-created primitives (placed components, net ports, wires, rectangles, and text created in this transaction) are deleted on rollback.',
   ];
   if (existingComponents.some((component) => component.pinConnections.length > 0)) {
     rollbackNotes.push(
@@ -285,6 +353,8 @@ export function planWorkflowBlock(
     existingComponents,
     netPorts,
     wires,
+    rectangles,
+    texts,
     operations,
   );
 

--- a/src/workflows/rp2040-servo-module-scaffold.ts
+++ b/src/workflows/rp2040-servo-module-scaffold.ts
@@ -1,5 +1,7 @@
 import {
   planSafeSchematicRegion,
+  rectsOverlap,
+  type SchematicRect,
   type SchematicRegionPreference,
 } from './schematic-safe-region.js';
 import type { WorkflowBlockInput, WorkflowDeviceItem } from './types.js';
@@ -16,8 +18,11 @@ export type ServoModuleBlockId =
 export interface ServoModuleBlockPlan {
   id: ServoModuleBlockId;
   title: string;
+  /** Top-left planning origin. The public rectangle frame below uses normalized bottom-left coordinates. */
   origin: { x: number; y: number };
   size: { width: number; height: number };
+  frame: SchematicRect;
+  titlePosition: { x: number; y: number };
   refs: string[];
 }
 
@@ -61,62 +66,97 @@ export interface Rp2040ServoModulePlan {
     referenceCount: number;
     symbolGroups: Array<{ symbol: string; refs: string[]; count: number }>;
   };
+  diagnostics: {
+    mode: 'placement-scaffold';
+    electricalCompleteness: 'intentionally-incomplete';
+    sectionFrameCount: number;
+    sectionTitleCount: number;
+    detachedNetPortCount: number;
+    wireCount: number;
+    allExpectedRefsAssigned: boolean;
+    duplicateBlockRefs: string[];
+    missingBlockRefs: string[];
+    blocksNonOverlapping: boolean;
+    placementAnchorsInsideBlocks: boolean;
+    drcExpectation: string;
+    ercExpectation: string;
+  };
   warnings: string[];
   notes: string[];
 }
 
+// Includes every visible frame/title and leaves a 30-unit guard below the connector block.
 const CONTENT = { width: 1260, height: 760 } as const;
+const SECTION_TITLE_RISE = 18;
 
 const BLOCK_DEFS: Array<
-  Omit<ServoModuleBlockPlan, 'origin'> & { offset: { dx: number; dy: number } }
+  Omit<ServoModuleBlockPlan, 'origin' | 'frame' | 'titlePosition'> & {
+    offset: { dx: number; dy: number };
+  }
 > = [
   {
     id: 'power_usb',
     title: 'power and usb',
-    offset: { dx: 0, dy: -40 },
-    size: { width: 390, height: 290 },
+    offset: { dx: 0, dy: -35 },
+    size: { width: 380, height: 220 },
     refs: ['P1', 'FH1', 'D1', 'U2', 'C5', 'C7', 'C9', 'C10', 'R1', 'R2', 'R3', 'R4'],
   },
   {
     id: 'rp2040_core',
     title: 'rp2040 and reqs',
-    offset: { dx: 440, dy: -40 },
-    size: { width: 500, height: 460 },
+    offset: { dx: 410, dy: -35 },
+    size: { width: 490, height: 340 },
     refs: ['U3', 'U1', 'X1', 'SW1', 'SW2', 'R5', 'R6', 'R7', 'R8', 'R9', 'C1', 'C2', 'C3', 'C4'],
   },
   {
     id: 'decoupling',
     title: 'decoupling and rails',
-    offset: { dx: 955, dy: -40 },
-    size: { width: 305, height: 270 },
-    refs: ['C6', 'C8', 'C11', 'C12', 'C13', 'C14', 'C15', 'C16', 'C19', 'C20', 'C21', 'C22'],
+    offset: { dx: 930, dy: -20 },
+    size: { width: 330, height: 240 },
+    refs: [
+      'C6',
+      'C8',
+      'C11',
+      'C12',
+      'C13',
+      'C14',
+      'C15',
+      'C16',
+      'C19',
+      'C20',
+      'C21',
+      'C22',
+      'R13',
+      'R14',
+      'R15',
+    ],
   },
   {
     id: 'motor_driver',
     title: 'motor driver',
-    offset: { dx: 0, dy: -385 },
-    size: { width: 390, height: 210 },
+    offset: { dx: 0, dy: -310 },
+    size: { width: 380, height: 180 },
     refs: ['U4', 'R10', 'R11', 'R12', 'C17', 'C18'],
   },
   {
     id: 'level_shifter',
     title: 'level shifter',
-    offset: { dx: 520, dy: -535 },
-    size: { width: 210, height: 160 },
+    offset: { dx: 930, dy: -310 },
+    size: { width: 330, height: 150 },
     refs: ['U5'],
   },
   {
     id: 'leds',
     title: 'LEDs',
-    offset: { dx: 440, dy: -625 },
-    size: { width: 430, height: 135 },
+    offset: { dx: 410, dy: -430 },
+    size: { width: 490, height: 130 },
     refs: ['LED1', 'LED2', 'LED3', 'LED4'],
   },
   {
     id: 'connectors',
     title: 'connectors',
-    offset: { dx: 0, dy: -720 },
-    size: { width: 900, height: 160 },
+    offset: { dx: 0, dy: -600 },
+    size: { width: 900, height: 130 },
     refs: ['J1', 'J2', 'J3', 'J4'],
   },
 ];
@@ -208,67 +248,67 @@ function devFor(ref: string, devices: Rp2040ServoModuleDevices): WorkflowDeviceI
 }
 
 const REF_OFFSETS: Record<string, { dx: number; dy: number; rotation?: number }> = {
-  P1: { dx: 90, dy: -170 },
-  FH1: { dx: 45, dy: -260 },
-  D1: { dx: 235, dy: -110 },
-  U2: { dx: 270, dy: -125 },
+  P1: { dx: 90, dy: -140 },
+  FH1: { dx: 45, dy: -220 },
+  D1: { dx: 235, dy: -100 },
+  U2: { dx: 270, dy: -110 },
   R1: { dx: 40, dy: -60, rotation: 180 },
   R2: { dx: 45, dy: -105, rotation: 180 },
   R3: { dx: 160, dy: -60, rotation: 180 },
   R4: { dx: 160, dy: -105, rotation: 180 },
   C5: { dx: 315, dy: -70 },
-  C7: { dx: 170, dy: -200 },
-  C9: { dx: 270, dy: -185 },
-  C10: { dx: 340, dy: -185 },
+  C7: { dx: 170, dy: -170 },
+  C9: { dx: 270, dy: -165 },
+  C10: { dx: 340, dy: -165 },
 
-  U3: { dx: 720, dy: -220 },
-  U1: { dx: 565, dy: -170 },
-  X1: { dx: 565, dy: -330 },
-  SW1: { dx: 610, dy: -250 },
-  SW2: { dx: 800, dy: -85 },
-  R5: { dx: 540, dy: -250, rotation: 270 },
-  R6: { dx: 505, dy: -85, rotation: 180 },
-  R7: { dx: 630, dy: -335 },
-  R8: { dx: 640, dy: -150, rotation: 180 },
-  R9: { dx: 675, dy: -150, rotation: 180 },
-  C1: { dx: 455, dy: -270 },
-  C2: { dx: 540, dy: -390 },
-  C3: { dx: 490, dy: -275 },
-  C4: { dx: 645, dy: -390 },
+  U3: { dx: 690, dy: -190 },
+  U1: { dx: 535, dy: -140 },
+  X1: { dx: 535, dy: -290 },
+  SW1: { dx: 580, dy: -215 },
+  SW2: { dx: 770, dy: -80 },
+  R5: { dx: 510, dy: -220, rotation: 270 },
+  R6: { dx: 475, dy: -80, rotation: 180 },
+  R7: { dx: 600, dy: -295 },
+  R8: { dx: 610, dy: -125, rotation: 180 },
+  R9: { dx: 645, dy: -125, rotation: 180 },
+  C1: { dx: 425, dy: -235 },
+  C2: { dx: 510, dy: -335 },
+  C3: { dx: 460, dy: -240 },
+  C4: { dx: 615, dy: -335 },
 
-  C6: { dx: 980, dy: -115 },
-  C8: { dx: 1110, dy: -225 },
-  C11: { dx: 965, dy: -35 },
-  C12: { dx: 990, dy: -185 },
-  C13: { dx: 1030, dy: -185 },
-  C14: { dx: 1070, dy: -205 },
-  C15: { dx: 1060, dy: -35 },
-  C16: { dx: 1055, dy: -80 },
-  C19: { dx: 1145, dy: -35 },
-  C20: { dx: 1155, dy: -120 },
-  C21: { dx: 1195, dy: -165 },
-  C22: { dx: 1235, dy: -35 },
-  R13: { dx: 1125, dy: -145 },
-  R14: { dx: 960, dy: -145 },
-  R15: { dx: 960, dy: -185 },
+  C6: { dx: 955, dy: -110 },
+  C8: { dx: 1085, dy: -220 },
+  C11: { dx: 950, dy: -65 },
+  C12: { dx: 965, dy: -180 },
+  C13: { dx: 1005, dy: -180 },
+  C14: { dx: 1045, dy: -200 },
+  C15: { dx: 1035, dy: -65 },
+  C16: { dx: 1030, dy: -100 },
+  C19: { dx: 1120, dy: -65 },
+  C20: { dx: 1130, dy: -115 },
+  C21: { dx: 1170, dy: -160 },
+  C22: { dx: 1225, dy: -65 },
+  R13: { dx: 1100, dy: -140 },
+  R14: { dx: 940, dy: -140 },
+  R15: { dx: 940, dy: -180 },
 
-  U4: { dx: 220, dy: -485 },
-  R10: { dx: 155, dy: -485, rotation: 90 },
-  R11: { dx: 255, dy: -485, rotation: 90 },
-  R12: { dx: 45, dy: -505 },
-  C17: { dx: 45, dy: -545 },
-  C18: { dx: 110, dy: -545 },
+  U4: { dx: 220, dy: -390 },
+  R10: { dx: 155, dy: -390, rotation: 90 },
+  R11: { dx: 255, dy: -390, rotation: 90 },
+  R12: { dx: 45, dy: -430 },
+  C17: { dx: 45, dy: -465 },
+  C18: { dx: 110, dy: -465 },
 
-  U5: { dx: 590, dy: -545 },
-  LED1: { dx: 450, dy: -675 },
-  LED2: { dx: 550, dy: -675 },
-  LED3: { dx: 650, dy: -675 },
-  LED4: { dx: 750, dy: -675 },
+  U5: { dx: 1080, dy: -390 },
+  LED1: { dx: 450, dy: -500 },
+  LED2: { dx: 560, dy: -500 },
+  LED3: { dx: 670, dy: -500 },
+  LED4: { dx: 780, dy: -500 },
 
-  J1: { dx: 95, dy: -790 },
-  J2: { dx: 340, dy: -790 },
-  J3: { dx: 540, dy: -815 },
-  J4: { dx: 700, dy: -790 },
+  J1: { dx: 95, dy: -665 },
+  J2: { dx: 340, dy: -665 },
+  J3: { dx: 540, dy: -690 },
+  J4: { dx: 700, dy: -665 },
 };
 
 function expectedRefs(): string[] {
@@ -278,25 +318,134 @@ function expectedRefs(): string[] {
 }
 
 function buildBlocks(anchor: { x: number; y: number }): ServoModuleBlockPlan[] {
-  return BLOCK_DEFS.map((block) => ({
-    id: block.id,
-    title: block.title,
-    size: block.size,
-    refs: block.refs,
-    origin: { x: anchor.x + block.offset.dx, y: anchor.y + block.offset.dy },
-  }));
+  return BLOCK_DEFS.map((block) => {
+    const origin = { x: anchor.x + block.offset.dx, y: anchor.y + block.offset.dy };
+    return {
+      id: block.id,
+      title: block.title,
+      size: block.size,
+      refs: block.refs,
+      origin,
+      frame: {
+        x: origin.x,
+        y: origin.y - block.size.height,
+        width: block.size.width,
+        height: block.size.height,
+      },
+      titlePosition: { x: origin.x + 12, y: origin.y + SECTION_TITLE_RISE },
+    };
+  });
+}
+
+function actualSafeRegionForAnchor(
+  base: ReturnType<typeof planSafeSchematicRegion>,
+  explicitAnchor: { x: number; y: number } | undefined,
+): ReturnType<typeof planSafeSchematicRegion> {
+  if (!explicitAnchor) return base;
+  const bounds: SchematicRect = {
+    x: explicitAnchor.x,
+    y: explicitAnchor.y - CONTENT.height,
+    width: CONTENT.width,
+    height: CONTENT.height,
+  };
+  const issues = base.issues.filter((entry) =>
+    ['INVALID_CONTENT_SIZE', 'CONTENT_DOES_NOT_FIT_USABLE_BOUNDS'].includes(entry.code),
+  );
+  if (
+    bounds.x < base.usableBounds.x ||
+    bounds.y < base.usableBounds.y ||
+    bounds.x + bounds.width > base.usableBounds.x + base.usableBounds.width ||
+    bounds.y + bounds.height > base.usableBounds.y + base.usableBounds.height
+  ) {
+    issues.push({
+      code: 'EXPLICIT_ANCHOR_OUTSIDE_USABLE_BOUNDS',
+      message: 'The explicit top-left anchor places part of the scaffold outside usable bounds.',
+    });
+  }
+  if (base.keepouts.some((keepout) => rectsOverlap(bounds, keepout))) {
+    issues.push({
+      code: 'EXPLICIT_ANCHOR_OVERLAPS_TITLE_BLOCK',
+      message: 'The explicit top-left anchor places the scaffold over the title-block keep-out.',
+    });
+  }
+  return {
+    ...base,
+    blocked: issues.length > 0,
+    requestedBounds: bounds,
+    bounds,
+    anchor: explicitAnchor,
+    warnings: [],
+    issues,
+  };
+}
+
+function duplicated(values: string[]): string[] {
+  const seen = new Set<string>();
+  const duplicates = new Set<string>();
+  for (const value of values) {
+    if (seen.has(value)) duplicates.add(value);
+    seen.add(value);
+  }
+  return [...duplicates].sort((a, b) => a.localeCompare(b, 'en'));
+}
+
+function buildDiagnostics(
+  refs: string[],
+  blocks: ServoModuleBlockPlan[],
+  anchor: { x: number; y: number },
+): Rp2040ServoModulePlan['diagnostics'] {
+  const assignedRefs = blocks.flatMap((block) => block.refs);
+  const assigned = new Set(assignedRefs);
+  const blockForRef = new Map(blocks.flatMap((block) => block.refs.map((ref) => [ref, block])));
+  const framesOverlap = blocks.some((block, index) =>
+    blocks.slice(index + 1).some((other) => rectsOverlap(block.frame, other.frame)),
+  );
+  const placementAnchorsInsideBlocks = refs.every((ref) => {
+    const block = blockForRef.get(ref);
+    const offset = REF_OFFSETS[ref];
+    if (!block || !offset) return false;
+    const x = anchor.x + offset.dx;
+    const y = anchor.y + offset.dy;
+    return (
+      x >= block.frame.x &&
+      x <= block.frame.x + block.frame.width &&
+      y >= block.frame.y &&
+      y <= block.frame.y + block.frame.height
+    );
+  });
+
+  return {
+    mode: 'placement-scaffold',
+    electricalCompleteness: 'intentionally-incomplete',
+    sectionFrameCount: blocks.length,
+    sectionTitleCount: blocks.length,
+    detachedNetPortCount: 0,
+    wireCount: 0,
+    allExpectedRefsAssigned: refs.every((ref) => assigned.has(ref)),
+    duplicateBlockRefs: duplicated(assignedRefs),
+    missingBlockRefs: refs.filter((ref) => !assigned.has(ref)),
+    blocksNonOverlapping: !framesOverlap,
+    placementAnchorsInsideBlocks,
+    drcExpectation:
+      'No wires, net ports, or net labels are created in placement-scaffold mode; section frames and titles are cosmetic.',
+    ercExpectation:
+      'Incomplete by design: components are intentionally unconnected until block-level netlists are supplied.',
+  };
 }
 
 export function buildRp2040ServoModuleScaffold(
   input: Rp2040ServoModuleInput,
 ): Rp2040ServoModulePlan {
-  const safeRegion = planSafeSchematicRegion({
-    sheetInfo: input.sheetInfo,
-    contentWidth: CONTENT.width,
-    contentHeight: CONTENT.height,
-    preferredRegion: input.preferredRegion ?? 'upper-left',
-    margin: input.margin,
-  });
+  const safeRegion = actualSafeRegionForAnchor(
+    planSafeSchematicRegion({
+      sheetInfo: input.sheetInfo,
+      contentWidth: CONTENT.width,
+      contentHeight: CONTENT.height,
+      preferredRegion: input.preferredRegion ?? 'upper-left',
+      margin: input.margin,
+    }),
+    input.anchor,
+  );
   const anchor = input.anchor ?? safeRegion.anchor;
   const refs = expectedRefs();
   const components = refs.map((ref) => {
@@ -311,6 +460,7 @@ export function buildRp2040ServoModuleScaffold(
     };
   });
 
+  const blocks = buildBlocks(anchor);
   const workflowInput: WorkflowBlockInput = {
     projectId: input.projectId,
     mode: input.mode ?? 'preview',
@@ -319,12 +469,44 @@ export function buildRp2040ServoModuleScaffold(
     components,
     netPorts: [],
     wires: [],
+    rectangles: blocks.map((block) => ({
+      ref: `section:${block.id}:frame`,
+      role: `servo-module-section:${block.id}`,
+      placementOffset: { dx: block.frame.x - anchor.x, dy: block.frame.y - anchor.y },
+      width: block.frame.width,
+      height: block.frame.height,
+      cornerRadius: 0,
+      rotation: 0,
+      color: '#6B7280',
+      fillColor: 'none',
+      lineWidth: 1,
+      lineType: 0,
+      fillStyle: 'none',
+    })),
+    texts: blocks.map((block) => ({
+      ref: `section:${block.id}:title`,
+      role: `servo-module-section-title:${block.id}`,
+      placementOffset: {
+        dx: block.titlePosition.x - anchor.x,
+        dy: block.titlePosition.y - anchor.y,
+      },
+      content: block.title.toUpperCase(),
+      rotation: 0,
+      color: '#111827',
+      fontName: 'Arial',
+      fontSize: 16,
+      bold: true,
+      italic: false,
+      underline: false,
+      alignMode: 1,
+    })),
   };
+  const diagnostics = buildDiagnostics(refs, blocks, anchor);
 
   return {
     workflowInput,
     safeRegion,
-    blocks: buildBlocks(anchor),
+    blocks,
     bom: {
       expectedRefs: refs,
       referenceCount: refs.length,
@@ -334,6 +516,7 @@ export function buildRp2040ServoModuleScaffold(
         count: group.refs.length,
       })),
     },
+    diagnostics,
     warnings: [
       'This scaffold intentionally places BOM blocks only; exact pin-to-net wiring is not inferred from screenshot+BOM.',
       'Use follow-up block workflows for power/USB, RP2040 core, motor driver, LEDs, connectors, and level shifter netlists.',
@@ -341,6 +524,7 @@ export function buildRp2040ServoModuleScaffold(
     ],
     notes: [
       'Functional blocks mirror the user-provided servo-module reference: power and usb, rp2040 and reqs, motor driver, LEDs, connectors, decoupling, and level shifter.',
+      'Each functional block now has a visible rollback-backed rectangle and title in preview/apply operations.',
       'Detached netports are disabled by default; future netlist milestones should add visible wiring per block.',
     ],
   };

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -69,6 +69,38 @@ export interface WorkflowWireInput {
   lineWidth?: number;
 }
 
+export interface WorkflowRectangleInput {
+  ref?: string;
+  role: string;
+  /** Bottom-left offset from the workflow anchor in normalized schematic coordinates. */
+  placementOffset: { dx: number; dy: number };
+  width: number;
+  height: number;
+  cornerRadius?: number;
+  rotation?: number;
+  color?: string;
+  fillColor?: string;
+  lineWidth?: number;
+  lineType?: number;
+  fillStyle?: string;
+}
+
+export interface WorkflowTextInput {
+  ref?: string;
+  role: string;
+  /** Text-anchor offset from the workflow anchor in normalized schematic coordinates. */
+  placementOffset: { dx: number; dy: number };
+  content: string;
+  rotation?: number;
+  color?: string;
+  fontName?: string;
+  fontSize?: number;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  alignMode?: number;
+}
+
 export interface WorkflowBlockInput {
   projectId: string;
   mode?: WorkflowExecutionMode;
@@ -81,6 +113,8 @@ export interface WorkflowBlockInput {
   netPorts?: WorkflowNetPortInput[];
   netPortAnchor?: { x: number; y: number };
   wires?: WorkflowWireInput[];
+  rectangles?: WorkflowRectangleInput[];
+  texts?: WorkflowTextInput[];
 }
 
 export type WorkflowOperation =
@@ -110,6 +144,20 @@ export type WorkflowOperation =
       role: string;
       netName?: string;
       method: 'schematic.addWire';
+      params: Record<string, unknown>;
+    }
+  | {
+      kind: 'addRectangle';
+      ref?: string;
+      role: string;
+      method: 'schematic.addRectangle';
+      params: Record<string, unknown>;
+    }
+  | {
+      kind: 'addText';
+      ref?: string;
+      role: string;
+      method: 'schematic.addText';
       params: Record<string, unknown>;
     };
 

--- a/tests/unit/tools/workflows.test.ts
+++ b/tests/unit/tools/workflows.test.ts
@@ -165,7 +165,7 @@ describe('Workflow Tools', () => {
       diode: deviceItem,
     };
 
-    it('previews the RP2040 servo-module scaffold without writing to EasyEDA', async () => {
+    it('previews visible RP2040 functional sections without writing to EasyEDA', async () => {
       bridgeCall.mockResolvedValueOnce({ currentPage: { width: 1682, height: 1189 } });
       const tool = registry.get('easyeda_workflow_rp2040_servo_module');
       const result = (await tool?.handler(context, {
@@ -177,17 +177,165 @@ describe('Workflow Tools', () => {
       expect(result.applied).toBe(false);
       expect(result.blocked).toBe(false);
       expect(result.placements).toHaveLength(56);
-      expect(result.operations).toHaveLength(56);
-      expect(result.operations.every((op: any) => op.kind === 'placeComponent')).toBe(true);
+      expect(result.operations).toHaveLength(70);
+      expect(result.operations.filter((op: any) => op.kind === 'placeComponent')).toHaveLength(56);
+      expect(result.operations.filter((op: any) => op.kind === 'addRectangle')).toHaveLength(7);
+      expect(result.operations.filter((op: any) => op.kind === 'addText')).toHaveLength(7);
+      expect(result.operations.filter((op: any) => op.kind === 'createNetPort')).toHaveLength(0);
+      expect(result.operations.filter((op: any) => op.kind === 'addWire')).toHaveLength(0);
       expect(result.scaffold.bom.referenceCount).toBe(56);
       expect(result.scaffold.blocks).toHaveLength(7);
+      expect(result.scaffold.diagnostics).toMatchObject({
+        sectionFrameCount: 7,
+        sectionTitleCount: 7,
+        allExpectedRefsAssigned: true,
+        blocksNonOverlapping: true,
+        placementAnchorsInsideBlocks: true,
+        detachedNetPortCount: 0,
+        wireCount: 0,
+      });
       expect(result.scaffold.warnings.join('\n')).toContain(
         'exact pin-to-net wiring is not inferred',
       );
       expect(
         result.issues.some((issue: any) => issue.code === 'WORKFLOW_EMPTY_PIN_CONNECTIONS'),
       ).toBe(true);
+      expect(bridgeCall).toHaveBeenCalledTimes(1);
       expect(bridgeCall).toHaveBeenCalledWith('schematic.getSheetInfo', { projectId: 'servo' });
+    });
+
+    it('applies all component, frame, and title operations in one rollback-backed workflow', async () => {
+      let componentId = 0;
+      let rectangleId = 0;
+      let textId = 0;
+      const rectangleIds: string[] = [];
+      const textIds: string[] = [];
+      bridgeCall.mockImplementation(async (method: string, params: any) => {
+        if (method === 'schematic.getSheetInfo') {
+          return { currentPage: { width: 1682, height: 1189 } };
+        }
+        if (method === 'schematic.placeComponent') {
+          componentId += 1;
+          return { primitiveId: `component-${componentId}` };
+        }
+        if (method === 'schematic.listPrimitiveIds') {
+          return {
+            primitiveIds: params.primitiveKind === 'rectangle' ? rectangleIds : textIds,
+          };
+        }
+        if (method === 'schematic.addRectangle') {
+          rectangleId += 1;
+          rectangleIds.push(`rectangle-${rectangleId}`);
+          return { primitiveId: 'misleading-existing-text-id' };
+        }
+        if (method === 'schematic.addText') {
+          textId += 1;
+          textIds.push(`text-${textId}`);
+          return { primitiveId: 'misleading-existing-rectangle-id' };
+        }
+        return { result: [] };
+      });
+
+      const tool = registry.get('easyeda_workflow_rp2040_servo_module');
+      const result = (await tool?.handler(context, {
+        projectId: 'servo',
+        mode: 'apply',
+        confirmWrite: true,
+        devices: servoDevices,
+      })) as any;
+
+      expect(result.success).toBe(true);
+      expect(result.applied).toBe(true);
+      expect(result.apply_results).toHaveLength(70);
+      expect(
+        bridgeCall.mock.calls.filter(([method]) => method === 'schematic.placeComponent'),
+      ).toHaveLength(56);
+      expect(
+        bridgeCall.mock.calls.filter(([method]) => method === 'schematic.addRectangle'),
+      ).toHaveLength(7);
+      expect(
+        bridgeCall.mock.calls.filter(([method]) => method === 'schematic.addText'),
+      ).toHaveLength(7);
+      expect(
+        result.apply_results.filter((entry: any) => entry.method === 'schematic.addRectangle'),
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ primitiveId: 'rectangle-1' }),
+          expect.objectContaining({ primitiveId: 'rectangle-7' }),
+        ]),
+      );
+      expect(
+        result.apply_results.filter((entry: any) => entry.method === 'schematic.addText'),
+      ).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ primitiveId: 'text-1' }),
+          expect.objectContaining({ primitiveId: 'text-7' }),
+        ]),
+      );
+      expect(bridgeCall).not.toHaveBeenCalledWith('schematic.createNetPort', expect.anything());
+      expect(bridgeCall).not.toHaveBeenCalledWith('schematic.addWire', expect.anything());
+    });
+
+    it('rolls back section frames and placed components when a title write fails', async () => {
+      let componentId = 0;
+      let rectangleId = 0;
+      let textCalls = 0;
+      const rectangleIds: string[] = [];
+      const textIds: string[] = [];
+      let rolledBackIds: string[] = [];
+      bridgeCall.mockImplementation(async (method: string, params: any) => {
+        if (method === 'schematic.getSheetInfo') {
+          return { currentPage: { width: 1682, height: 1189 } };
+        }
+        if (method === 'schematic.placeComponent') {
+          componentId += 1;
+          return { primitiveId: `component-${componentId}` };
+        }
+        if (method === 'schematic.listPrimitiveIds') {
+          return {
+            primitiveIds: params.primitiveKind === 'rectangle' ? rectangleIds : textIds,
+          };
+        }
+        if (method === 'schematic.addRectangle') {
+          rectangleId += 1;
+          rectangleIds.push(`rectangle-${rectangleId}`);
+          return { primitiveId: 'misleading-existing-text-id' };
+        }
+        if (method === 'schematic.addText') {
+          textCalls += 1;
+          textIds.push(`text-${textCalls}`);
+          if (textCalls === 2) throw new Error('forced title failure after create');
+          return { primitiveId: 'misleading-existing-rectangle-id' };
+        }
+        if (method === 'schematic.deletePrimitive') {
+          rolledBackIds = params.primitiveIds;
+          return { success: true };
+        }
+        return { result: [] };
+      });
+
+      const tool = registry.get('easyeda_workflow_rp2040_servo_module');
+      const result = (await tool?.handler(context, {
+        projectId: 'servo',
+        mode: 'apply',
+        confirmWrite: true,
+        devices: servoDevices,
+      })) as any;
+
+      expect(result.success).toBe(false);
+      expect(result.applied).toBe(false);
+      expect(result.rolled_back).toBe(true);
+      expect(rolledBackIds).toHaveLength(65);
+      expect(rolledBackIds).toEqual(
+        expect.arrayContaining([
+          'component-1',
+          'component-56',
+          'rectangle-1',
+          'rectangle-7',
+          'text-1',
+          'text-2',
+        ]),
+      );
     });
   });
 

--- a/tests/unit/workflows/planner.test.ts
+++ b/tests/unit/workflows/planner.test.ts
@@ -98,6 +98,43 @@ describe('planWorkflowBlock', () => {
     expect(connectOp?.params.primitiveId).toBe('real-primitive-id');
   });
 
+  it('plans cosmetic-only rectangle and text operations with anchor-relative coordinates', () => {
+    const plan = planWorkflowBlock(
+      baseInput({
+        components: [],
+        rectangles: [
+          {
+            ref: 'section:frame',
+            role: 'section-frame',
+            placementOffset: { dx: 10, dy: -50 },
+            width: 120,
+            height: 80,
+            fillColor: 'none',
+          },
+        ],
+        texts: [
+          {
+            ref: 'section:title',
+            role: 'section-title',
+            placementOffset: { dx: 15, dy: 10 },
+            content: 'POWER',
+            fontSize: 16,
+            bold: true,
+          },
+        ],
+      }),
+      'wf_cosmetic',
+    );
+
+    expect(plan.blocked).toBe(false);
+    expect(plan.operations.map((operation) => operation.kind)).toEqual(['addRectangle', 'addText']);
+    expect(plan.operations[0]?.params).toMatchObject({ x: 110, y: 50, width: 120, height: 80 });
+    expect(plan.operations[1]?.params).toMatchObject({ x: 115, y: 110, content: 'POWER' });
+    expect(plan.summary).toContain('1 rectangle(s)');
+    expect(plan.summary).toContain('1 text label(s)');
+    expect(plan.rollbackNotes[0]).toContain('rectangles');
+  });
+
   it('flags an empty workflow as blocked with WORKFLOW_NO_COMPONENTS', () => {
     const plan = planWorkflowBlock(baseInput({ components: [] }), 'wf_test');
     expect(plan.blocked).toBe(true);

--- a/tests/unit/workflows/rp2040-servo-module-scaffold.test.ts
+++ b/tests/unit/workflows/rp2040-servo-module-scaffold.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { buildRp2040ServoModuleScaffold } from '../../../src/workflows/rp2040-servo-module-scaffold.js';
+import { rectsOverlap } from '../../../src/workflows/schematic-safe-region.js';
 
 const deviceItem = { libraryUuid: 'lib', uuid: 'dev' };
 const devices = {
@@ -23,12 +24,14 @@ const devices = {
   diode: deviceItem,
 };
 
+const a3Sheet = { currentPage: { width: 1682, height: 1189 } };
+
 describe('RP2040 servo-module scaffold', () => {
-  it('builds the expected BOM scaffold without netlist wiring', () => {
+  it('builds seven visible, non-overlapping sections without inventing a netlist', () => {
     const result = buildRp2040ServoModuleScaffold({
       projectId: 'servo',
       devices,
-      sheetInfo: { currentPage: { width: 1682, height: 1189 } },
+      sheetInfo: a3Sheet,
     });
 
     expect(result.safeRegion.blocked).toBe(false);
@@ -43,32 +46,90 @@ describe('RP2040 servo-module scaffold', () => {
     ]);
     expect(result.bom.referenceCount).toBe(56);
     expect(result.workflowInput.components).toHaveLength(56);
+    expect(result.workflowInput.rectangles).toHaveLength(7);
+    expect(result.workflowInput.texts).toHaveLength(7);
     expect(result.workflowInput.netPorts).toEqual([]);
     expect(result.workflowInput.wires).toEqual([]);
+    expect(result.diagnostics).toMatchObject({
+      mode: 'placement-scaffold',
+      electricalCompleteness: 'intentionally-incomplete',
+      sectionFrameCount: 7,
+      sectionTitleCount: 7,
+      detachedNetPortCount: 0,
+      wireCount: 0,
+      allExpectedRefsAssigned: true,
+      duplicateBlockRefs: [],
+      missingBlockRefs: [],
+      blocksNonOverlapping: true,
+      placementAnchorsInsideBlocks: true,
+    });
     expect(result.warnings.join('\n')).toContain('exact pin-to-net wiring is not inferred');
+
+    const assignedRefs = result.blocks.flatMap((block) => block.refs).sort();
+    expect(assignedRefs).toEqual([...result.bom.expectedRefs].sort());
+    result.blocks.forEach((block, index) => {
+      expect(block.frame.x).toBeGreaterThanOrEqual(result.safeRegion.bounds.x);
+      expect(block.frame.y).toBeGreaterThanOrEqual(result.safeRegion.bounds.y);
+      expect(block.frame.x + block.frame.width).toBeLessThanOrEqual(
+        result.safeRegion.bounds.x + result.safeRegion.bounds.width,
+      );
+      expect(block.frame.y + block.frame.height).toBeLessThanOrEqual(
+        result.safeRegion.bounds.y + result.safeRegion.bounds.height,
+      );
+      expect(block.titlePosition.x).toBeGreaterThanOrEqual(result.safeRegion.bounds.x);
+      expect(block.titlePosition.y).toBeLessThanOrEqual(
+        result.safeRegion.bounds.y + result.safeRegion.bounds.height,
+      );
+      for (const other of result.blocks.slice(index + 1)) {
+        expect(rectsOverlap(block.frame, other.frame)).toBe(false);
+      }
+    });
   });
 
-  it('places major components in deterministic functional blocks', () => {
+  it('places major components deterministically inside their functional sections', () => {
     const result = buildRp2040ServoModuleScaffold({
       projectId: 'servo',
       devices,
-      anchor: { x: 100, y: 900 },
+      sheetInfo: a3Sheet,
+      anchor: { x: 100, y: 1080 },
     });
     const byRef = new Map(
       result.workflowInput.components?.map((component) => [component.ref, component]),
     );
 
-    expect(byRef.get('P1')?.placementOffset).toEqual({ dx: 90, dy: -170 });
-    expect(byRef.get('U3')?.placementOffset).toEqual({ dx: 720, dy: -220 });
-    expect(byRef.get('U4')?.placementOffset).toEqual({ dx: 220, dy: -485 });
-    expect(byRef.get('LED4')?.placementOffset).toEqual({ dx: 750, dy: -675 });
-    expect(byRef.get('J4')?.placementOffset).toEqual({ dx: 700, dy: -790 });
+    expect(result.safeRegion.blocked).toBe(false);
+    expect(byRef.get('P1')?.placementOffset).toEqual({ dx: 90, dy: -140 });
+    expect(byRef.get('U3')?.placementOffset).toEqual({ dx: 690, dy: -190 });
+    expect(byRef.get('U4')?.placementOffset).toEqual({ dx: 220, dy: -390 });
+    expect(byRef.get('LED4')?.placementOffset).toEqual({ dx: 780, dy: -500 });
+    expect(byRef.get('J4')?.placementOffset).toEqual({ dx: 700, dy: -665 });
 
     expect(result.blocks.find((block) => block.id === 'power_usb')).toMatchObject({
       title: 'power and usb',
-      origin: { x: 100, y: 860 },
+      origin: { x: 100, y: 1045 },
+      frame: { x: 100, y: 825, width: 380, height: 220 },
     });
     expect(result.blocks.find((block) => block.id === 'rp2040_core')?.refs).toContain('U3');
+    expect(result.blocks.find((block) => block.id === 'decoupling')?.refs).toEqual(
+      expect.arrayContaining(['R13', 'R14', 'R15']),
+    );
+  });
+
+  it('blocks an explicit anchor that would leave usable bounds or overlap the title block', () => {
+    const result = buildRp2040ServoModuleScaffold({
+      projectId: 'servo',
+      devices,
+      sheetInfo: a3Sheet,
+      anchor: { x: 900, y: 760 },
+    });
+
+    expect(result.safeRegion.blocked).toBe(true);
+    expect(result.safeRegion.issues.map((issue) => issue.code)).toEqual(
+      expect.arrayContaining([
+        'EXPLICIT_ANCHOR_OUTSIDE_USABLE_BOUNDS',
+        'EXPLICIT_ANCHOR_OVERLAPS_TITLE_BLOCK',
+      ]),
+    );
   });
 
   it('maps representative references to the correct device buckets', () => {


### PR DESCRIPTION
## Summary

- extend the generic schematic workflow planner with rollback-backed rectangle and text operations
- turn the RP2040 servo-module scaffold into seven visible, non-overlapping functional sections with deterministic titles
- keep all 56 BOM references assigned exactly once, including R13-R15, while preserving the intentionally-unwired first milestone
- add machine-readable scaffold diagnostics for section coverage, overlap, placement containment, ERC intent, and DRC intent
- reconcile rectangle/text creation by expected-kind inventory delta instead of trusting EasyEDA's unreliable native create return ID
- recover primitives created before a thrown bridge error so workflow rollback can still delete them safely

## Validation

- `pnpm verify`
- main suite: 108 files, 1278 tests passed
- bridge extension: 5 files, 93 tests passed
- format, typecheck, lint, tool metadata, tool coverage, builds, extension packaging, metadata alignment, and docs build passed

## Issue scope

Partially addresses #258.

This completes the first-milestone placement scaffold acceptance: safe-region placement, visible functional blocks, deterministic labels, no detached netports, and explicit incompleteness diagnostics. Exact block-level pin-to-net wiring and live visual/DRC/ERC dogfood remain follow-up milestones and are deliberately not inferred here.
