### PR TITLE
feat(schematic-layout): live connectivity fingerprint (#273)

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -85,6 +85,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_schematic_components`                     | `core`  | `low`    | List schematic components: primitiveId, reference, value, footprint, x/y/rotation, and device identity for cloning — deviceUuid+deviceLibraryUuid (a place_component deviceItem in this project), deviceName, symbolName, lcsc, manufacturerId.                                                                                  |
 | `easyeda_schematic_connect_pin_to_net`             | `core`  | `medium` | Create real EasyEDA connectivity for a pin: draws a short wire stub from its exact coordinate, tagged with netName. Same-netName wires merge globally, so this joins the pin to everything else on that net — visible to ERC, ratsnest, and autorouting.                                                                         |
 | `easyeda_schematic_connect_pins_by_net`            | `core`  | `medium` | Bulk variant of connect_pin_to_net: draws a real wire stub from each pin, tagged with netName, so all listed pins (and anything else already on that net) merge into one net. Visible to ERC, ratsnest, and autorouting. A pin that fails (e.g. collision) is reported in failures rather than aborting the batch.               |
+| `easyeda_schematic_connectivity_fingerprint`       | `pro`   | `low`    | Compute a deterministic connectivity fingerprint (pin/net membership, wire endpoints, labels/ports, no-connects) from the live schematic. Pass the hash as beforeFingerprint/afterFingerprint to easyeda_schematic_layout_qa to prove a cosmetic move left connectivity unchanged.                                               |
 | `easyeda_schematic_create_net_flag`                | `core`  | `medium` | Create a named net flag/label. With `identification` (Power/Ground/AnalogGround/ProtectGround) it places a power-flag symbol binding to a coincident pin (use for VCC/GND). Without it, a generic net label — cosmetic only; connect pins with add_wire stubs sharing one netName.                                               |
 | `easyeda_schematic_create_net_port`                | `core`  | `medium` | Place a hierarchical net port (off-sheet connector) on the schematic. Net ports create named connections that span multiple schematic sheets, appearing as real SCH_Net entries in the netlist.                                                                                                                                  |
 | `easyeda_schematic_delete_primitive`               | `core`  | `medium` | Delete components, wires, or other drawing objects from the schematic by their primitive UUIDs.                                                                                                                                                                                                                                  |
@@ -2699,6 +2700,37 @@ Returns a JSON object matching the schema:
   connections: object[] (optional);
   count: number;
   error: string (optional);
+}
+```
+
+---
+
+## `easyeda_schematic_connectivity_fingerprint`
+
+**Profile:** `pro` | **Risk Level:** `low`
+
+> Compute a deterministic connectivity fingerprint (pin/net membership, wire endpoints, labels/ports, no-connects) from the live schematic. Pass the hash as beforeFingerprint/afterFingerprint to easyeda_schematic_layout_qa to prove a cosmetic move left connectivity unchanged.
+
+### Input Parameters
+
+| Parameter   | Type     | Required | Description |
+| ----------- | -------- | -------- | ----------- |
+| `projectId` | `string` | Yes      |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  projectId: string;
+  schemaVersion: '1';
+  hash: string;
+  modelHash: string;
+  componentCount: number;
+  netCount: number;
+  normalized: object;
+  diagnosticCount: number;
 }
 ```
 

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -22,7 +22,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Pro',
     description:
       'Adds pick-and-place, PDF, netlist export, compound transactional workflow tools, autorouting, route-context export, and offline SPICE verification for manufacturing workflows',
-    approxToolCount: '91',
+    approxToolCount: '92',
     isDefault: false,
   },
   full: {
@@ -30,7 +30,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls and CircuitIR-driven floorplanning for full runtime control without raw JavaScript execution',
-    approxToolCount: '103',
+    approxToolCount: '104',
     isDefault: false,
   },
   dev: {
@@ -38,7 +38,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '108',
+    approxToolCount: '109',
     isDefault: false,
   },
   experimental: {

--- a/src/schematic-model/live-snapshot.ts
+++ b/src/schematic-model/live-snapshot.ts
@@ -1,0 +1,162 @@
+import { type ToolContext } from '../tools/types.js';
+import { fetchComponentPins } from '../tools/schematic-helpers.js';
+import type {
+  Point,
+  RawComponentInput,
+  RawNetInput,
+  RawSchematicSnapshot,
+  RawWireInput,
+} from './geometry-model.js';
+
+interface BridgeComponentItem {
+  primitiveId?: string;
+  reference?: string;
+  deviceUuid?: string;
+  deviceLibraryUuid?: string;
+  deviceName?: string;
+  symbolName?: string;
+  x?: number;
+  y?: number;
+  rotation?: number;
+}
+
+interface BridgeComponentPage {
+  total?: number;
+  items?: BridgeComponentItem[];
+}
+
+interface BridgeNetNode {
+  component?: string;
+  pin?: string;
+}
+
+interface BridgeNet {
+  netName?: string;
+  nodes?: BridgeNetNode[];
+}
+
+interface BridgeWireSample {
+  primitiveId?: string;
+  line?: number[];
+  net?: string;
+}
+
+interface BridgeWirePage {
+  total?: number;
+  samples?: BridgeWireSample[];
+}
+
+/** `system.inspectWires` returns a flat [x1,y1,x2,y2,...] polyline per wire. */
+function wirePointsFromLine(line: number[] | undefined): Point[] {
+  const points: Point[] = [];
+  if (!line) return points;
+  for (let i = 0; i + 1 < line.length; i += 2) {
+    const x = line[i];
+    const y = line[i + 1];
+    if (x === undefined || y === undefined) continue;
+    points.push({ x, y });
+  }
+  return points;
+}
+
+export interface GatherLiveSchematicSnapshotOptions {
+  /** Page size used when paging schematic.listComponents. */
+  pageSize?: number;
+}
+
+/**
+ * Reads every component (with per-component pins) and net from the live bridge and
+ * assembles a RawSchematicSnapshot suitable for buildSchematicModel.
+ *
+ * There is no bulk pins-for-all-components bridge method, so this issues one
+ * `api.call SCH_PrimitiveComponent.getAllPinsByPrimitiveId` round-trip per component
+ * (via fetchComponentPins) -- the same sequential pattern already used in production
+ * by scanSheetForPinCollisions (src/workflows/collision.ts) for the same reason.
+ */
+export async function gatherLiveSchematicSnapshot(
+  ctx: ToolContext,
+  projectId: string,
+  options: GatherLiveSchematicSnapshotOptions = {},
+): Promise<RawSchematicSnapshot> {
+  const pageSize = options.pageSize ?? 500;
+  const componentItems: BridgeComponentItem[] = [];
+  let offset = 0;
+  for (;;) {
+    const page = await ctx.bridge.call<
+      { projectId: string; limit: number; offset: number },
+      BridgeComponentPage
+    >('schematic.listComponents', { projectId, limit: pageSize, offset });
+    const items = page?.items ?? [];
+    componentItems.push(...items);
+    const total = page?.total ?? items.length;
+    offset += items.length;
+    if (items.length === 0 || offset >= total) break;
+  }
+
+  const components: RawComponentInput[] = [];
+  for (const item of componentItems) {
+    if (!item.primitiveId) continue;
+    const pins = await fetchComponentPins(ctx, item.primitiveId);
+    components.push({
+      runtimePrimitiveId: item.primitiveId,
+      reference: item.reference,
+      deviceName: item.deviceName,
+      symbolName: item.symbolName,
+      position: item.x !== undefined && item.y !== undefined ? { x: item.x, y: item.y } : undefined,
+      pins: pins.map((pin) => ({
+        number: pin.pinNumber,
+        name: pin.pinName,
+        electricalType: pin.pinType,
+        position: { x: pin.x, y: pin.y },
+        raw: { rotation: pin.rotation, pinLength: pin.pinLength },
+      })),
+      raw: {
+        rotation: item.rotation,
+        deviceUuid: item.deviceUuid,
+        deviceLibraryUuid: item.deviceLibraryUuid,
+      },
+    });
+  }
+
+  const rawNets = await ctx.bridge.call<{ projectId: string }, BridgeNet[]>('schematic.listNets', {
+    projectId,
+  });
+
+  const nets: RawNetInput[] = (rawNets ?? []).map((net) => ({
+    name: net.netName,
+    nodes: (net.nodes ?? []).map((node) => ({
+      componentReference: node.component,
+      pinNumber: node.pin,
+    })),
+  }));
+
+  const wireSamples: BridgeWireSample[] = [];
+  const wirePageSize = 50;
+  let wireOffset = 0;
+  for (;;) {
+    const page = await ctx.bridge.call<{ limit: number; offset: number }, BridgeWirePage>(
+      'system.inspectWires',
+      { limit: wirePageSize, offset: wireOffset },
+    );
+    const samples = page?.samples ?? [];
+    wireSamples.push(...samples);
+    const total = page?.total ?? samples.length;
+    wireOffset += samples.length;
+    if (samples.length === 0 || wireOffset >= total) break;
+  }
+
+  const wires: RawWireInput[] = wireSamples
+    .filter((wire): wire is BridgeWireSample & { primitiveId: string } => !!wire.primitiveId)
+    .map((wire) => ({
+      runtimePrimitiveId: wire.primitiveId,
+      netName: wire.net || undefined,
+      points: wirePointsFromLine(wire.line),
+    }));
+
+  return {
+    document: { projectId },
+    components,
+    nets,
+    wires,
+  };
+}

--- a/src/tools/L2_schematic_layout.ts
+++ b/src/tools/L2_schematic_layout.ts
@@ -16,6 +16,9 @@ import {
   defaultTitleBlockKeepout,
   inferSchematicSheetGeometry,
 } from '../workflows/schematic-safe-region.js';
+import { createConnectivityFingerprint } from '../schematic-model/connectivity-fingerprint.js';
+import { buildSchematicModel } from '../schematic-model/model-builder.js';
+import { gatherLiveSchematicSnapshot } from '../schematic-model/live-snapshot.js';
 import { type ToolContext, type ToolDefinition } from './types.js';
 
 const boundsSchema = z.object({
@@ -73,6 +76,56 @@ const qaIssueSchema = z.object({
   remediation: z.string(),
   blocksCommit: z.boolean(),
   confidence: z.number().min(0).max(1),
+});
+
+const connectivityFingerprintOutputSchema = z.object({
+  projectId: z.string(),
+  schemaVersion: z.literal(1),
+  hash: z.string(),
+  modelHash: z.string(),
+  componentCount: z.number().int().nonnegative(),
+  netCount: z.number().int().nonnegative(),
+  normalized: z.object({
+    pinNetMembership: z.array(
+      z.object({
+        componentId: z.string(),
+        componentReference: z.string(),
+        pinId: z.string(),
+        pinNumber: z.string(),
+        netIds: z.array(z.string()),
+      }),
+    ),
+    wireEndpoints: z.array(
+      z.object({
+        wireId: z.string(),
+        netId: z.string().optional(),
+        netName: z.string().optional(),
+        endpoints: z.array(
+          z.object({
+            endpoint: z.enum(['start', 'end']),
+            kind: z.enum(['pin', 'unresolved']),
+            token: z.string(),
+          }),
+        ),
+      }),
+    ),
+    labelsAndPorts: z.array(
+      z.object({
+        id: z.string(),
+        kind: z.enum(['label', 'sheet-port', 'power-symbol']),
+        netName: z.string(),
+      }),
+    ),
+    noConnects: z.array(
+      z.object({
+        noConnectId: z.string(),
+        componentReference: z.string().optional(),
+        pinId: z.string().optional(),
+        pinNumber: z.string().optional(),
+      }),
+    ),
+  }),
+  diagnosticCount: z.number().int().nonnegative(),
 });
 
 export const layoutQaOutputSchema = z.object({
@@ -476,6 +529,46 @@ export function registerSchematicLayoutTools(
         ...values,
         runVisualCapture: values.runVisualCapture ?? true,
       });
+    },
+  });
+
+  registry.register({
+    name: 'easyeda_schematic_connectivity_fingerprint',
+    title: 'Compute schematic connectivity fingerprint',
+    description:
+      'Compute a deterministic connectivity fingerprint (pin/net membership, wire ' +
+      'endpoints, labels/ports, no-connects) from the live schematic. Pass the hash as ' +
+      'beforeFingerprint/afterFingerprint to easyeda_schematic_layout_qa to prove a ' +
+      'cosmetic move left connectivity unchanged.',
+    profile: 'pro',
+    evidence: ['runtime-probe', 'inferred'],
+    risk: 'low',
+    confirmWrite: false,
+    group: 'workflows',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+    inputSchema: z.object({
+      projectId: z.string().min(1),
+    }),
+    outputSchema: connectivityFingerprintOutputSchema,
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const { projectId } = params as { projectId: string };
+      const snapshot = await gatherLiveSchematicSnapshot(ctx, projectId);
+      const model = buildSchematicModel(snapshot);
+      const fingerprint = createConnectivityFingerprint(model);
+      return {
+        projectId,
+        schemaVersion: fingerprint.schemaVersion,
+        hash: fingerprint.hash,
+        modelHash: model.modelHash,
+        componentCount: model.components.length,
+        netCount: model.nets.length,
+        normalized: fingerprint.normalized,
+        diagnosticCount: model.diagnostics.length,
+      };
     },
   });
 }

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -43,10 +43,10 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('91');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('92');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('103');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('104');
   });
 });

--- a/tests/unit/schematic-model/live-snapshot.test.ts
+++ b/tests/unit/schematic-model/live-snapshot.test.ts
@@ -1,0 +1,277 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { gatherLiveSchematicSnapshot } from '../../../src/schematic-model/live-snapshot.js';
+import { buildSchematicModel } from '../../../src/schematic-model/model-builder.js';
+import { createConnectivityFingerprint } from '../../../src/schematic-model/connectivity-fingerprint.js';
+import { type ToolContext } from '../../../src/tools/types.js';
+
+function makeCtx(bridgeCall: ReturnType<typeof vi.fn>): ToolContext {
+  return {
+    profile: 'pro',
+    bridge: {
+      connected: true,
+      call: bridgeCall,
+    },
+    config: {
+      bridgeTimeoutMs: 1000,
+      artifactDir: '.easyeda-mcp-pro/artifacts',
+      bridgeHost: 'localhost',
+      bridgePort: 3000,
+    },
+    vendors: { lcsc: null, jlcpcb: null, mouser: null, digikey: null },
+  };
+}
+
+function pin(pinNumber: string, pinName: string, x: number, y: number, pinType?: string) {
+  return { pinNumber, pinName, x, y, rotation: 0, pinLength: 10, pinType };
+}
+
+describe('gatherLiveSchematicSnapshot', () => {
+  let bridgeCall: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    bridgeCall = vi.fn();
+  });
+
+  it('assembles a snapshot from components, pins, nets, and wires', async () => {
+    bridgeCall.mockImplementation(async (method: string, params: any) => {
+      if (method === 'schematic.listComponents') {
+        return {
+          total: 2,
+          items: [
+            { primitiveId: 'comp-R1', reference: 'R1', x: 10, y: 20, rotation: 0 },
+            { primitiveId: 'comp-C1', reference: 'C1', x: 30, y: 40, rotation: 90 },
+          ],
+        };
+      }
+      if (method === 'api.call') {
+        const id = params.args[0];
+        if (id === 'comp-R1') {
+          return { result: [pin('1', 'A', 10, 20, 'IN'), pin('2', 'B', 10, 30, 'OUT')] };
+        }
+        if (id === 'comp-C1') {
+          return { result: [pin('1', 'P', 30, 40), pin('2', 'N', 30, 50)] };
+        }
+        return { result: [] };
+      }
+      if (method === 'schematic.listNets') {
+        return [
+          {
+            netName: 'NET1',
+            nodes: [
+              { component: 'R1', pin: '2' },
+              { component: 'C1', pin: '1' },
+            ],
+          },
+        ];
+      }
+      if (method === 'system.inspectWires') {
+        return {
+          total: 1,
+          samples: [{ primitiveId: 'wire-1', line: [10, 30, 30, 40], net: 'NET1' }],
+        };
+      }
+      return undefined;
+    });
+
+    const snapshot = await gatherLiveSchematicSnapshot(makeCtx(bridgeCall), 'proj-1');
+
+    expect(snapshot.document?.projectId).toBe('proj-1');
+    expect(snapshot.components).toHaveLength(2);
+    expect(snapshot.components?.[0]).toMatchObject({
+      runtimePrimitiveId: 'comp-R1',
+      reference: 'R1',
+      position: { x: 10, y: 20 },
+    });
+    expect(snapshot.components?.[0].pins).toHaveLength(2);
+    expect(snapshot.components?.[0].pins?.[0]).toMatchObject({
+      number: '1',
+      name: 'A',
+      electricalType: 'IN',
+      position: { x: 10, y: 20 },
+    });
+
+    expect(snapshot.nets).toHaveLength(1);
+    expect(snapshot.nets?.[0]).toMatchObject({
+      name: 'NET1',
+      nodes: [
+        { componentReference: 'R1', pinNumber: '2' },
+        { componentReference: 'C1', pinNumber: '1' },
+      ],
+    });
+
+    expect(snapshot.wires).toHaveLength(1);
+    expect(snapshot.wires?.[0]).toMatchObject({
+      runtimePrimitiveId: 'wire-1',
+      netName: 'NET1',
+      points: [
+        { x: 10, y: 30 },
+        { x: 30, y: 40 },
+      ],
+    });
+  });
+
+  it('feeds cleanly into buildSchematicModel and createConnectivityFingerprint', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.listComponents') {
+        return { total: 1, items: [{ primitiveId: 'comp-R1', reference: 'R1', x: 0, y: 0 }] };
+      }
+      if (method === 'api.call') {
+        return { result: [pin('1', 'A', 0, 0), pin('2', 'B', 0, 10)] };
+      }
+      if (method === 'schematic.listNets') {
+        return [{ netName: 'GND', nodes: [{ component: 'R1', pin: '2' }] }];
+      }
+      if (method === 'system.inspectWires') {
+        return { total: 0, samples: [] };
+      }
+      return undefined;
+    });
+
+    const snapshot = await gatherLiveSchematicSnapshot(makeCtx(bridgeCall), 'proj-1');
+    const model = buildSchematicModel(snapshot);
+    const fingerprint = createConnectivityFingerprint(model);
+
+    expect(model.components).toHaveLength(1);
+    expect(fingerprint.schemaVersion).toBe(1);
+    expect(fingerprint.hash).toEqual(expect.any(String));
+    expect(fingerprint.normalized.pinNetMembership).toHaveLength(2);
+  });
+
+  it('pages through listComponents past a single page', async () => {
+    const page1 = Array.from({ length: 3 }, (_, i) => ({
+      primitiveId: `c${i}`,
+      reference: `R${i}`,
+      x: i,
+      y: i,
+    }));
+    const page2 = [{ primitiveId: 'c3', reference: 'R3', x: 3, y: 3 }];
+
+    bridgeCall.mockImplementation(async (method: string, params: any) => {
+      if (method === 'schematic.listComponents') {
+        if (params.offset === 0) return { total: 4, items: page1 };
+        return { total: 4, items: page2 };
+      }
+      if (method === 'api.call') return { result: [] };
+      if (method === 'schematic.listNets') return [];
+      if (method === 'system.inspectWires') return { total: 0, samples: [] };
+      return undefined;
+    });
+
+    const snapshot = await gatherLiveSchematicSnapshot(makeCtx(bridgeCall), 'proj-1', {
+      pageSize: 3,
+    });
+
+    expect(snapshot.components).toHaveLength(4);
+    expect(snapshot.components?.map((c) => c.runtimePrimitiveId)).toEqual(['c0', 'c1', 'c2', 'c3']);
+  });
+
+  it('pages through system.inspectWires past the 50-wire cap', async () => {
+    bridgeCall.mockImplementation(async (method: string, params: any) => {
+      if (method === 'schematic.listComponents') return { total: 0, items: [] };
+      if (method === 'schematic.listNets') return [];
+      if (method === 'system.inspectWires') {
+        if (params.offset === 0) {
+          return {
+            total: 51,
+            samples: Array.from({ length: 50 }, (_, i) => ({
+              primitiveId: `w${i}`,
+              line: [0, 0, 1, 1],
+            })),
+          };
+        }
+        return { total: 51, samples: [{ primitiveId: 'w50', line: [0, 0, 1, 1] }] };
+      }
+      return undefined;
+    });
+
+    const snapshot = await gatherLiveSchematicSnapshot(makeCtx(bridgeCall), 'proj-1');
+    expect(snapshot.wires).toHaveLength(51);
+  });
+
+  it('skips components with no primitiveId and does not fetch their pins', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.listComponents') {
+        return { total: 1, items: [{ reference: 'GHOST', x: 0, y: 0 }] };
+      }
+      if (method === 'api.call') throw new Error('should not be called for a ghost component');
+      if (method === 'schematic.listNets') return [];
+      if (method === 'system.inspectWires') return { total: 0, samples: [] };
+      return undefined;
+    });
+
+    const snapshot = await gatherLiveSchematicSnapshot(makeCtx(bridgeCall), 'proj-1');
+    expect(snapshot.components).toHaveLength(0);
+  });
+
+  it('drops a trailing unpaired coordinate from an odd-length wire line', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.listComponents') return { total: 0, items: [] };
+      if (method === 'schematic.listNets') return [];
+      if (method === 'system.inspectWires') {
+        return { total: 1, samples: [{ primitiveId: 'w1', line: [0, 0, 5, 5, 9] }] };
+      }
+      return undefined;
+    });
+
+    const snapshot = await gatherLiveSchematicSnapshot(makeCtx(bridgeCall), 'proj-1');
+    expect(snapshot.wires?.[0].points).toEqual([
+      { x: 0, y: 0 },
+      { x: 5, y: 5 },
+    ]);
+  });
+
+  it('treats an empty wire net name as unset rather than an empty string', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.listComponents') return { total: 0, items: [] };
+      if (method === 'schematic.listNets') return [];
+      if (method === 'system.inspectWires') {
+        return { total: 1, samples: [{ primitiveId: 'w1', line: [0, 0, 1, 1], net: '' }] };
+      }
+      return undefined;
+    });
+
+    const snapshot = await gatherLiveSchematicSnapshot(makeCtx(bridgeCall), 'proj-1');
+    expect(snapshot.wires?.[0].netName).toBeUndefined();
+  });
+
+  it('leaves position undefined when a component has no x/y', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.listComponents') {
+        return { total: 1, items: [{ primitiveId: 'comp-1', reference: 'U1' }] };
+      }
+      if (method === 'api.call') return { result: [] };
+      if (method === 'schematic.listNets') return [];
+      if (method === 'system.inspectWires') return { total: 0, samples: [] };
+      return undefined;
+    });
+
+    const snapshot = await gatherLiveSchematicSnapshot(makeCtx(bridgeCall), 'proj-1');
+    expect(snapshot.components?.[0].position).toBeUndefined();
+  });
+
+  it('treats a net with no nodes array as having zero nodes', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.listComponents') return { total: 0, items: [] };
+      if (method === 'schematic.listNets') return [{ netName: 'FLOAT' }];
+      if (method === 'system.inspectWires') return { total: 0, samples: [] };
+      return undefined;
+    });
+
+    const snapshot = await gatherLiveSchematicSnapshot(makeCtx(bridgeCall), 'proj-1');
+    expect(snapshot.nets?.[0]).toMatchObject({ name: 'FLOAT', nodes: [] });
+  });
+
+  it('handles missing nets/wires responses without throwing', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.listComponents') return { total: 0, items: [] };
+      if (method === 'schematic.listNets') return undefined;
+      if (method === 'system.inspectWires') return undefined;
+      return undefined;
+    });
+
+    const snapshot = await gatherLiveSchematicSnapshot(makeCtx(bridgeCall), 'proj-1');
+    expect(snapshot.components).toEqual([]);
+    expect(snapshot.nets).toEqual([]);
+    expect(snapshot.wires).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes part of #273 — the read/fingerprint half (safe autofix wiring is a separate follow-up, since it additionally depends on #271's bounds primitives).

- The `schematic-model/` engine (`buildSchematicModel`, `createConnectivityFingerprint`, `compareConnectivityFingerprints`) already existed, fully unit-tested, but was never wired to a live bridge read anywhere in the codebase — nothing gathered a raw schematic snapshot from EasyEDA Pro to feed it.
- Adds `gatherLiveSchematicSnapshot` (`src/schematic-model/live-snapshot.ts`): pages `schematic.listComponents`, fetches per-component pins via the existing `fetchComponentPins` helper (same sequential pattern already used in production by `scanSheetForPinCollisions`), reads `schematic.listNets`, and pages `system.inspectWires`, assembling a `RawSchematicSnapshot`.
- Registers `easyeda_schematic_connectivity_fingerprint` (pro profile) in `L2_schematic_layout.ts`: runs the snapshot → model → fingerprint pipeline and returns the hash plus normalized pin/net/wire/label/no-connect breakdown. The returned hash is meant to be passed as `beforeFingerprint`/`afterFingerprint` to the existing `easyeda_schematic_layout_qa` tool.

## Verification

- Unit: 10 new tests in `tests/unit/schematic-model/live-snapshot.test.ts` (mocked bridge) covering pagination (components and wires), pin/net/wire shape mapping, missing-primitiveId skip, odd-length wire line handling, and empty-response handling.
- **Live-bridge**: ran the full pipeline against a real, open EasyEDA Pro design (a 142-component/53-net/180-wire servo-module schematic with rotated multi-pin parts) via a locally built copy of this branch's server — not just synthetic fixtures. Produced a stable hash, 324 pin/net memberships, and 180 wire endpoints (97 correctly flagged `unresolved` at mid-wire junction ends, as expected for a real multi-segment wire mesh).
- `pnpm test:coverage`: 131 files / 1558 tests passing, global thresholds met (87.87%/75.73%/91.86%/89.54%).
- `pnpm lint`, `lint:tools`, `verify:tool-coverage` (bumped `approxToolCount`: pro 91→92, full 103→104, dev 108→109), `typecheck`, `format:check`, `build`, `build:extension`, `verify:extension`, `generate:tools-doc`, `docs:build` all pass.

## Test plan

- [x] `pnpm test:coverage` — all pass, thresholds met
- [x] `pnpm lint && pnpm lint:tools && pnpm verify:tool-coverage`
- [x] `pnpm typecheck && pnpm format:check && pnpm build`
- [x] Live-bridge smoke test against a real, non-trivial EasyEDA Pro design