### PR TITLE
test(ne555-astable): golden regression tests for title-block clearance and uniqueness (partial #245)

### DIFF
--- a/tests/unit/workflows/ne555-astable-template.test.ts
+++ b/tests/unit/workflows/ne555-astable-template.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildNe555AstableTemplate,
   calculateNe555Astable,
+  NE555_ASTABLE_CONTENT,
 } from '../../../src/workflows/ne555-astable-template.js';
 
 const deviceItem = { libraryUuid: 'lib-1', uuid: 'dev-1' };
@@ -114,5 +115,47 @@ describe('NE555 astable template', () => {
     const led = result.workflowInput.components?.find((c) => c.ref === 'D1');
     expect(led?.pinConnections).toContainEqual({ pin: 'A', netName: 'LED_A' });
     expect(led?.pinConnections).toContainEqual({ pin: 'K', netName: 'GND' });
+  });
+
+  it('golden: reserves a title-block-clear region and keeps every component offset inside it', () => {
+    // Partial regression guard for #245's "prevents title-block overlap"
+    // criterion. This proves the reserved bounding box (NE555_ASTABLE_CONTENT)
+    // never overlaps the title-block keep-out, and that no component's
+    // placementOffset literal has drifted outside that declared box. It does
+    // NOT prove the template's interior is collision-free -- the template
+    // hard-codes placementOffset dx/dy per component instead of running them
+    // through the shared planFunctionalLayout engine (#272), so there are no
+    // per-component rendered bounds to check text/body overlap against here.
+    // See #245 for that open gap.
+    const result = buildNe555AstableTemplate({ projectId: 'proj-555', devices });
+
+    expect(result.safeRegion.blocked).toBe(false);
+    expect(result.safeRegion.issues).toEqual([]);
+    expect(result.safeRegion.bounds.width).toBe(NE555_ASTABLE_CONTENT.width);
+    expect(result.safeRegion.bounds.height).toBe(NE555_ASTABLE_CONTENT.height);
+
+    for (const component of result.workflowInput.components ?? []) {
+      const offset = component.placementOffset;
+      expect(offset).toBeDefined();
+      expect(offset!.dx).toBeGreaterThanOrEqual(0);
+      expect(offset!.dx).toBeLessThanOrEqual(NE555_ASTABLE_CONTENT.width);
+      expect(offset!.dy).toBeLessThanOrEqual(0);
+      expect(offset!.dy).toBeGreaterThanOrEqual(-NE555_ASTABLE_CONTENT.height);
+    }
+  });
+
+  it('golden: never assigns two different logical nets or two components the same name', () => {
+    // Regression guard for #245's "prevents ... duplicate net-name warnings"
+    // acceptance criterion, at the data level this template controls.
+    const result = buildNe555AstableTemplate({ projectId: 'proj-555', devices });
+
+    const netNames = Object.values(result.nets);
+    expect(new Set(netNames).size).toBe(netNames.length);
+
+    const refs = Object.values(result.refs);
+    expect(new Set(refs).size).toBe(refs.length);
+
+    const refsFromComponents = (result.workflowInput.components ?? []).map((c) => c.ref);
+    expect(new Set(refsFromComponents).size).toBe(refsFromComponents.length);
   });
 });


### PR DESCRIPTION
## Summary

Partial gap analysis for #245 (NE555 astable LED flasher template) — **this does not close #245.**

### What's already there

`src/workflows/ne555-astable-template.ts` + the `easyeda_workflow_ne555_astable` MCP tool (`src/tools/L2_workflows.ts`) already satisfy most of the issue's acceptance criteria: deterministic template, explicit `deviceItem` overrides per component, all 7 required nets (VCC/GND/DISCH/TIMING/CTRL/OUT/LED_A) routed with explicit pin-to-net connectivity, `confirmWrite`-gated apply, and optional post-write QA (`runPostWriteQa`) that already runs native DRC/ERC *and* the shared `evaluateSchematicLayoutQa` engine (#244) plus support-component distance checks. None of that needed changes.

### The two criteria this PR closes

Added `tests/unit/workflows/ne555-astable-template.test.ts` golden regression tests:
1. The reserved content box (`NE555_ASTABLE_CONTENT`) never overlaps the title-block keep-out, and every component's `placementOffset` literal stays inside that declared box — catching drift that would silently escape the existing keep-out check.
2. Every logical net name and every component reference the template assigns is unique.

### The real gap this PR does not attempt

**Acceptance criterion "use a layout planner instead of hard-coded unsafe coordinates" is not met.** The template hard-codes a fixed `placementOffset: { dx, dy }` literal per component; it only calls `planSafeSchematicRegion` to pick a safe *anchor* for the whole block, never `planFunctionalLayout` (the shared, collision-aware planner #272 built for exactly this). Two concrete consequences:
- The template has no per-component rendered bounds, so nothing can detect component-to-component or text overlap *inside* the block — only that the outer reserved box clears the title block. (My new tests are scoped to that outer-box property; they do not claim the interior is collision-free — see the comment on the first new test.)
- The template is blind to other components already on the sheet elsewhere — `planSafeSchematicRegion` has no `existingOccupiedRegions` concept, unlike the live #272/#243 planning path (`gatherLiveFunctionalLayoutPlan`), so applying this template onto a non-empty sheet could still collide with unrelated existing content.

Migrating the template to build `FunctionalLayoutComponent[]` (role/blockId/renderedSize) and call `planFunctionalLayout`/`gatherLiveFunctionalLayoutPlan` would close this properly, but changes the tool's coordinate-output shape and needs live-bridge verification given `confirmWrite: true` — scoping that as a separate follow-up rather than bundling it here.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm lint:tools`
- [x] `pnpm verify:tool-coverage`
- [x] `pnpm test` (1581/1581 passing)
- [x] `pnpm build`
- [x] `pnpm check:metadata`

Refs #245.
