### PR TITLE
fix(ne555-astable): stop createWireStubs from crashing every live apply (partial #253)

### DIFF
--- a/src/workflows/ne555-wire-stubs.ts
+++ b/src/workflows/ne555-wire-stubs.ts
@@ -1,6 +1,23 @@
 import type { WorkflowWireInput } from './types.js';
 import type { Ne555AstableNets, Ne555AstableRefs } from './ne555-astable-template.js';
 
+/**
+ * Short, per-pin visual wire stubs for the NE555 astable template.
+ *
+ * Each of U1's 8 pins gets a single 15-unit stub pointing away from the
+ * shared pin column (left side pins 1-4 stub left, right side pins 5-8 stub
+ * right) rather than a long bus/junction route. An earlier version tried to
+ * route full VCC/GND rails and DISCH/TIMING/CTRL/OUT junctions all the way
+ * back to U1's pins; because pins 1-4 all exit at the same x-column (and 5-8
+ * at another), any two of those long routes shared that column for more
+ * than a single point and tripped EasyEDA's same-coordinate net-collision
+ * guard the moment a live apply actually tried to draw them (see #253) --
+ * this was never caught before because `createWireStubs` had no live/golden
+ * coverage. Short, pin-local stubs are collision-free by construction: they
+ * never re-visit another pin's column or another net's rail/junction. Exact
+ * pin-to-net connectivity is created by connectPinToNet regardless -- these
+ * stubs are a readability aid, not the electrical connection.
+ */
 export function buildNe555VisibleWireStubs(
   anchor: { x: number; y: number },
   refs: Ne555AstableRefs,
@@ -18,7 +35,8 @@ export function buildNe555VisibleWireStubs(
     });
   };
 
-  // 1. VCC Rail (+5V) and connections
+  // VCC rail and non-U1-pin connections (safe: none of these share a column
+  // or row with each other or with the short U1 pin stubs below).
   route(`${refs.timer}-vcc-rail`, nets.vcc, [
     { dx: 80, dy: -40 },
     { dx: 450, dy: -40 },
@@ -27,20 +45,12 @@ export function buildNe555VisibleWireStubs(
     { dx: 100, dy: -70 },
     { dx: 100, dy: -40 },
   ]);
-  route(`${refs.timer}-pin4-reset-vcc`, nets.vcc, [
-    { dx: 225, dy: -165 },
-    { dx: 225, dy: -40 },
-  ]);
-  route(`${refs.timer}-pin8-vcc`, nets.vcc, [
-    { dx: 335, dy: -135 },
-    { dx: 335, dy: -40 },
-  ]);
   route(`${refs.cDecouple}-pin1-vcc`, nets.vcc, [
     { dx: 370, dy: -65 },
     { dx: 370, dy: -40 },
   ]);
 
-  // 2. GND Rail (GND) and connections
+  // GND rail and non-U1-pin connections.
   route(`${refs.timer}-gnd-rail`, nets.gnd, [
     { dx: 80, dy: -280 },
     { dx: 580, dy: -280 },
@@ -49,73 +59,75 @@ export function buildNe555VisibleWireStubs(
     { dx: 140, dy: -250 },
     { dx: 140, dy: -280 },
   ]);
-  route(`${refs.timer}-pin1-gnd`, nets.gnd, [
-    { dx: 225, dy: -135 },
-    { dx: 225, dy: -280 },
-  ]);
   route(`${refs.cCtrl}-pin2-gnd`, nets.gnd, [
     { dx: 410, dy: -245 },
     { dx: 410, dy: -280 },
   ]);
   route(`${refs.cDecouple}-pin2-gnd`, nets.gnd, [
     { dx: 410, dy: -65 },
-    { dx: 410, dy: -280 },
+    { dx: 410, dy: -80 },
   ]);
-  route(`${refs.led}-pin2-gnd`, nets.gnd, [
-    { dx: 580, dy: -150 },
-    { dx: 580, dy: -280 },
-  ]);
+  // No dedicated LED-cathode-to-GND stub: D1's two pins sit close enough
+  // together that every coordinate tried here landed on the runtime's own
+  // auto-drawn stub for D1's anode pin (a different net), which the bridge
+  // correctly refuses to short together (see the collision-avoidance test
+  // below). connectPinToNet still makes the real electrical connection;
+  // `${refs.rLed}-${refs.led}-anode` still shows D1's anode side visually.
 
-  // 3. Discharge Node (DISCH)
+  // Discharge/timing junction between R1/R2/C1 (safe: local to that cluster).
   route(`${refs.r1}-${refs.r2}-disch`, nets.discharge, [
     { dx: 140, dy: -70 },
     { dx: 140, dy: -112 },
     { dx: 100, dy: -112 },
     { dx: 100, dy: -155 },
   ]);
-  route(`${refs.timer}-pin7-disch`, nets.discharge, [
-    { dx: 335, dy: -145 },
-    { dx: 120, dy: -145 },
-    { dx: 120, dy: -112 },
-  ]);
-
-  // 4. Timing Node (TIMING)
   route(`${refs.r2}-${refs.cTiming}-timing`, nets.timing, [
     { dx: 140, dy: -155 },
     { dx: 140, dy: -202 },
     { dx: 100, dy: -202 },
     { dx: 100, dy: -250 },
   ]);
-  route(`${refs.timer}-pin6-thresh`, nets.timing, [
-    { dx: 335, dy: -155 },
-    { dx: 335, dy: -202 },
-    { dx: 120, dy: -202 },
-  ]);
-  route(`${refs.timer}-pin2-trig`, nets.timing, [
-    { dx: 225, dy: -145 },
-    { dx: 225, dy: -202 },
-    { dx: 120, dy: -202 },
-  ]);
 
-  // 5. Control bypass Node (CTRL)
-  route(`${refs.timer}-pin5-ctrl`, nets.control, [
-    { dx: 335, dy: -165 },
-    { dx: 370, dy: -165 },
-    { dx: 370, dy: -245 },
-  ]);
-
-  // 6. Output Node (OUT)
-  route(`${refs.timer}-pin3-out`, nets.output, [
-    { dx: 225, dy: -155 },
-    { dx: 225, dy: -190 },
-    { dx: 450, dy: -190 },
-    { dx: 450, dy: -150 },
-  ]);
-
-  // 7. LED Anode (LED_A)
+  // LED anode chain.
   route(`${refs.rLed}-${refs.led}-anode`, nets.ledAnode, [
     { dx: 490, dy: -150 },
     { dx: 540, dy: -150 },
+  ]);
+
+  // U1 pin stubs: left column (pins 1-4, x=225) stub left to x=210; right
+  // column (pins 5-8, x=335) stub right to x=350. Every stub sits at that
+  // pin's own y, so no two stubs (left or right) ever share a coordinate.
+  route(`${refs.timer}-pin1-gnd-stub`, nets.gnd, [
+    { dx: 225, dy: -135 },
+    { dx: 210, dy: -135 },
+  ]);
+  route(`${refs.timer}-pin2-trig-stub`, nets.timing, [
+    { dx: 225, dy: -145 },
+    { dx: 210, dy: -145 },
+  ]);
+  route(`${refs.timer}-pin3-out-stub`, nets.output, [
+    { dx: 225, dy: -155 },
+    { dx: 210, dy: -155 },
+  ]);
+  route(`${refs.timer}-pin4-reset-vcc-stub`, nets.vcc, [
+    { dx: 225, dy: -165 },
+    { dx: 210, dy: -165 },
+  ]);
+  route(`${refs.timer}-pin5-ctrl-stub`, nets.control, [
+    { dx: 335, dy: -165 },
+    { dx: 350, dy: -165 },
+  ]);
+  route(`${refs.timer}-pin6-thresh-stub`, nets.timing, [
+    { dx: 335, dy: -155 },
+    { dx: 350, dy: -155 },
+  ]);
+  route(`${refs.timer}-pin7-disch-stub`, nets.discharge, [
+    { dx: 335, dy: -145 },
+    { dx: 350, dy: -145 },
+  ]);
+  route(`${refs.timer}-pin8-vcc-stub`, nets.vcc, [
+    { dx: 335, dy: -135 },
+    { dx: 350, dy: -135 },
   ]);
 
   return wires;

--- a/tests/unit/workflows/ne555-astable-template.test.ts
+++ b/tests/unit/workflows/ne555-astable-template.test.ts
@@ -54,7 +54,7 @@ describe('NE555 astable template', () => {
       createWireStubs: true,
     });
 
-    expect(result.workflowInput.wires).toHaveLength(19);
+    expect(result.workflowInput.wires).toHaveLength(18);
   });
 
   it('wires NE555 pins to the correct astable nets', () => {

--- a/tests/unit/workflows/ne555-wire-stubs.test.ts
+++ b/tests/unit/workflows/ne555-wire-stubs.test.ts
@@ -35,7 +35,7 @@ describe('buildNe555VisibleWireStubs', () => {
 
   it('produces the expected total number of routed guide wires', () => {
     const wires = buildNe555VisibleWireStubs(anchor, DEFAULT_REFS, DEFAULT_NETS);
-    expect(wires).toHaveLength(19);
+    expect(wires).toHaveLength(18);
   });
 
   it('every wire stub has at least 2 points', () => {
@@ -164,5 +164,51 @@ describe('buildNe555VisibleWireStubs', () => {
     for (const wire of wires) {
       expect(wire.lineWidth).toBe(1);
     }
+  });
+
+  it('golden: no two different-net wire stubs ever share an exact coordinate', () => {
+    // Regression guard for #253's live-apply failure: EasyEDA Pro auto-merges
+    // any two primitives that share an exact (x, y) once either is wired,
+    // shorting the two nets together. The bridge's own NET_COLLISION guard
+    // rejects the write outright when this happens (see
+    // easyeda-bridge-extension/src/dispatcher.ts), so a colliding stub table
+    // makes createWireStubs unconditionally fail on live apply -- unit tests
+    // never caught it because none of them checked point-level geometry
+    // across different nets. This walks every orthogonal segment as its full
+    // set of integer lattice points (matching how the bridge's collision
+    // check treats a drawn wire) and asserts no two segments belonging to
+    // different nets ever intersect.
+    const wires = buildNe555VisibleWireStubs(anchor, DEFAULT_REFS, DEFAULT_NETS);
+
+    const segmentPoints = (a: { x: number; y: number }, b: { x: number; y: number }) => {
+      const points: string[] = [];
+      if (a.x === b.x) {
+        const [lo, hi] = a.y <= b.y ? [a.y, b.y] : [b.y, a.y];
+        for (let y = lo; y <= hi; y++) points.push(`${a.x},${y}`);
+      } else if (a.y === b.y) {
+        const [lo, hi] = a.x <= b.x ? [a.x, b.x] : [b.x, a.x];
+        for (let x = lo; x <= hi; x++) points.push(`${x},${a.y}`);
+      } else {
+        throw new Error(`non-orthogonal segment ${JSON.stringify(a)} -> ${JSON.stringify(b)}`);
+      }
+      return points;
+    };
+
+    const pointToNets = new Map<string, Set<string>>();
+    for (const wire of wires) {
+      const occupied = new Set<string>();
+      for (let i = 1; i < wire.points.length; i++) {
+        for (const key of segmentPoints(wire.points[i - 1], wire.points[i])) {
+          occupied.add(key);
+        }
+      }
+      for (const key of occupied) {
+        if (!pointToNets.has(key)) pointToNets.set(key, new Set());
+        pointToNets.get(key)!.add(wire.netName);
+      }
+    }
+
+    const collisions = [...pointToNets.entries()].filter(([, nets]) => nets.size > 1);
+    expect(collisions).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

Live-tested `easyeda_workflow_ne555_astable` with `createWireStubs: true` against a real blank EasyEDA Pro project (with the user's explicit approval to write there) — **this does not close #253.**

### The bug

The wire-stub routing tried to draw long "bus" wires (VCC/GND rails, DISCH/TIMING/CTRL/OUT junction rows) all the way back to U1's individual pins. U1's pins 1-4 all exit at the same x-column and pins 5-8 at another; any two of those long routes shared that column for more than a single point. A static check (`scripts` in this PR's history, not committed) found **14 cross-net coordinate collisions** in the old table. Live apply confirmed it: the very first real write hit `NET_COLLISION` and rolled back cleanly (no bad state left — the transaction safety worked correctly), but `createWireStubs` was **unconditionally broken** for any real use. No prior test caught this because nothing checked point-level geometry across different nets — only wire *count* was asserted.

### The fix

Replaced the long-bus routing with short (15-unit) per-pin stubs that never revisit another pin's column or another net's rail/junction — collision-free by construction, and now guarded by a new regression test (`tests/unit/workflows/ne555-wire-stubs.test.ts`, "golden: no two different-net wire stubs ever share an exact coordinate") that walks every segment as its full set of lattice points, matching how the bridge's own collision check treats a drawn wire.

One more collision surfaced only on live apply: a stub near D1 (LED cathode-to-GND) landed on the *runtime's own auto-drawn stub* for D1's anode pin — a collision source no static check can predict without live rendered bounds. Removed that one specific stub (D1's cathode connection is still made electrically via `connectPinToNet`; only the decorative wire is gone).

### Live verification

On a blank project (`easyeda_schematic_components` confirmed 0 components before/after cleanup):
- Apply succeeded: `applied: true, rolled_back: false`.
- `easyeda_schematic_components` read back all 8 components correctly placed with real NE555/R/C/LED devices.
- `easyeda_schematic_nets` read back 7 nets with correct node counts (22 total, matching the 22 `connectPinToNet` calls).
- A full-page capture (`allowInferredA4: true` — see caveat below) visually confirmed the expected functional grouping: NE555 roughly centered, timing network (R1/R2/C1) grouped left, output chain (R3/LED1) right, no overlapping geometry.

### What this does not fix (out of scope here)

- **#253's core ask** (visible long-bus routing showing functional connectivity, not just short stubs) is not attempted. That needs real per-component rendered bounds to route around safely — the same underlying gap already identified in #245 (the template hard-codes placement instead of using the shared `planFunctionalLayout` engine). Short stubs are functionally the same tier the issue's own 0.30.0 follow-up comment already called "cleaner but not fully professional."
- **A separate, unrelated bug found during this verification:** `collectSchematicLayoutQa` (which every `confirmWrite` workflow tool's `runPostWriteQa` depends on) never successfully resolves component references — it calls `schematic.primitiveBounds` without the `primitiveIds` parameter (unlike the correct pattern in `gatherLivePrimitiveBounds`), and even when that's fixed, `schematic.primitiveBounds`'s response has no reference-designator field to cross-reference against `expectedComponentRefs`. Live evidence: `easyeda_schematic_layout_qa`'s `EXPECTED_NET_MISMATCH` reported every one of the 8 real, correctly-wired components as "missing," while a direct `easyeda_schematic_components` call in the same session showed them all present with correct `reference` fields. This affects post-write QA across the whole workflow-tool surface (block/power-rail/decouple/connector-breakout/LED-blinker/NE555), not just this template — filing it as its own issue rather than fixing it here given that blast radius.
- The full-page capture required `allowInferredA4: true` (runtime sheet-geometry detection failed for this specific project) — not investigated further, noted for awareness only.
- One test device I selected during live testing (`0805W8F3301T5E`, decodes to 3.3kΩ) doesn't match the template's intended 330Ω for R3 — my own part-selection mistake during manual testing, not a code defect; not touched here.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm lint:tools`
- [x] `pnpm verify:tool-coverage`
- [x] `pnpm test` (1585/1585 passing)
- [x] `pnpm build`
- [x] `pnpm check:metadata`
- [x] Live-verified against a real blank EasyEDA Pro project (see above)

Refs #253.
