### PR TITLE
fix(schematic-layout-qa): resolve component refs from listComponents, not primitiveBounds

### DIFF
--- a/src/tools/L2_schematic_layout.ts
+++ b/src/tools/L2_schematic_layout.ts
@@ -20,6 +20,7 @@ import { createConnectivityFingerprint } from '../schematic-model/connectivity-f
 import { buildSchematicModel } from '../schematic-model/model-builder.js';
 import { gatherLiveSchematicSnapshot } from '../schematic-model/live-snapshot.js';
 import { gatherLivePrimitiveBounds } from '../schematic-model/live-primitive-bounds.js';
+import type { PrimitiveBoundsResult } from '../schematic-model/primitive-bounds.js';
 import {
   gatherLiveFunctionalLayoutPlan,
   type LiveFunctionalLayoutComponentInput,
@@ -476,10 +477,6 @@ function numberValue(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
 }
 
-function booleanValue(value: unknown): boolean | undefined {
-  return typeof value === 'boolean' ? value : undefined;
-}
-
 function bounds(value: unknown): LayoutQaBounds | undefined {
   const item = record(value);
   const x = numberValue(item.x ?? item.left);
@@ -520,36 +517,79 @@ function normalizeGeometrySource(value: unknown): LayoutQaPrimitive['geometrySou
   return 'derived';
 }
 
-function primitiveItems(result: unknown): unknown[] {
-  if (Array.isArray(result)) return result;
-  const root = record(result);
-  for (const key of ['items', 'primitives', 'bounds', 'results']) {
-    if (Array.isArray(root[key])) return root[key];
+/**
+ * schematic.primitiveBounds is a pure-geometry endpoint keyed by internal
+ * primitiveId -- it has no reference-designator string field at all (the
+ * `reference` key it does carry is the bounds of the reference-designator
+ * *text label*, not a "U1"-style string). QA's expected-component/pin
+ * matching needs real ref strings, so cross-reference against
+ * schematic.listComponents separately rather than guessing a ref out of the
+ * bounds response (see #288).
+ */
+async function fetchPrimitiveIdToRef(
+  ctx: ToolContext,
+  projectId: string,
+): Promise<Map<string, string>> {
+  const refById = new Map<string, string>();
+  const pageSize = 500;
+  let offset = 0;
+  for (;;) {
+    let page: { items?: Array<{ primitiveId?: string; reference?: string }>; total?: number };
+    try {
+      page = (await ctx.bridge.call('schematic.listComponents', {
+        projectId,
+        limit: pageSize,
+        offset,
+      })) as typeof page;
+    } catch {
+      break;
+    }
+    const items = page?.items ?? [];
+    for (const item of items) {
+      if (item.primitiveId && item.reference) refById.set(item.primitiveId, item.reference);
+    }
+    offset += items.length;
+    const total = page?.total ?? items.length;
+    if (items.length === 0 || offset >= total) break;
   }
-  return [];
+  return refById;
 }
 
-function normalizePrimitive(itemValue: unknown): LayoutQaPrimitive | undefined {
-  const item = record(itemValue);
-  const combined = bounds(item.combinedBounds ?? item.combined_bounds ?? item.bounds);
-  const id = stringValue(item.id ?? item.primitiveId ?? item.primitive_id);
-  if (!combined || !id) return undefined;
+async function gatherLivePrimitiveBoundsSafely(
+  ctx: ToolContext,
+  projectId: string,
+): Promise<{ available: boolean; result: PrimitiveBoundsResult[]; error?: string }> {
+  try {
+    const batch = await gatherLivePrimitiveBounds(ctx, projectId);
+    return { available: true, result: batch.items };
+  } catch (error) {
+    return {
+      available: false,
+      result: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function normalizePrimitiveBoundsResult(
+  item: PrimitiveBoundsResult,
+  ref: string | undefined,
+): LayoutQaPrimitive | undefined {
+  const combined = bounds(item.combinedBounds);
+  if (!combined) return undefined;
   return {
-    id,
-    primitiveType: normalizePrimitiveType(item.primitiveType ?? item.primitive_type ?? item.type),
-    ref: stringValue(item.ref ?? item.reference ?? item.designator),
-    netName: stringValue(item.netName ?? item.net_name ?? item.net),
-    blockId: stringValue(item.blockId ?? item.block_id),
+    id: item.id,
+    primitiveType: normalizePrimitiveType(item.primitiveType),
+    ref,
     combinedBounds: combined,
-    bodyBounds: bounds(item.bodyBounds ?? item.body_bounds),
-    referenceBounds: bounds(item.referenceBounds ?? item.reference_bounds),
-    valueBounds: bounds(item.valueBounds ?? item.value_bounds),
-    pinTextBounds: boundsArray(item.pinTextBounds ?? item.pin_text_bounds),
-    labelBounds: boundsArray(item.labelBounds ?? item.label_bounds),
-    annotationBounds: boundsArray(item.annotationBounds ?? item.annotation_bounds),
-    connected: booleanValue(item.connected),
-    rotation: numberValue(item.rotation),
-    geometrySource: normalizeGeometrySource(item.geometrySource ?? item.geometry_source),
+    bodyBounds: bounds(item.body?.bounds),
+    referenceBounds: bounds(item.reference?.bounds),
+    valueBounds: bounds(item.value?.bounds),
+    pinTextBounds: boundsArray(item.pinTexts?.map((segment) => segment.bounds)),
+    labelBounds: boundsArray(item.labels?.map((segment) => segment.bounds)),
+    annotationBounds: boundsArray(item.annotations?.map((segment) => segment.bounds)),
+    rotation: item.rotation,
+    geometrySource: normalizeGeometrySource(item.geometrySource),
   };
 }
 
@@ -669,8 +709,9 @@ export async function collectSchematicLayoutQa(
     height: Math.max(0, sheet.height - margin * 2),
   };
 
-  const [boundsRead, netsRead, wiresRead, drcRead, ercRead] = await Promise.all([
-    optionalBridgeCall(ctx, 'schematic.primitiveBounds', { projectId }),
+  const [boundsRead, refByPrimitiveId, netsRead, wiresRead, drcRead, ercRead] = await Promise.all([
+    gatherLivePrimitiveBoundsSafely(ctx, projectId),
+    fetchPrimitiveIdToRef(ctx, projectId),
     optionalBridgeCall(ctx, 'schematic.listNets', { projectId }),
     optionalBridgeCall(ctx, 'system.inspectWires', { projectId, limit: 10_000, offset: 0 }),
     optionalBridgeCall(ctx, 'design.drc', { projectId }),
@@ -678,8 +719,8 @@ export async function collectSchematicLayoutQa(
   ]);
 
   const pinsByRef = netPinMap(netsRead.result);
-  const primitives = primitiveItems(boundsRead.result)
-    .map(normalizePrimitive)
+  const primitives = boundsRead.result
+    .map((item) => normalizePrimitiveBoundsResult(item, refByPrimitiveId.get(item.id)))
     .filter((item): item is LayoutQaPrimitive => Boolean(item))
     .map((primitive) => {
       const pins = primitive.ref ? pinsByRef.get(primitive.ref) : undefined;

--- a/tests/unit/tools/schematic-layout.test.ts
+++ b/tests/unit/tools/schematic-layout.test.ts
@@ -26,16 +26,26 @@ describe('schematic layout tools', () => {
       switch (method) {
         case 'schematic.getSheetInfo':
           return { pageSize: { width: 1000, height: 700, unit: 'mil' } };
+        case 'schematic.listComponents':
+          return {
+            total: 1,
+            items: [
+              {
+                primitiveId: 'component-u1',
+                reference: 'U1',
+                component_kind: 'part',
+                x: 100,
+                y: 200,
+                rotation: 0,
+              },
+            ],
+          };
         case 'schematic.primitiveBounds':
           return {
             items: [
               {
-                id: 'component-u1',
-                primitiveType: 'component',
-                ref: 'U1',
-                combinedBounds: { x: 100, y: 200, width: 80, height: 60 },
-                bodyBounds: { x: 100, y: 200, width: 80, height: 60 },
-                geometrySource: 'runtime',
+                primitiveId: 'component-u1',
+                bounds: { minX: 100, maxX: 180, minY: 200, maxY: 260 },
               },
             ],
           };
@@ -75,7 +85,7 @@ describe('schematic layout tools', () => {
       },
     });
     expect(bridgeCall).toHaveBeenCalledWith('schematic.primitiveBounds', {
-      projectId: 'project-1',
+      primitiveIds: ['component-u1'],
     });
   });
 
@@ -83,15 +93,26 @@ describe('schematic layout tools', () => {
     bridgeCall.mockImplementation(async (method: string) => {
       if (method === 'schematic.getSheetInfo')
         return { pageSize: { width: 1000, height: 700, unit: 'mil' } };
+      if (method === 'schematic.listComponents')
+        return {
+          total: 1,
+          items: [
+            {
+              primitiveId: 'component-u1',
+              reference: 'U1',
+              component_kind: 'part',
+              x: 530,
+              y: 100,
+              rotation: 0,
+            },
+          ],
+        };
       if (method === 'schematic.primitiveBounds')
         return {
           items: [
             {
-              id: 'component-u1',
-              primitiveType: 'component',
-              ref: 'U1',
-              combinedBounds: { x: 530, y: 100, width: 80, height: 80 },
-              geometrySource: 'runtime',
+              primitiveId: 'component-u1',
+              bounds: { minX: 530, maxX: 610, minY: 100, maxY: 180 },
             },
           ],
         };
@@ -109,6 +130,59 @@ describe('schematic layout tools', () => {
 
     expect(result?.status).toBe('fail');
     expect(result?.summary.criticalIssueCodes).toContain('TITLE_BLOCK_OVERLAP');
+  });
+
+  it('resolves component references from schematic.listComponents, not from schematic.primitiveBounds (#288)', async () => {
+    // Regression guard: schematic.primitiveBounds is a pure-geometry endpoint
+    // keyed by internal primitiveId -- its response never carries a "U1"-style
+    // reference string (this mock deliberately omits one, matching the real
+    // bridge shape). Live evidence showed a prior version of this code path
+    // tried to read a ref straight off that response and always got
+    // `undefined`, so every expected component was reported missing even
+    // when the write genuinely succeeded. The fix cross-references
+    // schematic.listComponents (which does carry `.reference`) by
+    // primitiveId instead.
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.getSheetInfo')
+        return { pageSize: { width: 1000, height: 700, unit: 'mil' } };
+      if (method === 'schematic.listComponents')
+        return {
+          total: 1,
+          items: [
+            {
+              primitiveId: 'component-u1',
+              reference: 'U1',
+              component_kind: 'part',
+              x: 100,
+              y: 200,
+              rotation: 0,
+            },
+          ],
+        };
+      if (method === 'schematic.primitiveBounds')
+        return {
+          items: [
+            {
+              primitiveId: 'component-u1',
+              bounds: { minX: 100, maxX: 180, minY: 200, maxY: 260 },
+            },
+          ],
+        };
+      if (method === 'schematic.listNets')
+        return [{ netName: 'GND', nodes: [{ component: 'U1', pin: '1' }] }];
+      if (method === 'system.inspectWires') return { samples: [] };
+      if (method === 'design.drc' || method === 'design.erc') return { violations: [] };
+      throw new Error(`Unexpected method ${method}`);
+    });
+
+    const result = await registry.get('easyeda_schematic_layout_qa')?.handler(context, {
+      projectId: 'project-1',
+      expectedComponentRefs: ['U1'],
+      expectedPinMappings: [{ componentRef: 'U1', pin: '1', netName: 'GND' }],
+    });
+
+    const codes = result?.issues.map((issue: { code: string }) => issue.code) ?? [];
+    expect(codes).not.toContain('EXPECTED_NET_MISMATCH');
   });
 
   it('does not pass when complete rendered bounds are unavailable', async () => {

--- a/tests/unit/tools/workflows.test.ts
+++ b/tests/unit/tools/workflows.test.ts
@@ -127,16 +127,29 @@ describe('Workflow Tools', () => {
           return { primitiveId: `wire-${bridgeCall.mock.calls.length}` };
         if (method === 'schematic.createNetPort')
           return { primitiveId: `net-${bridgeCall.mock.calls.length}` };
-        if (method === 'schematic.listComponents') return { total: 8, items: [] };
+        if (method === 'schematic.listComponents') {
+          return {
+            total: Object.keys(placedBounds).length,
+            items: Object.keys(placedBounds).map((ref) => ({
+              primitiveId: `component-${ref}`,
+              reference: ref,
+              component_kind: 'part',
+              x: placedBounds[ref]!.x,
+              y: placedBounds[ref]!.y,
+              rotation: 0,
+            })),
+          };
+        }
         if (method === 'schematic.primitiveBounds') {
           return {
             items: Object.entries(placedBounds).map(([ref, bounds]) => ({
-              id: `component-${ref}`,
-              primitiveType: 'component',
-              ref,
-              combinedBounds: bounds,
-              bodyBounds: bounds,
-              geometrySource: 'runtime',
+              primitiveId: `component-${ref}`,
+              bounds: {
+                minX: bounds.x,
+                maxX: bounds.x + bounds.width,
+                minY: bounds.y,
+                maxY: bounds.y + bounds.height,
+              },
             })),
           };
         }


### PR DESCRIPTION
Closes #288

## Summary

`collectSchematicLayoutQa` — the shared function every `confirmWrite` workflow tool's `runPostWriteQa` option depends on — always reported every expected component as "missing" and every pin as "on no net," regardless of whether the write actually succeeded.

Root cause: it called `schematic.primitiveBounds` with `{projectId}` (missing the required `primitiveIds` array), and even if that were fixed, `schematic.primitiveBounds`'s response has no reference-designator string field at all — it's a pure-geometry endpoint keyed by internal `primitiveId`. `normalizePrimitive()` tried `item.ref ?? item.reference ?? item.designator`, but the response's `reference` key (when present) is a *bounds sub-object* for the reference-designator text label, not a string, so `ref` was always `undefined`. Matching against `expectedComponentRefs`/pin mappings then failed for every component, every time.

## Fix

- Use the existing, correctly-implemented `gatherLivePrimitiveBounds` (already used elsewhere in the codebase) for geometry instead of a raw, incorrectly-parameterized bridge call.
- Separately cross-reference `schematic.listComponents` (which does carry `.reference`) by `primitiveId` to resolve each component's real reference designator before matching against expected refs/pin mappings.
- Removed the now-dead `primitiveItems`/`normalizePrimitive` helpers that only ever parsed the broken raw shape.

## Live verification

Re-ran the exact NE555 apply from #253's verification (10 real components, including two placed during #270's testing) against the same real EasyEDA Pro project:

| | Before | After |
|---|---|---|
| `EXPECTED_NET_MISMATCH` count | 18 (every component + every pin) | 0 |
| `evidence.exactGeometry` | — | `true` |
| Remaining issues | — | Genuine only: `TITLE_BLOCK_OVERLAP` on the two components I'd placed without checking title-block position, real ERC warnings, DRC-unavailable notice |

Also updated the 3 existing unit tests that mocked the old (broken) response shape directly, and added a new dedicated regression test (`tests/unit/tools/schematic-layout.test.ts`, `'resolves component references from schematic.listComponents, not from schematic.primitiveBounds (#288)'`) that mocks `schematic.primitiveBounds` with **no** ref field at all — matching the real bridge response — to pin this specific failure mode.

## Test plan

- [x] `pnpm format:check`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm lint:tools`
- [x] `pnpm verify:tool-coverage`
- [x] `pnpm test` (1586/1586 passing)
- [x] `pnpm build`
- [x] `pnpm check:metadata`
- [x] Live-verified against a real EasyEDA Pro project (see table above)
