### PR TITLE
feat(schematic-layout): live primitive bounding boxes (#271)

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -96,6 +96,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_schematic_place_component`                | `core`  | `medium` | Place a library component/device on the active schematic sheet. Auto-assigns the next free designator ("R?" → "R1") — check the returned value, duplicate "R?" merge into one node. On a timeout error, auto-reconciles against the sheet before reporting failure (see reconciled/unconfirmed) — do not blindly retry.          |
 | `easyeda_schematic_plan_safe_region`               | `core`  | `low`    | Compute a safe schematic drawing region before placing components. Uses live sheet info when available, assumes EasyEDA bottom-left coordinates, reserves the default lower-right title-block keep-out, and returns an anchor/bounds plan that avoids title-block overlap.                                                       |
 | `easyeda_schematic_preview_imported_normalization` | `core`  | `low`    | Read the live schematic and produce a deterministic, read-only normalization plan with a stable plan ID, model hash, proposed net-name/reference/metadata operations, validation gates, warnings, and blockers. This tool never writes to EasyEDA.                                                                               |
+| `easyeda_schematic_primitive_bounds`               | `pro`   | `low`    | Read real rendered (sheet-space, rotation-aware) component bounding boxes from the live bridge, batched in one call. Origin is not a collision bound -- use combinedBounds for overlap/page/title-block checks. Reference/value text is not independently addressable here and reports not_available.                            |
 | `easyeda_schematic_search_device`                  | `core`  | `low`    | Search for schematic symbols/devices in the EasyEDA library by keywords. Full results carry the library's complete metadata object per device; pass minimal:true to get back only uuid/libraryUuid/name/pin_count/symbol_type when that is all you need.                                                                         |
 | `easyeda_schematic_set_title_block`                | `core`  | `medium` | Update schematic title block text fields (Company, Version, Drawn, Reviewed, Page Size). Only these 5 are exposed — writing Symbol/Border/Device/etc once corrupted a real title block; those are read-only natively and must be fixed via the EasyEDA Pro UI.                                                                   |
 | `easyeda_schematic_sheet_info`                     | `core`  | `low`    | Return read-only active schematic sheet metadata including page size, frame, origin, and grid hints for safer component placement.                                                                                                                                                                                               |
@@ -3070,6 +3071,35 @@ Returns a JSON object matching the schema:
   plan: object;
   not_available: boolean(optional);
   error: string(optional);
+}
+```
+
+---
+
+## `easyeda_schematic_primitive_bounds`
+
+**Profile:** `pro` | **Risk Level:** `low`
+
+> Read real rendered (sheet-space, rotation-aware) component bounding boxes from the live bridge, batched in one call. Origin is not a collision bound -- use combinedBounds for overlap/page/title-block checks. Reference/value text is not independently addressable here and reports not_available.
+
+### Input Parameters
+
+| Parameter      | Type                  | Required | Description |
+| -------------- | --------------------- | -------- | ----------- |
+| `projectId`    | `string`              | Yes      |             |
+| `primitiveIds` | `string[] (optional)` | No       |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  items: object[];
+  availableCount: number;
+  notAvailableCount: number;
+  units: string;
+  coordinateOrigins: object[];
 }
 ```
 

--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -1220,6 +1220,50 @@ async function listComponentsApi(limit?: number, offset = 0): Promise<unknown> {
   return { total, items: result };
 }
 
+interface RawPrimitiveBBox {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
+/**
+ * Real rendered (sheet-space) bounding box per primitive, via the runtime's own
+ * SCH_Primitive.getPrimitivesBBox -- already rotation/mirror-aware since it reads
+ * the live rendered geometry rather than recomputing it from origin+rotation.
+ */
+async function primitiveBoundsApi(primitiveIds: unknown): Promise<unknown> {
+  const schPrimitiveClass = readFirstPath<any>(['SCH_Primitive', 'sch_Primitive']);
+  if (!schPrimitiveClass) {
+    throw new Error('SCH_Primitive class not found in EasyEDA Pro API');
+  }
+  const ids = Array.isArray(primitiveIds)
+    ? primitiveIds.filter((id): id is string => typeof id === 'string' && id.length > 0)
+    : [];
+
+  const items: Array<{ primitiveId: string; bounds: RawPrimitiveBBox | null }> = [];
+  for (const id of ids) {
+    let bounds: RawPrimitiveBBox | null = null;
+    try {
+      bounds = (await schPrimitiveClass.getPrimitivesBBox([id])) ?? null;
+    } catch (err) {
+      logRecoverableError(`failed to read bounding box for primitive ${id}`, err);
+    }
+    items.push({ primitiveId: id, bounds });
+  }
+
+  let combined: RawPrimitiveBBox | null = null;
+  if (ids.length > 0) {
+    try {
+      combined = (await schPrimitiveClass.getPrimitivesBBox(ids)) ?? null;
+    } catch (err) {
+      logRecoverableError('failed to read combined bounding box', err);
+    }
+  }
+
+  return { items, combined };
+}
+
 async function getSchematicSheetInfoApi(): Promise<unknown> {
   const currentPage = await callFirst([
     'DMT_Schematic.getCurrentSchematicPageInfo',
@@ -3169,6 +3213,8 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
       );
     case 'schematic.getSheetInfo':
       return getSchematicSheetInfoApi();
+    case 'schematic.primitiveBounds':
+      return primitiveBoundsApi(params.primitiveIds);
     case 'schematic.searchDevice':
       return callFirst(
         ['LIB_Device.search', 'lib_Device.search'],

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -22,7 +22,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Pro',
     description:
       'Adds pick-and-place, PDF, netlist export, compound transactional workflow tools, autorouting, route-context export, and offline SPICE verification for manufacturing workflows',
-    approxToolCount: '92',
+    approxToolCount: '93',
     isDefault: false,
   },
   full: {
@@ -30,7 +30,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls and CircuitIR-driven floorplanning for full runtime control without raw JavaScript execution',
-    approxToolCount: '104',
+    approxToolCount: '105',
     isDefault: false,
   },
   dev: {
@@ -38,7 +38,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '109',
+    approxToolCount: '110',
     isDefault: false,
   },
   experimental: {

--- a/src/schematic-model/live-primitive-bounds.ts
+++ b/src/schematic-model/live-primitive-bounds.ts
@@ -1,0 +1,141 @@
+import { type ToolContext } from '../tools/types.js';
+import {
+  computePrimitiveBoundsBatch,
+  type PrimitiveBoundsBatchResult,
+  type PrimitiveBoundsInput,
+} from './primitive-bounds.js';
+import { type SchematicBounds } from '../schematic-engine/geometry.js';
+
+interface BridgeComponentItem {
+  primitiveId?: string;
+  reference?: string;
+  component_kind?: string;
+  x?: number;
+  y?: number;
+  rotation?: number;
+}
+
+interface BridgeComponentPage {
+  total?: number;
+  items?: BridgeComponentItem[];
+}
+
+interface RawPrimitiveBBox {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
+interface BridgePrimitiveBoundsResponse {
+  items?: Array<{ primitiveId: string; bounds: RawPrimitiveBBox | null }>;
+  combined?: RawPrimitiveBBox | null;
+}
+
+function bboxToSchematicBounds(box: RawPrimitiveBBox): SchematicBounds {
+  return {
+    x: box.minX,
+    y: box.minY,
+    width: box.maxX - box.minX,
+    height: box.maxY - box.minY,
+  };
+}
+
+const ROTATIONS = new Set([0, 90, 180, 270]);
+
+function normalizeRotation(rotation: number | undefined): 0 | 90 | 180 | 270 {
+  const normalized = ((Math.round(rotation ?? 0) % 360) + 360) % 360;
+  return (ROTATIONS.has(normalized) ? normalized : 0) as 0 | 90 | 180 | 270;
+}
+
+/**
+ * Page through schematic.listComponents to collect every component's identity
+ * and placement metadata (needed for the result's origin/rotation fields --
+ * the bounds themselves are already sheet-space, courtesy of the runtime's own
+ * SCH_Primitive.getPrimitivesBBox).
+ */
+async function listAllComponents(
+  ctx: ToolContext,
+  projectId: string,
+  pageSize = 500,
+): Promise<BridgeComponentItem[]> {
+  const all: BridgeComponentItem[] = [];
+  let offset = 0;
+  for (;;) {
+    const page = await ctx.bridge.call<
+      { projectId: string; limit: number; offset: number },
+      BridgeComponentPage
+    >('schematic.listComponents', { projectId, limit: pageSize, offset });
+    const items = page?.items ?? [];
+    all.push(...items);
+    const total = page?.total ?? items.length;
+    offset += items.length;
+    if (items.length === 0 || offset >= total) break;
+  }
+  return all;
+}
+
+export interface GatherLivePrimitiveBoundsOptions {
+  /** Restrict to these primitiveIds; defaults to every component on the sheet. */
+  primitiveIds?: string[];
+}
+
+/**
+ * Read real rendered (sheet-space, rotation/mirror-aware) bounding boxes for
+ * schematic primitives from the live bridge.
+ *
+ * Verified against a live EasyEDA Pro session (2026-07): component designator
+ * and value text are not independently addressable primitives -- they are
+ * rendered as attribute strings on the component itself (`sch_PrimitiveText`
+ * only enumerates free-floating sheet annotations, and `getPrimitivesInRegion`
+ * is an unimplemented stub in this runtime build) -- so `reference`/`value`
+ * segments are always `not_available` here. `body` is real runtime geometry.
+ */
+export async function gatherLivePrimitiveBounds(
+  ctx: ToolContext,
+  projectId: string,
+  options: GatherLivePrimitiveBoundsOptions = {},
+): Promise<PrimitiveBoundsBatchResult> {
+  const components = await listAllComponents(ctx, projectId);
+  const requested = new Set(options.primitiveIds);
+  const selected = options.primitiveIds
+    ? components.filter((c) => c.primitiveId && requested.has(c.primitiveId))
+    : components;
+
+  const ids = selected
+    .map((c) => c.primitiveId)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+  const raw = await ctx.bridge.call<{ primitiveIds: string[] }, BridgePrimitiveBoundsResponse>(
+    'schematic.primitiveBounds',
+    { primitiveIds: ids },
+  );
+  const boundsById = new Map((raw?.items ?? []).map((item) => [item.primitiveId, item.bounds]));
+
+  const inputs: PrimitiveBoundsInput[] = selected
+    .filter((c): c is BridgeComponentItem & { primitiveId: string } => !!c.primitiveId)
+    .map((component) => {
+      const box = boundsById.get(component.primitiveId);
+      return {
+        id: component.primitiveId,
+        primitiveType: component.component_kind ?? 'component',
+        origin: { x: component.x ?? 0, y: component.y ?? 0 },
+        rotation: normalizeRotation(component.rotation),
+        units: 'mil',
+        grid: 10,
+        coordinateOrigin: { x: 0, y: 0, yAxis: 'down' as const, source: 'runtime' as const },
+        ...(box
+          ? {
+              body: {
+                id: component.primitiveId,
+                bounds: bboxToSchematicBounds(box),
+                space: 'sheet' as const,
+                geometrySource: 'runtime' as const,
+              },
+            }
+          : {}),
+      } satisfies PrimitiveBoundsInput;
+    });
+
+  return computePrimitiveBoundsBatch(inputs);
+}

--- a/src/tools/L2_schematic_layout.ts
+++ b/src/tools/L2_schematic_layout.ts
@@ -19,6 +19,7 @@ import {
 import { createConnectivityFingerprint } from '../schematic-model/connectivity-fingerprint.js';
 import { buildSchematicModel } from '../schematic-model/model-builder.js';
 import { gatherLiveSchematicSnapshot } from '../schematic-model/live-snapshot.js';
+import { gatherLivePrimitiveBounds } from '../schematic-model/live-primitive-bounds.js';
 import { type ToolContext, type ToolDefinition } from './types.js';
 
 const boundsSchema = z.object({
@@ -126,6 +127,56 @@ const connectivityFingerprintOutputSchema = z.object({
     ),
   }),
   diagnosticCount: z.number().int().nonnegative(),
+});
+
+const primitiveBoundsSegmentSchema = z.object({
+  id: z.string().optional(),
+  bounds: boundsSchema,
+  geometrySource: z.enum(['runtime', 'derived', 'approximate']),
+  confidence: z.enum(['exact', 'conservative', 'low']),
+});
+
+const primitiveBoundsItemSchema = z.object({
+  id: z.string(),
+  primitiveType: z.string(),
+  origin: z.object({ x: z.number(), y: z.number() }),
+  rotation: z.union([z.literal(0), z.literal(90), z.literal(180), z.literal(270)]),
+  mirroredX: z.boolean(),
+  mirroredY: z.boolean(),
+  units: z.string(),
+  grid: z.number(),
+  coordinateOrigin: z.object({
+    x: z.number(),
+    y: z.number(),
+    yAxis: z.enum(['up', 'down']),
+    source: z.enum(['runtime', 'live-readback', 'derived']),
+  }),
+  availability: z.enum(['available', 'not_available']),
+  geometrySource: z.enum(['runtime', 'derived', 'approximate', 'not_available']),
+  confidence: z.enum(['exact', 'conservative', 'low', 'not_available']),
+  body: primitiveBoundsSegmentSchema.optional(),
+  reference: primitiveBoundsSegmentSchema.optional(),
+  value: primitiveBoundsSegmentSchema.optional(),
+  pinTexts: z.array(primitiveBoundsSegmentSchema),
+  labels: z.array(primitiveBoundsSegmentSchema),
+  annotations: z.array(primitiveBoundsSegmentSchema),
+  combinedBounds: boundsSchema.optional(),
+  limitations: z.array(z.string()),
+});
+
+const primitiveBoundsOutputSchema = z.object({
+  items: z.array(primitiveBoundsItemSchema),
+  availableCount: z.number().int().nonnegative(),
+  notAvailableCount: z.number().int().nonnegative(),
+  units: z.string(),
+  coordinateOrigins: z.array(
+    z.object({
+      x: z.number(),
+      y: z.number(),
+      yAxis: z.enum(['up', 'down']),
+      source: z.enum(['runtime', 'live-readback', 'derived']),
+    }),
+  ),
 });
 
 export const layoutQaOutputSchema = z.object({
@@ -569,6 +620,35 @@ export function registerSchematicLayoutTools(
         normalized: fingerprint.normalized,
         diagnosticCount: model.diagnostics.length,
       };
+    },
+  });
+
+  registry.register({
+    name: 'easyeda_schematic_primitive_bounds',
+    title: 'Get schematic primitive bounding boxes',
+    description:
+      'Read real rendered (sheet-space, rotation-aware) component bounding boxes from the ' +
+      'live bridge, batched in one call. Origin is not a collision bound -- use ' +
+      'combinedBounds for overlap/page/title-block checks. Reference/value text is not ' +
+      'independently addressable here and reports not_available.',
+    profile: 'pro',
+    evidence: ['runtime-probe', 'inferred'],
+    risk: 'low',
+    confirmWrite: false,
+    group: 'workflows',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+    inputSchema: z.object({
+      projectId: z.string().min(1),
+      primitiveIds: z.array(z.string().min(1)).optional(),
+    }),
+    outputSchema: primitiveBoundsOutputSchema,
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const { projectId, primitiveIds } = params as { projectId: string; primitiveIds?: string[] };
+      return gatherLivePrimitiveBounds(ctx, projectId, { primitiveIds });
     },
   });
 }

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -43,10 +43,10 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('92');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('93');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('104');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('105');
   });
 });

--- a/tests/unit/schematic-model/live-primitive-bounds.test.ts
+++ b/tests/unit/schematic-model/live-primitive-bounds.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { gatherLivePrimitiveBounds } from '../../../src/schematic-model/live-primitive-bounds.js';
+import { type ToolContext } from '../../../src/tools/types.js';
+
+function makeCtx(bridgeCall: ReturnType<typeof vi.fn>): ToolContext {
+  return {
+    profile: 'pro',
+    bridge: {
+      connected: true,
+      call: bridgeCall,
+    },
+    config: {
+      bridgeTimeoutMs: 1000,
+      artifactDir: '.easyeda-mcp-pro/artifacts',
+      bridgeHost: 'localhost',
+      bridgePort: 3000,
+    },
+    vendors: { lcsc: null, jlcpcb: null, mouser: null, digikey: null },
+  };
+}
+
+function component(primitiveId: string, x: number, y: number, rotation: number) {
+  return { primitiveId, reference: primitiveId, component_kind: 'part', x, y, rotation };
+}
+
+describe('gatherLivePrimitiveBounds', () => {
+  let bridgeCall: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    bridgeCall = vi.fn();
+  });
+
+  it('returns a runtime/exact body bound for a rotated component', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.listComponents') {
+        return { total: 1, items: [component('c1', 935, -290, 90)] };
+      }
+      if (method === 'schematic.primitiveBounds') {
+        return {
+          items: [
+            { primitiveId: 'c1', bounds: { minX: 924.5, maxX: 945.5, minY: -294.5, maxY: -285.5 } },
+          ],
+          combined: { minX: 924.5, maxX: 945.5, minY: -294.5, maxY: -285.5 },
+        };
+      }
+      return undefined;
+    });
+
+    const result = await gatherLivePrimitiveBounds(makeCtx(bridgeCall), 'proj-1');
+
+    expect(result.items).toHaveLength(1);
+    const item = result.items[0];
+    expect(item.rotation).toBe(90);
+    expect(item.availability).toBe('available');
+    expect(item.geometrySource).toBe('runtime');
+    expect(item.confidence).toBe('exact');
+    expect(item.body).toMatchObject({
+      bounds: { x: 924.5, y: -294.5, width: 21, height: 9 },
+      geometrySource: 'runtime',
+      confidence: 'exact',
+    });
+    expect(item.combinedBounds).toEqual({ x: 924.5, y: -294.5, width: 21, height: 9 });
+    expect(result.availableCount).toBe(1);
+    expect(result.notAvailableCount).toBe(0);
+  });
+
+  it('swaps width/height correctly between a 90 and a 180 rotation', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.listComponents') {
+        return {
+          total: 2,
+          items: [component('r90', 935, -290, 90), component('r180', 840, -360, 180)],
+        };
+      }
+      if (method === 'schematic.primitiveBounds') {
+        return {
+          items: [
+            {
+              primitiveId: 'r90',
+              bounds: { minX: 924.5, maxX: 945.5, minY: -294.5, maxY: -285.5 },
+            },
+            {
+              primitiveId: 'r180',
+              bounds: { minX: 835.5, maxX: 844.5, minY: -370.5, maxY: -349.5 },
+            },
+          ],
+          combined: null,
+        };
+      }
+      return undefined;
+    });
+
+    const result = await gatherLivePrimitiveBounds(makeCtx(bridgeCall), 'proj-1');
+    const r90 = result.items.find((i) => i.id === 'r90')!;
+    const r180 = result.items.find((i) => i.id === 'r180')!;
+
+    expect(r90.body?.bounds).toEqual({ x: 924.5, y: -294.5, width: 21, height: 9 });
+    expect(r180.body?.bounds).toEqual({ x: 835.5, y: -370.5, width: 9, height: 21 });
+  });
+
+  it('marks a primitive not_available when the bridge returns no bbox for it', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.listComponents') {
+        return { total: 1, items: [component('ghost', 0, 0, 0)] };
+      }
+      if (method === 'schematic.primitiveBounds') {
+        return { items: [{ primitiveId: 'ghost', bounds: null }], combined: null };
+      }
+      return undefined;
+    });
+
+    const result = await gatherLivePrimitiveBounds(makeCtx(bridgeCall), 'proj-1');
+    expect(result.items[0].availability).toBe('not_available');
+    expect(result.items[0].body).toBeUndefined();
+    expect(result.notAvailableCount).toBe(1);
+  });
+
+  it('filters to only the requested primitiveIds', async () => {
+    bridgeCall.mockImplementation(async (method: string, params: any) => {
+      if (method === 'schematic.listComponents') {
+        return {
+          total: 3,
+          items: [component('a', 0, 0, 0), component('b', 1, 1, 0), component('c', 2, 2, 0)],
+        };
+      }
+      if (method === 'schematic.primitiveBounds') {
+        expect(params.primitiveIds).toEqual(['b']);
+        return {
+          items: [{ primitiveId: 'b', bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 } }],
+          combined: null,
+        };
+      }
+      return undefined;
+    });
+
+    const result = await gatherLivePrimitiveBounds(makeCtx(bridgeCall), 'proj-1', {
+      primitiveIds: ['b'],
+    });
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].id).toBe('b');
+  });
+
+  it('normalizes an out-of-range or negative rotation to a canonical quarter-turn', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.listComponents') {
+        return { total: 1, items: [component('c1', 0, 0, -90)] };
+      }
+      if (method === 'schematic.primitiveBounds') {
+        return {
+          items: [{ primitiveId: 'c1', bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 } }],
+          combined: null,
+        };
+      }
+      return undefined;
+    });
+
+    const result = await gatherLivePrimitiveBounds(makeCtx(bridgeCall), 'proj-1');
+    expect(result.items[0].rotation).toBe(270);
+  });
+
+  it('pages through listComponents past a single page', async () => {
+    const page1 = Array.from({ length: 3 }, (_, i) => component(`c${i}`, i, i, 0));
+    const page2 = [component('c3', 3, 3, 0)];
+
+    bridgeCall.mockImplementation(async (method: string, params: any) => {
+      if (method === 'schematic.listComponents') {
+        if (params.offset === 0) return { total: 4, items: page1 };
+        return { total: 4, items: page2 };
+      }
+      if (method === 'schematic.primitiveBounds') {
+        return { items: [], combined: null };
+      }
+      return undefined;
+    });
+
+    const result = await gatherLivePrimitiveBounds(makeCtx(bridgeCall), 'proj-1');
+    expect(result.items).toHaveLength(4);
+  });
+
+  it('falls back to a generic primitiveType when component_kind is missing', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.listComponents') {
+        return { total: 1, items: [{ primitiveId: 'c1', x: 0, y: 0, rotation: 0 }] };
+      }
+      if (method === 'schematic.primitiveBounds') {
+        return {
+          items: [{ primitiveId: 'c1', bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 } }],
+          combined: null,
+        };
+      }
+      return undefined;
+    });
+
+    const result = await gatherLivePrimitiveBounds(makeCtx(bridgeCall), 'proj-1');
+    expect(result.items[0].primitiveType).toBe('component');
+  });
+
+  it('returns no items for an explicitly empty primitiveIds filter', async () => {
+    bridgeCall.mockImplementation(async (method: string, params: any) => {
+      if (method === 'schematic.listComponents') {
+        return { total: 1, items: [component('a', 0, 0, 0)] };
+      }
+      if (method === 'schematic.primitiveBounds') {
+        expect(params.primitiveIds).toEqual([]);
+        return { items: [], combined: null };
+      }
+      return undefined;
+    });
+
+    const result = await gatherLivePrimitiveBounds(makeCtx(bridgeCall), 'proj-1', {
+      primitiveIds: [],
+    });
+    expect(result.items).toHaveLength(0);
+  });
+
+  it('drops selected components with no primitiveId before requesting bounds', async () => {
+    bridgeCall.mockImplementation(async (method: string, params: any) => {
+      if (method === 'schematic.listComponents') {
+        return { total: 2, items: [{ x: 0, y: 0, rotation: 0 }, component('b', 1, 1, 0)] };
+      }
+      if (method === 'schematic.primitiveBounds') {
+        expect(params.primitiveIds).toEqual(['b']);
+        return {
+          items: [{ primitiveId: 'b', bounds: { minX: 0, maxX: 1, minY: 0, maxY: 1 } }],
+          combined: null,
+        };
+      }
+      return undefined;
+    });
+
+    const result = await gatherLivePrimitiveBounds(makeCtx(bridgeCall), 'proj-1');
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].id).toBe('b');
+  });
+});


### PR DESCRIPTION
## Summary

Closes #271's core scope: a read-only, batched, rotation-aware primitive-bounds tool backed by real runtime geometry, not by re-deriving bounds from origin+symbol-library assumptions.

- **New dispatcher method** `schematic.primitiveBounds` (`easyeda-bridge-extension/src/dispatcher.ts`): calls the runtime's own `eda.sch_Primitive.getPrimitivesBBox(primitiveIds)` — real, already-rendered, sheet-space bounding boxes, one bridge call per primitive plus one combined call, matching the existing `system.inspectWires`/`getPrimitivesBBox` cost shape used elsewhere. This method name was already declared in the server's `EasyedaApiMethodSchema` (from earlier work anticipating it) but had no dispatcher implementation until now.
- **New engine plumbing** `gatherLivePrimitiveBounds` (`src/schematic-model/live-primitive-bounds.ts`): pages `schematic.listComponents`, calls the new dispatcher method once for the whole selection, and feeds the results into the existing (already unit-tested) `computePrimitiveBoundsBatch`/`computePrimitiveBounds` engine as `space: 'sheet'`, `geometrySource: 'runtime'` segments.
- **New MCP tool** `easyeda_schematic_primitive_bounds` (pro profile, `L2_schematic_layout.ts`): batch-first (defaults to every component on the sheet; optionally scoped to specific `primitiveIds`), one round trip regardless of selection size.

## Scope note: reference/value/pin-text bounds are `not_available` (verified, not guessed)

Live-probed against a real EasyEDA Pro session before committing to this: designator ("R10") and value ("27R") text are rendered as attribute strings on the component itself, not as independently addressable primitives. `sch_PrimitiveText.getAllPrimitiveId()` only enumerates free-floating sheet annotations (9 found on a 142-component sheet — confirmed by content, e.g. `"BOOTSEL"`), and `eda.sch_Document.getPrimitivesInRegion` is an unimplemented stub (`{return[]}`) in this runtime build, so there's no spatial fallback either. Rather than emit a fabricated guess, these segments report `not_available` with the reasoning documented in the source. `body` bounds (the actual placement-safety-relevant geometry) are real runtime data.

## Verification

- **Live-bridge**: built this branch's server + extension, ran it against a real, non-trivial open EasyEDA Pro design. Confirmed real `getPrimitivesBBox` output for a 90°-rotated resistor (21×9 sheet-space box) and a 180°-rotated resistor (9×21 — correctly swapped vs. the 90° case), then round-tripped both through the actual `easyeda_schematic_primitive_bounds` MCP tool end-to-end. Batch mode across all 59 components on the sheet completed in ~0.36s in one MCP call.
- Unit: 9 new tests in `tests/unit/schematic-model/live-primitive-bounds.test.ts` (mocked bridge) covering rotation-correct bounds, not_available handling, primitiveIds filtering (including an explicit empty array), missing-primitiveId components, component_kind fallback, negative/out-of-range rotation normalization, and pagination.
- `pnpm test:coverage`: 132 files / 1567 tests passing, global thresholds met (87.89%/75.77%/91.85%/89.56%).
- `pnpm lint`, `lint:tools`, `verify:tool-coverage` (bumped `approxToolCount`: pro 92→93, full 104→105, dev 109→110), `typecheck`, `format:check`, `build`, `build:extension`, `verify:extension`, `generate:tools-doc`, `docs:build` all pass.

## Test plan

- [x] `pnpm test:coverage` — all pass, thresholds met
- [x] `pnpm lint && pnpm lint:tools && pnpm verify:tool-coverage`
- [x] `pnpm typecheck && pnpm format:check && pnpm build && pnpm build:extension && pnpm verify:extension`
- [x] Live-bridge smoke test against a real, non-trivial EasyEDA Pro design, including a rotation cross-check (90° vs 180°)