### PR TITLE
feat(schematic-layout): wire easyeda_schematic_layout_autofix (preview mode)

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -90,6 +90,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_schematic_create_net_flag`                | `core`  | `medium` | Create a named net flag/label. With `identification` (Power/Ground/AnalogGround/ProtectGround) it places a power-flag symbol binding to a coincident pin (use for VCC/GND). Without it, a generic net label — cosmetic only; connect pins with add_wire stubs sharing one netName.                                               |
 | `easyeda_schematic_create_net_port`                | `core`  | `medium` | Place a hierarchical net port (off-sheet connector) on the schematic. Net ports create named connections that span multiple schematic sheets, appearing as real SCH_Net entries in the netlist.                                                                                                                                  |
 | `easyeda_schematic_delete_primitive`               | `core`  | `medium` | Delete components, wires, or other drawing objects from the schematic by their primitive UUIDs.                                                                                                                                                                                                                                  |
+| `easyeda_schematic_layout_autofix`                 | `pro`   | `low`    | Detect title-block overlap, page-boundary overflow, and component-overlap violations from real rendered bounds, and propose cosmetic-only moves that resolve them. Read-only preview only (requiresConfirmWrite=true, no writes) -- confirmWrite apply with connectivity-fingerprint rollback is tracked separately (#273).      |
 | `easyeda_schematic_layout_qa`                      | `pro`   | `low`    | Run a normalized post-write QA pass combining runtime DRC/ERC, expected component/pin topology, rendered primitive bounds, title-block and page constraints, wiring/grouping checks, and connectivity fingerprints, with optional full-page visual evidence. Critical geometry or connectivity findings always block commit.     |
 | `easyeda_schematic_modify_primitive`               | `core`  | `medium` | Safely modify a schematic primitive while preserving omitted fields. With transactionId and projectId, capture before/after snapshots and automatically restore the prior state if the write or post-write read fails. Component moves keep connected wires attached.                                                            |
 | `easyeda_schematic_net_detail`                     | `core`  | `low`    | Get full details for a specific net in the schematic including all connected pins and components.                                                                                                                                                                                                                                |
@@ -2864,6 +2865,43 @@ Returns a JSON object matching the schema:
 {
   success: boolean;
   error: string(optional);
+}
+```
+
+---
+
+## `easyeda_schematic_layout_autofix`
+
+**Profile:** `pro` | **Risk Level:** `low`
+
+> Detect title-block overlap, page-boundary overflow, and component-overlap violations from real rendered bounds, and propose cosmetic-only moves that resolve them. Read-only preview only (requiresConfirmWrite=true, no writes) -- confirmWrite apply with connectivity-fingerprint rollback is tracked separately (#273).
+
+### Input Parameters
+
+| Parameter          | Type                  | Required | Description |
+| ------------------ | --------------------- | -------- | ----------- |
+| `projectId`        | `string`              | Yes      |             |
+| `allowlist`        | `object (optional)`   | No       |             |
+| `hardKeepouts`     | `object[] (optional)` | No       |             |
+| `reservedRegions`  | `object[] (optional)` | No       |             |
+| `minimumClearance` | `number (optional)`   | No       |             |
+| `maxMoves`         | `number (optional)`   | No       |             |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  projectId: string;
+  mode: 'preview';
+  requiresConfirmWrite: 'true';
+  violations: object[];
+  moves: object[];
+  report: object;
+  allowlist: object;
+  primitiveCount: number;
+  unavailablePrimitiveIds: string[];
 }
 ```
 

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -22,7 +22,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Pro',
     description:
       'Adds pick-and-place, PDF, netlist export, compound transactional workflow tools, autorouting, route-context export, and offline SPICE verification for manufacturing workflows',
-    approxToolCount: '95',
+    approxToolCount: '96',
     isDefault: false,
   },
   full: {
@@ -30,7 +30,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls and CircuitIR-driven floorplanning for full runtime control without raw JavaScript execution',
-    approxToolCount: '107',
+    approxToolCount: '108',
     isDefault: false,
   },
   dev: {
@@ -38,14 +38,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '112',
+    approxToolCount: '113',
     isDefault: false,
   },
   experimental: {
     name: 'experimental',
     label: 'Experimental',
     description: 'MCP Apps, Tasks, AI action plans',
-    approxToolCount: '105',
+    approxToolCount: '106',
     isDefault: false,
   },
 };

--- a/src/schematic-model/live-layout-autofix.ts
+++ b/src/schematic-model/live-layout-autofix.ts
@@ -1,0 +1,85 @@
+import { type ToolContext } from '../tools/types.js';
+import { gatherLivePrimitiveBounds } from './live-primitive-bounds.js';
+import { buildEngineSheetGeometry } from './live-functional-layout.js';
+import {
+  previewLayoutAutofix,
+  type LayoutAutofixAllowlist,
+  type LayoutAutofixPreview,
+  type LayoutAutofixPrimitive,
+} from '../layout/autofix.js';
+import type { PlacementConstraintRegion } from '../layout/placement.js';
+
+export interface GatherLiveLayoutAutofixPreviewOptions {
+  allowlist?: Partial<LayoutAutofixAllowlist>;
+  hardKeepouts?: readonly PlacementConstraintRegion[];
+  callerReservedRegions?: readonly PlacementConstraintRegion[];
+  minimumClearance?: number;
+  maxMoves?: number;
+}
+
+export interface LiveLayoutAutofixPreviewResult {
+  preview: LayoutAutofixPreview;
+  primitiveCount: number;
+  unavailablePrimitiveIds: string[];
+}
+
+const DEFAULT_ALLOWLIST: LayoutAutofixAllowlist = {
+  primitiveTypes: ['component'],
+  properties: ['position'],
+};
+
+/**
+ * Reads live sheet geometry and every component's real rendered bounds, then
+ * runs the pure `previewLayoutAutofix` engine against them -- read-only, no
+ * writes. `schematic.listComponents` is the only bridge source available for
+ * primitive identity, so every live primitive here is typed 'component';
+ * text/label/annotation/section-box primitives (and therefore TEXT_OVERLAP /
+ * SECTION_BOX_TOO_SMALL violations) are out of reach until the bridge exposes
+ * them independently -- same limitation already documented on
+ * easyeda_schematic_primitive_bounds.
+ */
+export async function gatherLiveLayoutAutofixPreview(
+  ctx: ToolContext,
+  projectId: string,
+  options: GatherLiveLayoutAutofixPreviewOptions = {},
+): Promise<LiveLayoutAutofixPreviewResult> {
+  const sheetInfoResult = await ctx.bridge.call<{ projectId: string }, unknown>(
+    'schematic.getSheetInfo',
+    { projectId },
+  );
+  const sheet = buildEngineSheetGeometry(sheetInfoResult);
+
+  const boundsBatch = await gatherLivePrimitiveBounds(ctx, projectId);
+  const primitives: LayoutAutofixPrimitive[] = [];
+  const unavailablePrimitiveIds: string[] = [];
+  for (const item of boundsBatch.items) {
+    if (!item.combinedBounds) {
+      unavailablePrimitiveIds.push(item.id);
+      continue;
+    }
+    primitives.push({
+      id: item.id,
+      primitiveType: 'component',
+      origin: item.origin,
+      combinedBounds: item.combinedBounds,
+      locked: false,
+    });
+  }
+
+  const allowlist: LayoutAutofixAllowlist = {
+    primitiveTypes: options.allowlist?.primitiveTypes ?? DEFAULT_ALLOWLIST.primitiveTypes,
+    properties: options.allowlist?.properties ?? DEFAULT_ALLOWLIST.properties,
+  };
+
+  const preview = previewLayoutAutofix({
+    sheet,
+    primitives,
+    allowlist,
+    hardKeepouts: options.hardKeepouts,
+    callerReservedRegions: options.callerReservedRegions,
+    minimumClearance: options.minimumClearance,
+    maxMoves: options.maxMoves,
+  });
+
+  return { preview, primitiveCount: primitives.length, unavailablePrimitiveIds };
+}

--- a/src/tools/L2_schematic_layout.ts
+++ b/src/tools/L2_schematic_layout.ts
@@ -31,6 +31,11 @@ import {
   gatherLivePlacementCheck,
   type LivePlacementCandidateInput,
 } from '../schematic-model/live-placement-check.js';
+import {
+  gatherLiveLayoutAutofixPreview,
+  type GatherLiveLayoutAutofixPreviewOptions,
+} from '../schematic-model/live-layout-autofix.js';
+import type { LayoutAutofixAllowlist } from '../layout/autofix.js';
 import { type ToolContext, type ToolDefinition } from './types.js';
 
 const boundsSchema = z.object({
@@ -335,6 +340,73 @@ const placementCheckOutputSchema = z.object({
   candidate: placementCandidateSchema.optional(),
   check: placementCheckResultSchema.optional(),
   rationale: z.array(z.string()).optional(),
+});
+
+const autofixPrimitiveTypeSchema = z.enum([
+  'component',
+  'text',
+  'label',
+  'annotation',
+  'section-box',
+  'section-title',
+  'wire',
+  'power-symbol',
+  'no-connect',
+]);
+
+const autofixPropertySchema = z.enum(['position', 'bounds']);
+
+const autofixAllowlistSchema = z.object({
+  primitiveTypes: z.array(autofixPrimitiveTypeSchema),
+  properties: z.array(autofixPropertySchema),
+});
+
+const autofixPointOrBoundsSchema = z.union([
+  z.object({ x: z.number(), y: z.number() }),
+  boundsSchema,
+]);
+
+const autofixViolationSchema = z.object({
+  id: z.string(),
+  code: z.enum([
+    'TITLE_BLOCK_OVERLAP',
+    'PAGE_BOUNDARY_OVERFLOW',
+    'COMPONENT_OVERLAP',
+    'TEXT_OVERLAP',
+    'SECTION_BOX_TOO_SMALL',
+  ]),
+  primitiveIds: z.array(z.string()),
+  message: z.string(),
+});
+
+const autofixMoveSchema = z.object({
+  id: z.string(),
+  primitiveId: z.string(),
+  primitiveType: autofixPrimitiveTypeSchema,
+  property: autofixPropertySchema,
+  from: autofixPointOrBoundsSchema,
+  to: autofixPointOrBoundsSchema,
+  reason: z.string(),
+  expectedQaImprovement: z.string(),
+  resolvesViolationIds: z.array(z.string()),
+});
+
+const autofixReportSchema = z.object({
+  fixed: z.array(z.string()),
+  skipped: z.array(z.object({ violationId: z.string(), reason: z.string() })),
+  remaining: z.array(z.string()),
+});
+
+const layoutAutofixOutputSchema = z.object({
+  projectId: z.string(),
+  mode: z.literal('preview'),
+  requiresConfirmWrite: z.literal(true),
+  violations: z.array(autofixViolationSchema),
+  moves: z.array(autofixMoveSchema),
+  report: autofixReportSchema,
+  allowlist: autofixAllowlistSchema,
+  primitiveCount: z.number().int().nonnegative(),
+  unavailablePrimitiveIds: z.array(z.string()),
 });
 
 const functionalLayoutOutputSchema = z.object({
@@ -1038,6 +1110,64 @@ export function registerSchematicLayoutTools(
         minimumClearance: values.minimumClearance,
         excludePrimitiveIds: values.excludePrimitiveIds,
       });
+    },
+  });
+
+  registry.register({
+    name: 'easyeda_schematic_layout_autofix',
+    title: 'Preview cosmetic schematic layout autofix moves',
+    description:
+      'Detect title-block overlap, page-boundary overflow, and component-overlap violations from ' +
+      'real rendered bounds, and propose cosmetic-only moves that resolve them. Read-only preview ' +
+      'only (requiresConfirmWrite=true, no writes) -- confirmWrite apply with connectivity-fingerprint ' +
+      'rollback is tracked separately (#273).',
+    profile: 'pro',
+    evidence: ['runtime-probe', 'inferred'],
+    risk: 'low',
+    confirmWrite: false,
+    group: 'workflows',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: true,
+      idempotentHint: true,
+    },
+    inputSchema: z.object({
+      projectId: z.string().min(1),
+      allowlist: z
+        .object({
+          primitiveTypes: z.array(autofixPrimitiveTypeSchema).min(1).optional(),
+          properties: z.array(autofixPropertySchema).min(1).optional(),
+        })
+        .optional(),
+      hardKeepouts: z.array(placementConstraintRegionSchema).optional(),
+      reservedRegions: z.array(placementConstraintRegionSchema).optional(),
+      minimumClearance: z.number().nonnegative().optional(),
+      maxMoves: z.number().int().positive().optional(),
+    }),
+    outputSchema: layoutAutofixOutputSchema,
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const values = params as {
+        projectId: string;
+        allowlist?: Partial<LayoutAutofixAllowlist>;
+        hardKeepouts?: GatherLiveLayoutAutofixPreviewOptions['hardKeepouts'];
+        reservedRegions?: GatherLiveLayoutAutofixPreviewOptions['callerReservedRegions'];
+        minimumClearance?: number;
+        maxMoves?: number;
+      };
+      const { preview, primitiveCount, unavailablePrimitiveIds } =
+        await gatherLiveLayoutAutofixPreview(ctx, values.projectId, {
+          allowlist: values.allowlist,
+          hardKeepouts: values.hardKeepouts,
+          callerReservedRegions: values.reservedRegions,
+          minimumClearance: values.minimumClearance,
+          maxMoves: values.maxMoves,
+        });
+      return {
+        projectId: values.projectId,
+        ...preview,
+        primitiveCount,
+        unavailablePrimitiveIds,
+      };
     },
   });
 }

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -43,10 +43,10 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('95');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('96');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('107');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('108');
   });
 });

--- a/tests/unit/tools/schematic-layout-autofix.test.ts
+++ b/tests/unit/tools/schematic-layout-autofix.test.ts
@@ -152,6 +152,10 @@ describe('easyeda_schematic_layout_autofix', () => {
   });
 
   it('honors a caller-supplied allowlist instead of the component/position default', async () => {
+    // Every live primitive is reported as primitiveType 'component' (see
+    // gatherLiveLayoutAutofixPreview), so an allowlist that only admits
+    // 'text' primitives excludes it -- schema-legal (inputSchema requires
+    // .min(1) per array) but effectively empty for this primitive set.
     bridgeCall.mockImplementation(async (method: string) => {
       if (method === 'schematic.getSheetInfo')
         return { pageSize: { width: 1000, height: 700, unit: 'mil' } };
@@ -182,12 +186,21 @@ describe('easyeda_schematic_layout_autofix', () => {
 
     const result = await registry.get('easyeda_schematic_layout_autofix')?.handler(context, {
       projectId: 'project-1',
-      allowlist: { primitiveTypes: [], properties: [] },
+      allowlist: { primitiveTypes: ['text'], properties: ['position'] },
     });
 
-    expect(result.allowlist).toEqual({ primitiveTypes: [], properties: [] });
+    expect(result.allowlist).toEqual({ primitiveTypes: ['text'], properties: ['position'] });
     expect(result.violations).toHaveLength(1);
     expect(result.moves).toEqual([]);
     expect(result.report.remaining).toEqual([result.violations[0].id]);
+  });
+
+  it('rejects an allowlist with an empty primitiveTypes or properties array via the input schema', () => {
+    const tool = registry.get('easyeda_schematic_layout_autofix');
+    const parsed = tool?.inputSchema?.safeParse({
+      projectId: 'project-1',
+      allowlist: { primitiveTypes: [], properties: [] },
+    });
+    expect(parsed?.success).toBe(false);
   });
 });

--- a/tests/unit/tools/schematic-layout-autofix.test.ts
+++ b/tests/unit/tools/schematic-layout-autofix.test.ts
@@ -1,0 +1,193 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EnvSchema } from '../../../src/config/env.js';
+import { registerSchematicLayoutTools } from '../../../src/tools/L2_schematic_layout.js';
+import { ToolRegistry } from '../../../src/tools/registry.js';
+import { type ToolContext } from '../../../src/tools/types.js';
+
+describe('easyeda_schematic_layout_autofix', () => {
+  let registry: ToolRegistry;
+  let context: ToolContext;
+  let bridgeCall: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    registry = new ToolRegistry();
+    registerSchematicLayoutTools(registry, EnvSchema.parse({ NODE_ENV: 'test' }));
+    bridgeCall = vi.fn();
+    context = {
+      profile: 'pro',
+      bridge: { connected: true, call: bridgeCall },
+      config: { bridgeTimeoutMs: 1000, artifactDir: '.easyeda-mcp-pro/artifacts' },
+      vendors: { lcsc: null, jlcpcb: null, mouser: null, digikey: null },
+    };
+  });
+
+  it('is registered as a read-only, confirmWrite:false tool', () => {
+    const tool = registry.get('easyeda_schematic_layout_autofix');
+    expect(tool?.confirmWrite).toBe(false);
+    expect(tool?.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it('reports no violations or moves for a clean, title-block-clear component', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.getSheetInfo')
+        return { pageSize: { width: 1000, height: 700, unit: 'mil' } };
+      if (method === 'schematic.listComponents')
+        return {
+          total: 1,
+          items: [
+            {
+              primitiveId: 'component-r1',
+              reference: 'R1',
+              component_kind: 'part',
+              x: 100,
+              y: -300,
+            },
+          ],
+        };
+      if (method === 'schematic.primitiveBounds')
+        // buildEngineSheetGeometry puts the sheet's y-range at [-700, 0] for a
+        // 700-tall page (top edge at y=0), so a component fully "on the page"
+        // needs negative y here, not positive.
+        return {
+          items: [
+            {
+              primitiveId: 'component-r1',
+              bounds: { minX: 100, maxX: 140, minY: -310, maxY: -290 },
+            },
+          ],
+        };
+      throw new Error(`Unexpected method ${method}`);
+    });
+
+    const result = await registry.get('easyeda_schematic_layout_autofix')?.handler(context, {
+      projectId: 'project-1',
+    });
+
+    expect(result).toMatchObject({
+      projectId: 'project-1',
+      mode: 'preview',
+      requiresConfirmWrite: true,
+      violations: [],
+      moves: [],
+      primitiveCount: 1,
+      unavailablePrimitiveIds: [],
+      allowlist: { primitiveTypes: ['component'], properties: ['position'] },
+    });
+    expect(bridgeCall).toHaveBeenCalledWith('schematic.primitiveBounds', {
+      primitiveIds: ['component-r1'],
+    });
+  });
+
+  it('detects TITLE_BLOCK_OVERLAP and proposes a cosmetic move that resolves it', async () => {
+    // For a 1000x700 mil sheet, buildEngineSheetGeometry's title block keepout
+    // is {x: 550, y: -182, width: 450, height: 182} -- a component fully
+    // inside that box overlaps the title block.
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.getSheetInfo')
+        return { pageSize: { width: 1000, height: 700, unit: 'mil' } };
+      if (method === 'schematic.listComponents')
+        return {
+          total: 1,
+          items: [
+            {
+              primitiveId: 'component-u1',
+              reference: 'U1',
+              component_kind: 'part',
+              x: 600,
+              y: -100,
+            },
+          ],
+        };
+      if (method === 'schematic.primitiveBounds')
+        return {
+          items: [
+            {
+              primitiveId: 'component-u1',
+              bounds: { minX: 600, maxX: 640, minY: -100, maxY: -80 },
+            },
+          ],
+        };
+      throw new Error(`Unexpected method ${method}`);
+    });
+
+    const result = await registry.get('easyeda_schematic_layout_autofix')?.handler(context, {
+      projectId: 'project-1',
+    });
+
+    expect(result.violations).toHaveLength(1);
+    expect(result.violations[0]).toMatchObject({ code: 'TITLE_BLOCK_OVERLAP' });
+    expect(result.moves).toHaveLength(1);
+    expect(result.moves[0]).toMatchObject({ primitiveId: 'component-u1', property: 'position' });
+    expect(result.report.remaining).toEqual([]);
+  });
+
+  it('reports components with unavailable bounds separately, not as autofix primitives', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.getSheetInfo')
+        return { pageSize: { width: 1000, height: 700, unit: 'mil' } };
+      if (method === 'schematic.listComponents')
+        return {
+          total: 1,
+          items: [
+            {
+              primitiveId: 'component-r1',
+              reference: 'R1',
+              component_kind: 'part',
+              x: 100,
+              y: 100,
+            },
+          ],
+        };
+      if (method === 'schematic.primitiveBounds') return { items: [] };
+      throw new Error(`Unexpected method ${method}`);
+    });
+
+    const result = await registry.get('easyeda_schematic_layout_autofix')?.handler(context, {
+      projectId: 'project-1',
+    });
+
+    expect(result.primitiveCount).toBe(0);
+    expect(result.unavailablePrimitiveIds).toEqual(['component-r1']);
+    expect(result.violations).toEqual([]);
+  });
+
+  it('honors a caller-supplied allowlist instead of the component/position default', async () => {
+    bridgeCall.mockImplementation(async (method: string) => {
+      if (method === 'schematic.getSheetInfo')
+        return { pageSize: { width: 1000, height: 700, unit: 'mil' } };
+      if (method === 'schematic.listComponents')
+        return {
+          total: 1,
+          items: [
+            {
+              primitiveId: 'component-u1',
+              reference: 'U1',
+              component_kind: 'part',
+              x: 600,
+              y: -100,
+            },
+          ],
+        };
+      if (method === 'schematic.primitiveBounds')
+        return {
+          items: [
+            {
+              primitiveId: 'component-u1',
+              bounds: { minX: 600, maxX: 640, minY: -100, maxY: -80 },
+            },
+          ],
+        };
+      throw new Error(`Unexpected method ${method}`);
+    });
+
+    const result = await registry.get('easyeda_schematic_layout_autofix')?.handler(context, {
+      projectId: 'project-1',
+      allowlist: { primitiveTypes: [], properties: [] },
+    });
+
+    expect(result.allowlist).toEqual({ primitiveTypes: [], properties: [] });
+    expect(result.violations).toHaveLength(1);
+    expect(result.moves).toEqual([]);
+    expect(result.report.remaining).toEqual([result.violations[0].id]);
+  });
+});


### PR DESCRIPTION
## Summary

Refs #273. Closes the "engine built, no MCP tool" gap for the autofix half of #273 -- the same pattern already found and closed for #271/#272/#243. `src/layout/autofix.ts` (`previewLayoutAutofix`/`applyLayoutAutofix`) and its two test files already existed but were never wired to live bridge data or registered as a tool.

This PR wires and registers the **preview half only**:

- New `gatherLiveLayoutAutofixPreview` (`src/schematic-model/live-layout-autofix.ts`) reads live sheet geometry + component bounds the same way `easyeda_schematic_check_placement`/`easyeda_schematic_plan_layout` already do, and feeds them into the existing pure `previewLayoutAutofix` engine.
- New tool `easyeda_schematic_layout_autofix`, registered `confirmWrite: false`. Every result reports `mode: 'preview'` / `requiresConfirmWrite: true`. No writes are made.
- Because `schematic.listComponents` is the only bridge source of primitive identity today, every live primitive is reported as `primitiveType: 'component'` -- text/label/annotation/section-box primitives (and `TEXT_OVERLAP`/`SECTION_BOX_TOO_SMALL` violations) are out of reach until the bridge exposes them independently. Documented in the tool description.
- Bumped `approxToolCount` for `pro`/`full`/`dev`/`experimental` profiles and regenerated `docs/reference/tools.md`.

## What's deliberately NOT in this PR

The `confirmWrite`-gated apply path (`applyLayoutAutofix`: real `modifyPrimitive` writes, batch-by-batch connectivity-fingerprint verification, rollback via `rollbackEasyedaTransaction`) is the highest-risk write path in this epic and is being left for its own PR, which will need a **live** test that deliberately breaks connectivity and proves the rollback actually fires -- unit tests against a mocked bridge don't prove that. Tracked as the remaining half of #273.

## Test plan

- [x] `pnpm format:check && pnpm typecheck && pnpm lint && pnpm lint:tools && pnpm verify:tool-coverage && pnpm test && pnpm build && pnpm check:metadata` all pass
- [x] `pnpm docs:build` passes
- [x] New unit tests cover: clean placement (no violations), `TITLE_BLOCK_OVERLAP` detection + proposed move, primitives with unavailable bounds reported separately, caller-supplied allowlist gating, and that the input schema actually rejects an empty allowlist array (not just asserted via a bypassed handler call)
