### PR TITLE
test(schematic-layout-qa): determinism and componentized-gate regression tests (partial #276)

### DIFF
--- a/tests/unit/workflows/schematic-layout-qa.test.ts
+++ b/tests/unit/workflows/schematic-layout-qa.test.ts
@@ -363,4 +363,32 @@ describe('schematic layout QA', () => {
 
     expect(result.issues.map((issue) => issue.code)).toContain('LOCAL_CROWDING');
   });
+
+  it('produces byte-identical output for identical input, run twice', () => {
+    const qaInput = input([component('U1', 660, 100, 80, 40), component('R1', 100, 300, 40, 20)]);
+
+    const first = evaluateSchematicLayoutQa(qaInput);
+    const second = evaluateSchematicLayoutQa(qaInput);
+
+    expect(first).toEqual(second);
+  });
+
+  it('blocks commit on a single critical geometry violation regardless of how high the averaged overall score reads', () => {
+    // Only one of the seven scored dimensions (geometry) takes the
+    // TITLE_BLOCK_OVERLAP penalty; the other six stay at 100. A
+    // threshold check on `scores.overall` alone (e.g. "block only if
+    // overall < 50") would miss this critical violation entirely, which
+    // is exactly why `commitBlocked`/`status` are computed directly from
+    // issue severity, not derived from the averaged score. This test
+    // pins that independence; it does not assert that a high `overall`
+    // here is the intended long-term behavior -- see #276 for whether
+    // `overall` itself should weight critical issues more heavily.
+    const primitive = component('U1', 660, 100, 80, 40);
+    const result = evaluateSchematicLayoutQa(input([primitive]));
+
+    expect(result.summary.criticalIssueCodes).toContain('TITLE_BLOCK_OVERLAP');
+    expect(result.status).toBe('fail');
+    expect(result.commitBlocked).toBe(true);
+    expect(result.scores.overall).toBeGreaterThanOrEqual(80);
+  });
 });


### PR DESCRIPTION
## Summary

Partial gap analysis for #276 (schematic layout regression + golden benchmark suite) — **this does not close #276.** Findings and remaining scope below.

### What's already there

The existing manufacturing golden harness (`scripts/run-evals.mts`, `tests/fixtures/golden/`, `.github/workflows/golden-benchmark.yml`) covers BOM/board/export — it does not touch schematic-layout QA. But the layout QA engine (`src/workflows/schematic-layout-qa.ts`) and its issue-code taxonomy already cover essentially all 14 of the issue's "Required Regression Cases" (`TITLE_BLOCK_OVERLAP`, `PAGE_BOUNDARY_OVERFLOW`, `COMPONENT_OVERLAP`, `COMPONENT_TEXT_OVERLAP`/`TEXT_TEXT_OVERLAP`, `SECTION_BOX_CONFLICT`, `RELATED_COMPONENT_DISTANCE`, `EXCESSIVE_WIRE_LENGTH`/`EXCESSIVE_WHITESPACE`/`LOCAL_CROWDING`, `DETACHED_NETPORT`, `CONNECTIVITY_CHANGED_DURING_COSMETIC_EDIT`), each with existing unit-test coverage in `tests/unit/workflows/schematic-layout-qa.test.ts`. `planFunctionalLayout` also already has a determinism test (`tests/unit/layout/planner.test.ts`, "returns repeatable grid coordinates" — same input twice, `toEqual` + `layoutHash` match). These already run in normal CI (`pnpm test` in `ci.yml`) without EasyEDA Pro.

### Two genuine gaps this PR closes

1. **QA determinism was untested.** `evaluateSchematicLayoutQa` had no test proving identical input produces identical output, unlike the planner.
2. **The componentized-gate property was implicit, not asserted.** `scores.overall` is a simple average across 7 dimensions (`(geometry+readability+grouping+spacing+wiring+electrical+runtime)/7`); a single critical issue (severity penalty 35) in one dimension leaves `overall` around 90+. `commitBlocked`/`status` are correctly computed from issue severity directly, not from `overall` — but nothing proved this. Added a test pinning that a single critical `TITLE_BLOCK_OVERLAP` blocks commit regardless of a high `overall`, with a comment explaining why (a naive `overall`-threshold check would miss it).

### What's still open (not attempted here — flagging for whoever picks this back up)

- **Open design question, not resolved here:** should `overall` itself weight critical issues more heavily, or is "gate is independent of the aggregate score" the intended design? The new test pins current behavior without asserting it's the desired end state — a reviewer/maintainer call.
- **Golden Workflows (NE555, RP2040, ESP32-S3-mixed)** — the issue names these as depending on #245/#253/#258, none of which exist yet. Building fixture scaffolding for them now would be speculative and likely reworked once those land.
- **Deliberate-connectivity-change → autofix rollback regression case** — blocked on #273's autofix half, which is still unimplemented at the live-wiring level.
- **CI visual-artifact-on-failure upload, captured-runtime fixture provenance/normalization docs, bounded CI runtime/artifact-size documentation** — deferred until there's an actual golden fixture suite (Level 3) to produce artifacts from; the repo has no live EasyEDA Pro in CI, so any such wiring would only ever run on mocked data, same as the existing `golden-benchmark.yml` split.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm lint:tools`
- [x] `pnpm verify:tool-coverage`
- [x] `pnpm test` (1581/1581 passing)
- [x] `pnpm build`
- [x] `pnpm check:metadata`

Refs #276.
