### PR TITLE
feat(schematic-layout): live placement check / safe-region search (#243)

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -81,6 +81,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_schematic_batch_write`                    | `core`  | `high`   | Apply up to 200 validated schematic create, modify, and delete operations in one snapshot-backed transaction. Any failure rolls the whole transaction back. Delete is limited to safely recreatable drawing primitives.                                                                                                          |
 | `easyeda_schematic_capture_full_page`              | `pro`   | `low`    | Read the active schematic sheet geometry, clear selection overlays, frame the complete sheet including its border and title block, and return a deterministic PNG plus the sheet-to-image coordinate transform. Refuses guessed geometry unless explicitly allowed.                                                              |
 | `easyeda_schematic_check_collisions`               | `core`  | `low`    | Scan every component's real pin coordinates and report any (x,y) shared by two or more components — a silent-short risk the native NET_COLLISION guard misses for never-wired pins. Run after manual placement outside easyeda_workflow_* tools (which reconcile this automatically).                                            |
+| `easyeda_schematic_check_placement`                | `pro`   | `low`    | Validate a candidate placement (rendered bounds, clearances, conflicts, deterministic alternatives) or -- when x/y are omitted -- search for a safe region of the given size, against real title-block/page-border/existing-primitive constraints. Read-only, no writes.                                                         |
 | `easyeda_schematic_component_pins`                 | `core`  | `low`    | Get exact pin numbers, names, coordinates, and native pinType for a schematic component by its primitive ID. pinType is EasyEDA's own symbol-library field and is unreliably authored (often "Undefined" even on real ICs) — treat it as a weak hint, not ground truth.                                                          |
 | `easyeda_schematic_components`                     | `core`  | `low`    | List schematic components: primitiveId, reference, value, footprint, x/y/rotation, and device identity for cloning — deviceUuid+deviceLibraryUuid (a place_component deviceItem in this project), deviceName, symbolName, lcsc, manufacturerId.                                                                                  |
 | `easyeda_schematic_connect_pin_to_net`             | `core`  | `medium` | Create real EasyEDA connectivity for a pin: draws a short wire stub from its exact coordinate, tagged with netName. Same-netName wires merge globally, so this joins the pin to everything else on that net — visible to ERC, ratsnest, and autorouting.                                                                         |
@@ -2576,6 +2577,46 @@ Returns a JSON object matching the schema:
   collision_count: number;
   success: boolean;
   error: string (optional);
+}
+```
+
+---
+
+## `easyeda_schematic_check_placement`
+
+**Profile:** `pro` | **Risk Level:** `low`
+
+> Validate a candidate placement (rendered bounds, clearances, conflicts, deterministic alternatives) or -- when x/y are omitted -- search for a safe region of the given size, against real title-block/page-border/existing-primitive constraints. Read-only, no writes.
+
+### Input Parameters
+
+| Parameter             | Type                  | Required | Description |
+| --------------------- | --------------------- | -------- | ----------- |
+| `projectId`           | `string`              | Yes      |             |
+| `candidate`           | `object`              | Yes      |             |
+| `reservedRegions`     | `object[] (optional)` | No       |             |
+| `minimumClearance`    | `number (optional)`   | No       |             |
+| `excludePrimitiveIds` | `string[] (optional)` | No       |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  mode: 'check-placement' | 'select-safe-region';
+  accepted: boolean (optional);
+  proposed: object (optional);
+  combinedBounds: object (optional);
+  clearances: object[] (optional);
+  conflicts: object[] (optional);
+  suggestedAlternatives: object[] (optional);
+  failure: object (optional);
+  feasible: boolean (optional);
+  preference: string (optional);
+  candidate: object (optional);
+  check: object (optional);
+  rationale: string[] (optional);
 }
 ```
 

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -22,7 +22,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Pro',
     description:
       'Adds pick-and-place, PDF, netlist export, compound transactional workflow tools, autorouting, route-context export, and offline SPICE verification for manufacturing workflows',
-    approxToolCount: '94',
+    approxToolCount: '95',
     isDefault: false,
   },
   full: {
@@ -30,7 +30,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls and CircuitIR-driven floorplanning for full runtime control without raw JavaScript execution',
-    approxToolCount: '106',
+    approxToolCount: '107',
     isDefault: false,
   },
   dev: {
@@ -38,7 +38,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '111',
+    approxToolCount: '112',
     isDefault: false,
   },
   experimental: {

--- a/src/schematic-model/live-functional-layout.ts
+++ b/src/schematic-model/live-functional-layout.ts
@@ -44,7 +44,7 @@ export interface GatherLiveFunctionalLayoutPlanOptions {
  * <= 0). `yAxis: 'up'` here documents that increasing Y visually goes up, i.e.
  * the page rectangle spans y in [-height, 0].
  */
-function buildEngineSheetGeometry(rawSheetInfo: unknown): SchematicSheetGeometry {
+export function buildEngineSheetGeometry(rawSheetInfo: unknown): SchematicSheetGeometry {
   const inferred = inferSchematicSheetGeometry(rawSheetInfo);
   const margin = Math.max(10, Math.round(Math.min(inferred.width, inferred.height) * 0.03));
   const bounds: SchematicBounds = {

--- a/src/schematic-model/live-placement-check.ts
+++ b/src/schematic-model/live-placement-check.ts
@@ -1,0 +1,100 @@
+import { type ToolContext } from '../tools/types.js';
+import { gatherLivePrimitiveBounds } from './live-primitive-bounds.js';
+import { buildEngineSheetGeometry } from './live-functional-layout.js';
+import {
+  checkPlacement,
+  selectSafeRegion,
+  type PlacementCheckResult,
+  type PlacementConstraintRegion,
+  type SafeRegionPreference,
+  type SafeRegionResult,
+} from '../layout/placement.js';
+import type { PrimitiveRotation } from './primitive-bounds.js';
+import type { SchematicBounds } from '../schematic-engine/geometry.js';
+
+export interface LivePlacementCandidateInput {
+  width: number;
+  height: number;
+  /** Omit x/y to search for a safe region instead of validating a specific spot. */
+  x?: number;
+  y?: number;
+  rotation?: PrimitiveRotation;
+  preference?: SafeRegionPreference;
+}
+
+export interface GatherLivePlacementCheckOptions {
+  /** Extra caller-defined reserved regions, beyond the inferred title block. */
+  reservedRegions?: readonly PlacementConstraintRegion[];
+  minimumClearance?: number;
+  /** primitiveIds to exclude from the live occupied-region set (e.g. the component being moved). */
+  excludePrimitiveIds?: readonly string[];
+}
+
+export type LivePlacementCheckResult =
+  | ({ mode: 'check-placement' } & PlacementCheckResult)
+  | ({ mode: 'select-safe-region' } & SafeRegionResult);
+
+/**
+ * Reads live sheet geometry and every other placed primitive's real rendered
+ * bounds, then either validates a specific candidate placement (`checkPlacement`)
+ * or searches for a safe region for a given size (`selectSafeRegion`) --
+ * read-only, no writes. Existing unrelated primitives are read as occupied
+ * regions and are never treated as free space.
+ */
+export async function gatherLivePlacementCheck(
+  ctx: ToolContext,
+  projectId: string,
+  candidate: LivePlacementCandidateInput,
+  options: GatherLivePlacementCheckOptions = {},
+): Promise<LivePlacementCheckResult> {
+  const sheetInfoResult = await ctx.bridge.call<{ projectId: string }, unknown>(
+    'schematic.getSheetInfo',
+    { projectId },
+  );
+  const sheet = buildEngineSheetGeometry(sheetInfoResult);
+
+  const excluded = new Set(options.excludePrimitiveIds ?? []);
+  const allBounds = await gatherLivePrimitiveBounds(ctx, projectId);
+  const occupiedRegions: PlacementConstraintRegion[] = allBounds.items
+    .filter((item) => !excluded.has(item.id) && item.combinedBounds)
+    .map((item) => ({
+      id: `existing:${item.id}`,
+      kind: 'existing-object' as const,
+      ownerId: item.id,
+      bounds: item.combinedBounds as SchematicBounds,
+    }));
+
+  const rotation = candidate.rotation ?? 0;
+
+  if (candidate.x !== undefined && candidate.y !== undefined) {
+    const origin = { x: candidate.x, y: candidate.y };
+    const result = checkPlacement({
+      sheet,
+      candidate: {
+        origin,
+        rotation,
+        combinedBounds: { ...origin, width: candidate.width, height: candidate.height },
+      },
+      reservedRegions: options.reservedRegions,
+      occupiedRegions,
+      ...(options.minimumClearance !== undefined
+        ? { minimumClearance: options.minimumClearance }
+        : {}),
+      searchPreference: candidate.preference,
+    });
+    return { mode: 'check-placement', ...result };
+  }
+
+  const result = selectSafeRegion({
+    sheet,
+    size: { width: candidate.width, height: candidate.height },
+    rotation,
+    preference: candidate.preference,
+    reservedRegions: options.reservedRegions,
+    occupiedRegions,
+    ...(options.minimumClearance !== undefined
+      ? { minimumClearance: options.minimumClearance }
+      : {}),
+  });
+  return { mode: 'select-safe-region', ...result };
+}

--- a/src/tools/L2_schematic_layout.ts
+++ b/src/tools/L2_schematic_layout.ts
@@ -25,7 +25,11 @@ import {
   type LiveFunctionalLayoutComponentInput,
 } from '../schematic-model/live-functional-layout.js';
 import type { FunctionalLayoutConstraints } from '../layout/planner.js';
-import type { PlacementConstraintRegion } from '../layout/placement.js';
+import type { PlacementConstraintRegion, SafeRegionPreference } from '../layout/placement.js';
+import {
+  gatherLivePlacementCheck,
+  type LivePlacementCandidateInput,
+} from '../schematic-model/live-placement-check.js';
 import { type ToolContext, type ToolDefinition } from './types.js';
 
 const boundsSchema = z.object({
@@ -236,6 +240,100 @@ const placementCandidateSchema = z.object({
   origin: z.object({ x: z.number(), y: z.number() }),
   rotation: z.union([z.literal(0), z.literal(90), z.literal(180), z.literal(270)]),
   combinedBounds: boundsSchema,
+});
+
+const placementConflictSchema = z.object({
+  code: z.enum([
+    'PAGE_BORDER_KEEP_OUT',
+    'TITLE_BLOCK_KEEP_OUT',
+    'CALLER_RESERVED_REGION',
+    'SUPPORT_RESERVATION',
+    'EXISTING_OBJECT_OCCUPIED',
+    'MINIMUM_CLEARANCE',
+  ]),
+  regionId: z.string(),
+  regionKind: z.enum([
+    'title-block',
+    'page-border',
+    'caller-reserved',
+    'support-reservation',
+    'existing-object',
+  ]),
+  candidateBounds: boundsSchema,
+  conflictingBounds: boundsSchema,
+  clearance: z.number(),
+  requiredClearance: z.number(),
+  message: z.string(),
+});
+
+const placementAlternativeSchema = placementCandidateSchema.extend({
+  reason: z.string(),
+});
+
+const placementCheckResultSchema = z.object({
+  accepted: z.boolean(),
+  proposed: placementCandidateSchema,
+  combinedBounds: boundsSchema,
+  clearances: z.array(
+    z.object({
+      regionId: z.string(),
+      regionKind: z.enum([
+        'title-block',
+        'page-border',
+        'caller-reserved',
+        'support-reservation',
+        'existing-object',
+      ]),
+      clearance: z.number(),
+    }),
+  ),
+  conflicts: z.array(placementConflictSchema),
+  suggestedAlternatives: z.array(placementAlternativeSchema),
+  failure: z
+    .object({
+      code: z.literal('NO_FEASIBLE_POSITION'),
+      unsatisfiedConstraints: z.array(z.string()),
+      searchedCandidates: z.number().int().nonnegative(),
+    })
+    .optional(),
+});
+
+const placementCheckOutputSchema = z.object({
+  mode: z.enum(['check-placement', 'select-safe-region']),
+  // check-placement mode
+  accepted: z.boolean().optional(),
+  proposed: placementCandidateSchema.optional(),
+  combinedBounds: boundsSchema.optional(),
+  clearances: z
+    .array(
+      z.object({
+        regionId: z.string(),
+        regionKind: z.enum([
+          'title-block',
+          'page-border',
+          'caller-reserved',
+          'support-reservation',
+          'existing-object',
+        ]),
+        clearance: z.number(),
+      }),
+    )
+    .optional(),
+  conflicts: z.array(placementConflictSchema).optional(),
+  suggestedAlternatives: z.array(placementAlternativeSchema).optional(),
+  failure: z
+    .object({
+      code: z.literal('NO_FEASIBLE_POSITION'),
+      unsatisfiedConstraints: z.array(z.string()),
+      searchedCandidates: z.number().int().nonnegative(),
+    })
+    .optional(),
+  // select-safe-region mode
+  feasible: z.boolean().optional(),
+  preference: z.string().optional(),
+  candidate: placementCandidateSchema.optional(),
+  check: placementCheckResultSchema.optional(),
+  rationale: z.array(z.string()).optional(),
 });
 
 const functionalLayoutOutputSchema = z.object({
@@ -838,6 +936,66 @@ export function registerSchematicLayoutTools(
         a3FallbackAllowed: values.allowA3Fallback,
         hardKeepouts: values.hardKeepouts,
         constraints: values.constraints,
+      });
+    },
+  });
+
+  registry.register({
+    name: 'easyeda_schematic_check_placement',
+    title: 'Check or find a safe schematic placement',
+    description:
+      'Validate a candidate placement (rendered bounds, clearances, conflicts, deterministic ' +
+      'alternatives) or -- when x/y are omitted -- search for a safe region of the given size, ' +
+      'against real title-block/page-border/existing-primitive constraints. Read-only, no writes.',
+    profile: 'pro',
+    evidence: ['runtime-probe', 'inferred'],
+    risk: 'low',
+    confirmWrite: false,
+    group: 'workflows',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+    inputSchema: z.object({
+      projectId: z.string().min(1),
+      candidate: z.object({
+        width: z.number().positive(),
+        height: z.number().positive(),
+        x: z.number().optional(),
+        y: z.number().optional(),
+        rotation: z.union([z.literal(0), z.literal(90), z.literal(180), z.literal(270)]).optional(),
+        preference: z
+          .enum([
+            'upper-left',
+            'upper-center',
+            'upper-right',
+            'center-left',
+            'center',
+            'center-right',
+            'lower-left',
+            'lower-center',
+            'lower-right',
+          ])
+          .optional(),
+      }),
+      reservedRegions: z.array(placementConstraintRegionSchema).optional(),
+      minimumClearance: z.number().nonnegative().optional(),
+      excludePrimitiveIds: z.array(z.string().min(1)).optional(),
+    }),
+    outputSchema: placementCheckOutputSchema,
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const values = params as {
+        projectId: string;
+        candidate: LivePlacementCandidateInput & { preference?: SafeRegionPreference };
+        reservedRegions?: PlacementConstraintRegion[];
+        minimumClearance?: number;
+        excludePrimitiveIds?: string[];
+      };
+      return gatherLivePlacementCheck(ctx, values.projectId, values.candidate, {
+        reservedRegions: values.reservedRegions,
+        minimumClearance: values.minimumClearance,
+        excludePrimitiveIds: values.excludePrimitiveIds,
       });
     },
   });

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -43,10 +43,10 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('94');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('95');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('106');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('107');
   });
 });

--- a/tests/unit/schematic-model/live-placement-check.test.ts
+++ b/tests/unit/schematic-model/live-placement-check.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { gatherLivePlacementCheck } from '../../../src/schematic-model/live-placement-check.js';
+import { type ToolContext } from '../../../src/tools/types.js';
+
+function makeCtx(bridgeCall: ReturnType<typeof vi.fn>): ToolContext {
+  return {
+    profile: 'pro',
+    bridge: {
+      connected: true,
+      call: bridgeCall,
+    },
+    config: {
+      bridgeTimeoutMs: 1000,
+      artifactDir: '.easyeda-mcp-pro/artifacts',
+      bridgeHost: 'localhost',
+      bridgePort: 3000,
+    },
+    vendors: { lcsc: null, jlcpcb: null, mouser: null, digikey: null },
+  };
+}
+
+function component(primitiveId: string, x: number, y: number, rotation = 0) {
+  return { primitiveId, reference: primitiveId, component_kind: 'part', x, y, rotation };
+}
+
+const RAW_SHEET_INFO = { page_size: { width: 1682, height: 1189 } };
+
+describe('gatherLivePlacementCheck', () => {
+  let bridgeCall: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    bridgeCall = vi.fn();
+  });
+
+  it('accepts a candidate placement with x/y in empty space', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.getSheetInfo') return RAW_SHEET_INFO;
+      if (method === 'schematic.listComponents') return { total: 0, items: [] };
+      if (method === 'schematic.primitiveBounds') return { items: [], combined: null };
+      return undefined;
+    });
+
+    const result = await gatherLivePlacementCheck(makeCtx(bridgeCall), 'proj-1', {
+      width: 50,
+      height: 30,
+      x: 100,
+      y: -200,
+    });
+
+    expect(result.mode).toBe('check-placement');
+    if (result.mode !== 'check-placement') throw new Error('unreachable');
+    expect(result.accepted).toBe(true);
+    expect(result.conflicts).toEqual([]);
+  });
+
+  it('rejects a candidate that overlaps a real existing component', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.getSheetInfo') return RAW_SHEET_INFO;
+      if (method === 'schematic.listComponents') {
+        return { total: 1, items: [component('blocker', 924, -294)] };
+      }
+      if (method === 'schematic.primitiveBounds') {
+        return {
+          items: [
+            { primitiveId: 'blocker', bounds: { minX: 924, maxX: 945, minY: -294, maxY: -285 } },
+          ],
+          combined: null,
+        };
+      }
+      return undefined;
+    });
+
+    const result = await gatherLivePlacementCheck(makeCtx(bridgeCall), 'proj-1', {
+      width: 21,
+      height: 9,
+      x: 924,
+      y: -294,
+    });
+
+    expect(result.mode).toBe('check-placement');
+    if (result.mode !== 'check-placement') throw new Error('unreachable');
+    expect(result.accepted).toBe(false);
+    expect(result.conflicts.some((c) => c.code === 'EXISTING_OBJECT_OCCUPIED')).toBe(true);
+    expect(result.conflicts.some((c) => c.regionId === 'existing:blocker')).toBe(true);
+  });
+
+  it('excludes a primitiveId from the occupied-region set', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.getSheetInfo') return RAW_SHEET_INFO;
+      if (method === 'schematic.listComponents') {
+        return { total: 1, items: [component('moving', 100, -100)] };
+      }
+      if (method === 'schematic.primitiveBounds') {
+        return {
+          items: [
+            { primitiveId: 'moving', bounds: { minX: 100, maxX: 121, minY: -100, maxY: -91 } },
+          ],
+          combined: null,
+        };
+      }
+      return undefined;
+    });
+
+    const result = await gatherLivePlacementCheck(
+      makeCtx(bridgeCall),
+      'proj-1',
+      { width: 21, height: 9, x: 100, y: -100 },
+      { excludePrimitiveIds: ['moving'] },
+    );
+
+    expect(result.mode).toBe('check-placement');
+    if (result.mode !== 'check-placement') throw new Error('unreachable');
+    expect(result.accepted).toBe(true);
+  });
+
+  it('searches for a safe region when x/y are omitted', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.getSheetInfo') return RAW_SHEET_INFO;
+      if (method === 'schematic.listComponents') return { total: 0, items: [] };
+      if (method === 'schematic.primitiveBounds') return { items: [], combined: null };
+      return undefined;
+    });
+
+    const result = await gatherLivePlacementCheck(makeCtx(bridgeCall), 'proj-1', {
+      width: 50,
+      height: 30,
+      preference: 'upper-left',
+    });
+
+    expect(result.mode).toBe('select-safe-region');
+    if (result.mode !== 'select-safe-region') throw new Error('unreachable');
+    expect(result.feasible).toBe(true);
+    expect(result.candidate).toBeDefined();
+  });
+
+  it('returns a structured no-feasible-position failure when the sheet is fully occupied', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.getSheetInfo') return RAW_SHEET_INFO;
+      if (method === 'schematic.listComponents') {
+        return { total: 1, items: [component('everything', 0, 0)] };
+      }
+      if (method === 'schematic.primitiveBounds') {
+        return {
+          items: [
+            {
+              primitiveId: 'everything',
+              bounds: { minX: -10000, maxX: 10000, minY: -10000, maxY: 10000 },
+            },
+          ],
+          combined: null,
+        };
+      }
+      return undefined;
+    });
+
+    const result = await gatherLivePlacementCheck(makeCtx(bridgeCall), 'proj-1', {
+      width: 50,
+      height: 30,
+      x: 100,
+      y: -200,
+    });
+
+    expect(result.mode).toBe('check-placement');
+    if (result.mode !== 'check-placement') throw new Error('unreachable');
+    expect(result.accepted).toBe(false);
+    expect(result.failure?.code).toBe('NO_FEASIBLE_POSITION');
+  });
+
+  it('passes caller-supplied reservedRegions and minimumClearance through', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.getSheetInfo') return RAW_SHEET_INFO;
+      if (method === 'schematic.listComponents') return { total: 0, items: [] };
+      if (method === 'schematic.primitiveBounds') return { items: [], combined: null };
+      return undefined;
+    });
+
+    const result = await gatherLivePlacementCheck(
+      makeCtx(bridgeCall),
+      'proj-1',
+      { width: 50, height: 30, x: 500, y: -500 },
+      {
+        reservedRegions: [
+          {
+            id: 'reserved',
+            kind: 'caller-reserved',
+            bounds: { x: 500, y: -500, width: 50, height: 30 },
+          },
+        ],
+        minimumClearance: 5,
+      },
+    );
+
+    expect(result.mode).toBe('check-placement');
+    if (result.mode !== 'check-placement') throw new Error('unreachable');
+    expect(result.conflicts.some((c) => c.code === 'CALLER_RESERVED_REGION')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the placement-authoring core of #243 (write-side application of accepted placements already exists via `easyeda_schematic_place_component`; this PR is the validate-before-write half the issue calls for).

Same shape as #271/#272/#273: the engine (`checkPlacement`/`selectSafeRegion` in `src/layout/placement.ts` — title-block/page-border/reserved/occupied-region conflict detection, deterministic grid-aligned alternative search, structured `NO_FEASIBLE_POSITION` failure) was already fully built and unit-tested. This PR wires it to live data.

- **New plumbing** `gatherLivePlacementCheck` (`src/schematic-model/live-placement-check.ts`): reads live sheet/title-block geometry (reusing #272's now-exported `buildEngineSheetGeometry` rather than a third divergent implementation) and real occupied regions from #271's `gatherLivePrimitiveBounds`, then either:
  - validates a specific `x`/`y` candidate via `checkPlacement`, or
  - searches for a safe region for a given `width`/`height` (+ optional `preference`) via `selectSafeRegion` when `x`/`y` are omitted.
  - Supports `excludePrimitiveIds` (for checking where to move an already-placed component without it blocking itself) and caller-supplied `reservedRegions`/`minimumClearance`.
- **New MCP tool** `easyeda_schematic_check_placement` (pro profile): read-only, no writes.

## Verification

- **Live-bridge**, against the same real 59-component design used for #271/#272/#273:
  1. Safe-region search (size only, `preference: upper-left`): the engine's own first internal candidate was correctly rejected for insufficient page-border clearance, and it found a genuinely different, valid position — not a trivial pass-through.
  2. Explicit-candidate check at a coordinate deliberately chosen to overlap a known real component (`R10` / primitiveId `ie287`): correctly rejected with `EXISTING_OBJECT_OCCUPIED` against exactly that component, with 3 deterministic alternatives returned.
- Unit: 6 new tests in `tests/unit/schematic-model/live-placement-check.test.ts` (mocked bridge) covering acceptance in empty space, rejection against a real occupied region, `excludePrimitiveIds`, safe-region search mode, a fully-occupied-sheet `NO_FEASIBLE_POSITION` failure, and caller-supplied `reservedRegions`/`minimumClearance` passthrough.
- `pnpm test:coverage`: 134 files / 1579 tests passing, global thresholds met (87.92%/75.81%/91.8%/89.57%).
- `pnpm lint`, `lint:tools`, `verify:tool-coverage` (bumped `approxToolCount`: pro 94→95, full 106→107, dev 111→112), `typecheck`, `format:check`, `build`, `build:extension`, `verify:extension`, `generate:tools-doc`, `docs:build` all pass.

## Test plan

- [x] `pnpm test:coverage` — all pass, thresholds met
- [x] `pnpm lint && pnpm lint:tools && pnpm verify:tool-coverage`
- [x] `pnpm typecheck && pnpm format:check && pnpm build && pnpm build:extension && pnpm verify:extension`
- [x] Live-bridge smoke test: forced rejection against a real known component + a real non-trivial safe-region search