### PR TITLE
feat(schematic-layout): wire confirmWrite-gated layout autofix apply mode

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -91,6 +91,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_schematic_create_net_port`                | `core`  | `medium` | Place a hierarchical net port (off-sheet connector) on the schematic. Net ports create named connections that span multiple schematic sheets, appearing as real SCH_Net entries in the netlist.                                                                                                                                  |
 | `easyeda_schematic_delete_primitive`               | `core`  | `medium` | Delete components, wires, or other drawing objects from the schematic by their primitive UUIDs.                                                                                                                                                                                                                                  |
 | `easyeda_schematic_layout_autofix`                 | `pro`   | `low`    | Detect title-block overlap, page-boundary overflow, and component-overlap violations from real rendered bounds, and propose cosmetic-only moves that resolve them. Read-only preview only (requiresConfirmWrite=true, no writes) -- confirmWrite apply with connectivity-fingerprint rollback is tracked separately (#273).      |
+| `easyeda_schematic_layout_autofix_apply`           | `pro`   | `high`   | Apply the layout-autofix cosmetic moves in a snapshot-backed transaction, re-verifying a connectivity fingerprint after every write batch. Any unintended electrical change or write failure rolls the transaction back and is reported, never thrown. dryRun:true previews only.                                                |
 | `easyeda_schematic_layout_qa`                      | `pro`   | `low`    | Run a normalized post-write QA pass combining runtime DRC/ERC, expected component/pin topology, rendered primitive bounds, title-block and page constraints, wiring/grouping checks, and connectivity fingerprints, with optional full-page visual evidence. Critical geometry or connectivity findings always block commit.     |
 | `easyeda_schematic_modify_primitive`               | `core`  | `medium` | Safely modify a schematic primitive while preserving omitted fields. With transactionId and projectId, capture before/after snapshots and automatically restore the prior state if the write or post-write read fails. Component moves keep connected wires attached.                                                            |
 | `easyeda_schematic_net_detail`                     | `core`  | `low`    | Get full details for a specific net in the schematic including all connected pins and components.                                                                                                                                                                                                                                |
@@ -2902,6 +2903,57 @@ Returns a JSON object matching the schema:
   allowlist: object;
   primitiveCount: number;
   unavailablePrimitiveIds: string[];
+}
+```
+
+---
+
+## `easyeda_schematic_layout_autofix_apply`
+
+**Profile:** `pro` | **Risk Level:** `high`
+
+> Apply the layout-autofix cosmetic moves in a snapshot-backed transaction, re-verifying a connectivity fingerprint after every write batch. Any unintended electrical change or write failure rolls the transaction back and is reported, never thrown. dryRun:true previews only.
+
+### Input Parameters
+
+| Parameter          | Type                  | Required | Description                                                                   |
+| ------------------ | --------------------- | -------- | ----------------------------------------------------------------------------- |
+| `projectId`        | `string`              | Yes      |                                                                               |
+| `allowlist`        | `object (optional)`   | No       |                                                                               |
+| `hardKeepouts`     | `object[] (optional)` | No       |                                                                               |
+| `reservedRegions`  | `object[] (optional)` | No       |                                                                               |
+| `minimumClearance` | `number (optional)`   | No       |                                                                               |
+| `maxMoves`         | `number (optional)`   | No       |                                                                               |
+| `batchSize`        | `number (optional)`   | No       |                                                                               |
+| `dryRun`           | `boolean`             | Yes      |                                                                               |
+| `confirmWrite`     | `'true'`              | Yes      | Must be the literal boolean true (not the string "true") to allow this write. |
+
+### Output Format
+
+Returns a JSON object matching the schema:
+
+```ts
+{
+  projectId: string;
+  dryRun: boolean;
+  mode: 'preview';
+  requiresConfirmWrite: 'true';
+  violations: object[];
+  moves: object[];
+  allowlist: object;
+  primitiveCount: number;
+  unavailablePrimitiveIds: string[];
+  applied: boolean;
+  batchesVerified: number;
+  actualStateReadAfterFailure: boolean;
+  beforeFingerprintHash: string (optional);
+  afterFingerprintHash: string (optional);
+  connectivityDiff: object (optional);
+  report: object;
+  transactionId: string (optional);
+  transactionState: 'active' | 'validating' | 'validated' | 'committed' | 'rolling-back' | 'rolled-back' | 'failed' | 'expired' (optional);
+  errorCode: string (optional);
+  error: string (optional);
 }
 ```
 

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -22,7 +22,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Pro',
     description:
       'Adds pick-and-place, PDF, netlist export, compound transactional workflow tools, autorouting, route-context export, and offline SPICE verification for manufacturing workflows',
-    approxToolCount: '96',
+    approxToolCount: '97',
     isDefault: false,
   },
   full: {
@@ -30,7 +30,7 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Full',
     description:
       'Adds controlled documented EasyEDA API method calls and CircuitIR-driven floorplanning for full runtime control without raw JavaScript execution',
-    approxToolCount: '108',
+    approxToolCount: '109',
     isDefault: false,
   },
   dev: {
@@ -38,14 +38,14 @@ export const PROFILE_DEFINITIONS: Record<ToolProfile, ProfileDefinition> = {
     label: 'Dev',
     description:
       'Adds diagnostics probes for bridge methods and live component runtime shape inspection',
-    approxToolCount: '113',
+    approxToolCount: '114',
     isDefault: false,
   },
   experimental: {
     name: 'experimental',
     label: 'Experimental',
     description: 'MCP Apps, Tasks, AI action plans',
-    approxToolCount: '106',
+    approxToolCount: '107',
     isDefault: false,
   },
 };

--- a/src/schematic-model/live-layout-autofix.ts
+++ b/src/schematic-model/live-layout-autofix.ts
@@ -13,6 +13,7 @@ import {
   previewLayoutAutofix,
   LayoutAutofixConnectivityError,
   type LayoutAutofixAllowlist,
+  type LayoutAutofixApplyResult,
   type LayoutAutofixPreview,
   type LayoutAutofixPrimitive,
   type LayoutAutofixReport,
@@ -127,6 +128,31 @@ async function readLiveConnectivityFingerprint(
   return createConnectivityFingerprint(model);
 }
 
+function toApplyResult(
+  base: Pick<
+    ApplyLiveLayoutAutofixResult,
+    'preview' | 'primitiveCount' | 'unavailablePrimitiveIds'
+  >,
+  engineResult: LayoutAutofixApplyResult,
+  errorInfo?: { errorCode: string; error: string },
+): ApplyLiveLayoutAutofixResult {
+  return {
+    ...base,
+    applied: engineResult.applied,
+    batchesVerified: engineResult.batchesVerified,
+    actualStateReadAfterFailure: engineResult.actualStateReadAfterFailure,
+    ...(engineResult.beforeFingerprint
+      ? { beforeFingerprint: engineResult.beforeFingerprint }
+      : {}),
+    ...(engineResult.afterFingerprint ? { afterFingerprint: engineResult.afterFingerprint } : {}),
+    ...(engineResult.connectivityDiff ? { connectivityDiff: engineResult.connectivityDiff } : {}),
+    report: engineResult.report,
+    ...(engineResult.transaction ? { transactionId: engineResult.transaction.id } : {}),
+    ...(engineResult.transaction ? { transactionState: engineResult.transaction.state } : {}),
+    ...(errorInfo ?? {}),
+  };
+}
+
 /**
  * Recomputes the autofix preview against current live state, then -- unless
  * dryRun is set or there are no moves to make -- applies it through the
@@ -160,6 +186,7 @@ export async function applyLiveLayoutAutofix(
     };
   }
 
+  const base = { preview, primitiveCount, unavailablePrimitiveIds };
   const transactionManager = getGlobalTransactionManager();
   try {
     const result = await applyLayoutAutofix(preview, {
@@ -170,44 +197,16 @@ export async function applyLiveLayoutAutofix(
       readConnectivity: () => readLiveConnectivityFingerprint(ctx, projectId),
       ...(options.batchSize !== undefined ? { batchSize: options.batchSize } : {}),
     });
-    return {
-      preview,
-      primitiveCount,
-      unavailablePrimitiveIds,
-      applied: result.applied,
-      batchesVerified: result.batchesVerified,
-      actualStateReadAfterFailure: result.actualStateReadAfterFailure,
-      ...(result.beforeFingerprint ? { beforeFingerprint: result.beforeFingerprint } : {}),
-      ...(result.afterFingerprint ? { afterFingerprint: result.afterFingerprint } : {}),
-      ...(result.connectivityDiff ? { connectivityDiff: result.connectivityDiff } : {}),
-      report: result.report,
-      ...(result.transaction ? { transactionId: result.transaction.id } : {}),
-      ...(result.transaction ? { transactionState: result.transaction.state } : {}),
-    };
+    return toApplyResult(base, result);
   } catch (error) {
     if (error instanceof LayoutAutofixConnectivityError) {
-      const { result } = error;
-      return {
-        preview,
-        primitiveCount,
-        unavailablePrimitiveIds,
-        applied: result.applied,
-        batchesVerified: result.batchesVerified,
-        actualStateReadAfterFailure: result.actualStateReadAfterFailure,
-        ...(result.beforeFingerprint ? { beforeFingerprint: result.beforeFingerprint } : {}),
-        ...(result.afterFingerprint ? { afterFingerprint: result.afterFingerprint } : {}),
-        ...(result.connectivityDiff ? { connectivityDiff: result.connectivityDiff } : {}),
-        report: result.report,
-        ...(result.transaction ? { transactionId: result.transaction.id } : {}),
-        ...(result.transaction ? { transactionState: result.transaction.state } : {}),
+      return toApplyResult(base, error.result, {
         errorCode: 'AUTOFIX_ROLLED_BACK',
         error: error.message,
-      };
+      });
     }
     return {
-      preview,
-      primitiveCount,
-      unavailablePrimitiveIds,
+      ...base,
       applied: false,
       batchesVerified: 0,
       actualStateReadAfterFailure: false,

--- a/src/schematic-model/live-layout-autofix.ts
+++ b/src/schematic-model/live-layout-autofix.ts
@@ -1,13 +1,24 @@
 import { type ToolContext } from '../tools/types.js';
 import { gatherLivePrimitiveBounds } from './live-primitive-bounds.js';
 import { buildEngineSheetGeometry } from './live-functional-layout.js';
+import { gatherLiveSchematicSnapshot } from './live-snapshot.js';
+import { buildSchematicModel } from './model-builder.js';
 import {
+  createConnectivityFingerprint,
+  type ConnectivityFingerprint,
+  type ConnectivityFingerprintDiff,
+} from './connectivity-fingerprint.js';
+import {
+  applyLayoutAutofix,
   previewLayoutAutofix,
+  LayoutAutofixConnectivityError,
   type LayoutAutofixAllowlist,
   type LayoutAutofixPreview,
   type LayoutAutofixPrimitive,
+  type LayoutAutofixReport,
 } from '../layout/autofix.js';
 import type { PlacementConstraintRegion } from '../layout/placement.js';
+import { getGlobalTransactionManager } from '../transactions/manager.js';
 
 export interface GatherLiveLayoutAutofixPreviewOptions {
   allowlist?: Partial<LayoutAutofixAllowlist>;
@@ -82,4 +93,127 @@ export async function gatherLiveLayoutAutofixPreview(
   });
 
   return { preview, primitiveCount: primitives.length, unavailablePrimitiveIds };
+}
+
+export interface ApplyLiveLayoutAutofixOptions extends GatherLiveLayoutAutofixPreviewOptions {
+  /** Compute and return the preview only -- never opens a transaction or writes. */
+  dryRun?: boolean;
+  batchSize?: number;
+}
+
+export interface ApplyLiveLayoutAutofixResult {
+  preview: LayoutAutofixPreview;
+  primitiveCount: number;
+  unavailablePrimitiveIds: string[];
+  applied: boolean;
+  batchesVerified: number;
+  actualStateReadAfterFailure: boolean;
+  beforeFingerprint?: ConnectivityFingerprint;
+  afterFingerprint?: ConnectivityFingerprint;
+  connectivityDiff?: ConnectivityFingerprintDiff;
+  report: LayoutAutofixReport;
+  transactionId?: string;
+  transactionState?: string;
+  errorCode?: string;
+  error?: string;
+}
+
+async function readLiveConnectivityFingerprint(
+  ctx: ToolContext,
+  projectId: string,
+): Promise<ConnectivityFingerprint> {
+  const snapshot = await gatherLiveSchematicSnapshot(ctx, projectId);
+  const model = buildSchematicModel(snapshot);
+  return createConnectivityFingerprint(model);
+}
+
+/**
+ * Recomputes the autofix preview against current live state, then -- unless
+ * dryRun is set or there are no moves to make -- applies it through the
+ * shared global TransactionManager with batch-by-batch connectivity-
+ * fingerprint verification (applyLayoutAutofix). Any connectivity change,
+ * write failure, or readback instability rolls the whole transaction back;
+ * this function never throws for those cases, it reports them in the
+ * returned errorCode/error fields instead (mirroring handleSchematicBatchWrite's
+ * catch-and-report convention).
+ */
+export async function applyLiveLayoutAutofix(
+  ctx: ToolContext,
+  projectId: string,
+  options: ApplyLiveLayoutAutofixOptions = {},
+): Promise<ApplyLiveLayoutAutofixResult> {
+  const { preview, primitiveCount, unavailablePrimitiveIds } = await gatherLiveLayoutAutofixPreview(
+    ctx,
+    projectId,
+    options,
+  );
+
+  if (options.dryRun) {
+    return {
+      preview,
+      primitiveCount,
+      unavailablePrimitiveIds,
+      applied: false,
+      batchesVerified: 0,
+      actualStateReadAfterFailure: false,
+      report: preview.report,
+    };
+  }
+
+  const transactionManager = getGlobalTransactionManager();
+  try {
+    const result = await applyLayoutAutofix(preview, {
+      confirmWrite: true,
+      documentId: projectId,
+      transactionManager,
+      bridge: ctx.bridge,
+      readConnectivity: () => readLiveConnectivityFingerprint(ctx, projectId),
+      ...(options.batchSize !== undefined ? { batchSize: options.batchSize } : {}),
+    });
+    return {
+      preview,
+      primitiveCount,
+      unavailablePrimitiveIds,
+      applied: result.applied,
+      batchesVerified: result.batchesVerified,
+      actualStateReadAfterFailure: result.actualStateReadAfterFailure,
+      ...(result.beforeFingerprint ? { beforeFingerprint: result.beforeFingerprint } : {}),
+      ...(result.afterFingerprint ? { afterFingerprint: result.afterFingerprint } : {}),
+      ...(result.connectivityDiff ? { connectivityDiff: result.connectivityDiff } : {}),
+      report: result.report,
+      ...(result.transaction ? { transactionId: result.transaction.id } : {}),
+      ...(result.transaction ? { transactionState: result.transaction.state } : {}),
+    };
+  } catch (error) {
+    if (error instanceof LayoutAutofixConnectivityError) {
+      const { result } = error;
+      return {
+        preview,
+        primitiveCount,
+        unavailablePrimitiveIds,
+        applied: result.applied,
+        batchesVerified: result.batchesVerified,
+        actualStateReadAfterFailure: result.actualStateReadAfterFailure,
+        ...(result.beforeFingerprint ? { beforeFingerprint: result.beforeFingerprint } : {}),
+        ...(result.afterFingerprint ? { afterFingerprint: result.afterFingerprint } : {}),
+        ...(result.connectivityDiff ? { connectivityDiff: result.connectivityDiff } : {}),
+        report: result.report,
+        ...(result.transaction ? { transactionId: result.transaction.id } : {}),
+        ...(result.transaction ? { transactionState: result.transaction.state } : {}),
+        errorCode: 'AUTOFIX_ROLLED_BACK',
+        error: error.message,
+      };
+    }
+    return {
+      preview,
+      primitiveCount,
+      unavailablePrimitiveIds,
+      applied: false,
+      batchesVerified: 0,
+      actualStateReadAfterFailure: false,
+      report: preview.report,
+      errorCode: 'AUTOFIX_APPLY_FAILED',
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
 }

--- a/src/tools/L2_schematic_layout.ts
+++ b/src/tools/L2_schematic_layout.ts
@@ -398,6 +398,39 @@ const autofixReportSchema = z.object({
   remaining: z.array(z.string()),
 });
 
+const autofixSharedInputFields = {
+  allowlist: z
+    .object({
+      primitiveTypes: z.array(autofixPrimitiveTypeSchema).min(1).optional(),
+      properties: z.array(autofixPropertySchema).min(1).optional(),
+    })
+    .optional(),
+  hardKeepouts: z.array(placementConstraintRegionSchema).optional(),
+  reservedRegions: z.array(placementConstraintRegionSchema).optional(),
+  minimumClearance: z.number().nonnegative().optional(),
+  maxMoves: z.number().int().positive().optional(),
+};
+
+interface AutofixSharedInputValues {
+  allowlist?: Partial<LayoutAutofixAllowlist>;
+  hardKeepouts?: GatherLiveLayoutAutofixPreviewOptions['hardKeepouts'];
+  reservedRegions?: GatherLiveLayoutAutofixPreviewOptions['callerReservedRegions'];
+  minimumClearance?: number;
+  maxMoves?: number;
+}
+
+function toAutofixGatherOptions(
+  values: AutofixSharedInputValues,
+): GatherLiveLayoutAutofixPreviewOptions {
+  return {
+    allowlist: values.allowlist,
+    hardKeepouts: values.hardKeepouts,
+    callerReservedRegions: values.reservedRegions,
+    minimumClearance: values.minimumClearance,
+    maxMoves: values.maxMoves,
+  };
+}
+
 const layoutAutofixOutputSchema = z.object({
   projectId: z.string(),
   mode: z.literal('preview'),
@@ -1216,35 +1249,13 @@ export function registerSchematicLayoutTools(
     },
     inputSchema: z.object({
       projectId: z.string().min(1),
-      allowlist: z
-        .object({
-          primitiveTypes: z.array(autofixPrimitiveTypeSchema).min(1).optional(),
-          properties: z.array(autofixPropertySchema).min(1).optional(),
-        })
-        .optional(),
-      hardKeepouts: z.array(placementConstraintRegionSchema).optional(),
-      reservedRegions: z.array(placementConstraintRegionSchema).optional(),
-      minimumClearance: z.number().nonnegative().optional(),
-      maxMoves: z.number().int().positive().optional(),
+      ...autofixSharedInputFields,
     }),
     outputSchema: layoutAutofixOutputSchema,
     handler: async (ctx: ToolContext, params: unknown) => {
-      const values = params as {
-        projectId: string;
-        allowlist?: Partial<LayoutAutofixAllowlist>;
-        hardKeepouts?: GatherLiveLayoutAutofixPreviewOptions['hardKeepouts'];
-        reservedRegions?: GatherLiveLayoutAutofixPreviewOptions['callerReservedRegions'];
-        minimumClearance?: number;
-        maxMoves?: number;
-      };
+      const values = params as { projectId: string } & AutofixSharedInputValues;
       const { preview, primitiveCount, unavailablePrimitiveIds } =
-        await gatherLiveLayoutAutofixPreview(ctx, values.projectId, {
-          allowlist: values.allowlist,
-          hardKeepouts: values.hardKeepouts,
-          callerReservedRegions: values.reservedRegions,
-          minimumClearance: values.minimumClearance,
-          maxMoves: values.maxMoves,
-        });
+        await gatherLiveLayoutAutofixPreview(ctx, values.projectId, toAutofixGatherOptions(values));
       return {
         projectId: values.projectId,
         ...preview,
@@ -1274,16 +1285,7 @@ export function registerSchematicLayoutTools(
     },
     inputSchema: z.object({
       projectId: z.string().min(1),
-      allowlist: z
-        .object({
-          primitiveTypes: z.array(autofixPrimitiveTypeSchema).min(1).optional(),
-          properties: z.array(autofixPropertySchema).min(1).optional(),
-        })
-        .optional(),
-      hardKeepouts: z.array(placementConstraintRegionSchema).optional(),
-      reservedRegions: z.array(placementConstraintRegionSchema).optional(),
-      minimumClearance: z.number().nonnegative().optional(),
-      maxMoves: z.number().int().positive().optional(),
+      ...autofixSharedInputFields,
       batchSize: z.number().int().positive().optional(),
       dryRun: z.boolean().default(false),
       confirmWrite: z
@@ -1294,20 +1296,11 @@ export function registerSchematicLayoutTools(
     handler: async (ctx: ToolContext, params: unknown) => {
       const values = params as {
         projectId: string;
-        allowlist?: Partial<LayoutAutofixAllowlist>;
-        hardKeepouts?: GatherLiveLayoutAutofixPreviewOptions['hardKeepouts'];
-        reservedRegions?: GatherLiveLayoutAutofixPreviewOptions['callerReservedRegions'];
-        minimumClearance?: number;
-        maxMoves?: number;
         batchSize?: number;
         dryRun: boolean;
-      };
+      } & AutofixSharedInputValues;
       const result = await applyLiveLayoutAutofix(ctx, values.projectId, {
-        allowlist: values.allowlist,
-        hardKeepouts: values.hardKeepouts,
-        callerReservedRegions: values.reservedRegions,
-        minimumClearance: values.minimumClearance,
-        maxMoves: values.maxMoves,
+        ...toAutofixGatherOptions(values),
         batchSize: values.batchSize,
         dryRun: values.dryRun,
       });

--- a/src/tools/L2_schematic_layout.ts
+++ b/src/tools/L2_schematic_layout.ts
@@ -32,6 +32,7 @@ import {
   type LivePlacementCandidateInput,
 } from '../schematic-model/live-placement-check.js';
 import {
+  applyLiveLayoutAutofix,
   gatherLiveLayoutAutofixPreview,
   type GatherLiveLayoutAutofixPreviewOptions,
 } from '../schematic-model/live-layout-autofix.js';
@@ -407,6 +408,88 @@ const layoutAutofixOutputSchema = z.object({
   allowlist: autofixAllowlistSchema,
   primitiveCount: z.number().int().nonnegative(),
   unavailablePrimitiveIds: z.array(z.string()),
+});
+
+const fingerprintPinMembershipSchema = z.object({
+  componentId: z.string(),
+  componentReference: z.string(),
+  pinId: z.string(),
+  pinNumber: z.string(),
+  netIds: z.array(z.string()),
+});
+
+const fingerprintWireEndpointSchema = z.object({
+  endpoint: z.enum(['start', 'end']),
+  kind: z.enum(['pin', 'unresolved']),
+  token: z.string(),
+});
+
+const fingerprintWireSchema = z.object({
+  wireId: z.string(),
+  netId: z.string().optional(),
+  netName: z.string().optional(),
+  endpoints: z.array(fingerprintWireEndpointSchema),
+});
+
+const fingerprintLabelOrPortSchema = z.object({
+  id: z.string(),
+  kind: z.enum(['label', 'sheet-port', 'power-symbol']),
+  netName: z.string(),
+});
+
+const fingerprintNoConnectSchema = z.object({
+  noConnectId: z.string(),
+  componentReference: z.string().optional(),
+  pinId: z.string().optional(),
+  pinNumber: z.string().optional(),
+});
+
+function diffEntrySchema<T extends z.ZodTypeAny>(inner: T) {
+  return z.object({ key: z.string(), before: inner.optional(), after: inner.optional() });
+}
+
+const connectivityFingerprintDiffSchema = z.object({
+  equal: z.boolean(),
+  beforeHash: z.string(),
+  afterHash: z.string(),
+  pinNetMembership: z.array(diffEntrySchema(fingerprintPinMembershipSchema)),
+  wireEndpoints: z.array(diffEntrySchema(fingerprintWireSchema)),
+  labelsAndPorts: z.array(diffEntrySchema(fingerprintLabelOrPortSchema)),
+  noConnects: z.array(diffEntrySchema(fingerprintNoConnectSchema)),
+});
+
+const layoutAutofixApplyOutputSchema = z.object({
+  projectId: z.string(),
+  dryRun: z.boolean(),
+  mode: z.literal('preview'),
+  requiresConfirmWrite: z.literal(true),
+  violations: z.array(autofixViolationSchema),
+  moves: z.array(autofixMoveSchema),
+  allowlist: autofixAllowlistSchema,
+  primitiveCount: z.number().int().nonnegative(),
+  unavailablePrimitiveIds: z.array(z.string()),
+  applied: z.boolean(),
+  batchesVerified: z.number().int().nonnegative(),
+  actualStateReadAfterFailure: z.boolean(),
+  beforeFingerprintHash: z.string().optional(),
+  afterFingerprintHash: z.string().optional(),
+  connectivityDiff: connectivityFingerprintDiffSchema.optional(),
+  report: autofixReportSchema,
+  transactionId: z.string().optional(),
+  transactionState: z
+    .enum([
+      'active',
+      'validating',
+      'validated',
+      'committed',
+      'rolling-back',
+      'rolled-back',
+      'failed',
+      'expired',
+    ])
+    .optional(),
+  errorCode: z.string().optional(),
+  error: z.string().optional(),
 });
 
 const functionalLayoutOutputSchema = z.object({
@@ -1167,6 +1250,90 @@ export function registerSchematicLayoutTools(
         ...preview,
         primitiveCount,
         unavailablePrimitiveIds,
+      };
+    },
+  });
+
+  registry.register({
+    name: 'easyeda_schematic_layout_autofix_apply',
+    title: 'Apply cosmetic schematic layout autofix moves',
+    description:
+      'Apply the layout-autofix cosmetic moves in a snapshot-backed transaction, re-verifying a ' +
+      'connectivity fingerprint after every write batch. Any unintended electrical change or write ' +
+      'failure rolls the transaction back and is reported, never thrown. dryRun:true previews only.',
+    profile: 'pro',
+    evidence: ['runtime-probe', 'inferred'],
+    risk: 'high',
+    confirmWrite: true,
+    group: 'workflows',
+    version: '1.0.0',
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: false,
+    },
+    inputSchema: z.object({
+      projectId: z.string().min(1),
+      allowlist: z
+        .object({
+          primitiveTypes: z.array(autofixPrimitiveTypeSchema).min(1).optional(),
+          properties: z.array(autofixPropertySchema).min(1).optional(),
+        })
+        .optional(),
+      hardKeepouts: z.array(placementConstraintRegionSchema).optional(),
+      reservedRegions: z.array(placementConstraintRegionSchema).optional(),
+      minimumClearance: z.number().nonnegative().optional(),
+      maxMoves: z.number().int().positive().optional(),
+      batchSize: z.number().int().positive().optional(),
+      dryRun: z.boolean().default(false),
+      confirmWrite: z
+        .literal(true)
+        .describe('Must be the literal boolean true (not the string "true") to allow this write.'),
+    }),
+    outputSchema: layoutAutofixApplyOutputSchema,
+    handler: async (ctx: ToolContext, params: unknown) => {
+      const values = params as {
+        projectId: string;
+        allowlist?: Partial<LayoutAutofixAllowlist>;
+        hardKeepouts?: GatherLiveLayoutAutofixPreviewOptions['hardKeepouts'];
+        reservedRegions?: GatherLiveLayoutAutofixPreviewOptions['callerReservedRegions'];
+        minimumClearance?: number;
+        maxMoves?: number;
+        batchSize?: number;
+        dryRun: boolean;
+      };
+      const result = await applyLiveLayoutAutofix(ctx, values.projectId, {
+        allowlist: values.allowlist,
+        hardKeepouts: values.hardKeepouts,
+        callerReservedRegions: values.reservedRegions,
+        minimumClearance: values.minimumClearance,
+        maxMoves: values.maxMoves,
+        batchSize: values.batchSize,
+        dryRun: values.dryRun,
+      });
+      return {
+        projectId: values.projectId,
+        dryRun: values.dryRun,
+        mode: 'preview' as const,
+        requiresConfirmWrite: true as const,
+        violations: result.preview.violations,
+        moves: result.preview.moves,
+        allowlist: result.preview.allowlist,
+        primitiveCount: result.primitiveCount,
+        unavailablePrimitiveIds: result.unavailablePrimitiveIds,
+        applied: result.applied,
+        batchesVerified: result.batchesVerified,
+        actualStateReadAfterFailure: result.actualStateReadAfterFailure,
+        ...(result.beforeFingerprint
+          ? { beforeFingerprintHash: result.beforeFingerprint.hash }
+          : {}),
+        ...(result.afterFingerprint ? { afterFingerprintHash: result.afterFingerprint.hash } : {}),
+        ...(result.connectivityDiff ? { connectivityDiff: result.connectivityDiff } : {}),
+        report: result.report,
+        ...(result.transactionId ? { transactionId: result.transactionId } : {}),
+        ...(result.transactionState ? { transactionState: result.transactionState } : {}),
+        ...(result.errorCode ? { errorCode: result.errorCode } : {}),
+        ...(result.error ? { error: result.error } : {}),
       };
     },
   });

--- a/tests/unit/config/profiles.test.ts
+++ b/tests/unit/config/profiles.test.ts
@@ -43,10 +43,10 @@ describe('PROFILE_DEFINITIONS', () => {
   });
 
   it('should have accurate approxToolCount for pro', () => {
-    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('96');
+    expect(PROFILE_DEFINITIONS.pro.approxToolCount).toBe('97');
   });
 
   it('should have accurate approxToolCount for full', () => {
-    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('108');
+    expect(PROFILE_DEFINITIONS.full.approxToolCount).toBe('109');
   });
 });

--- a/tests/unit/tools/schematic-layout-autofix-apply.test.ts
+++ b/tests/unit/tools/schematic-layout-autofix-apply.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EnvSchema } from '../../../src/config/env.js';
+import { registerSchematicLayoutTools } from '../../../src/tools/L2_schematic_layout.js';
+import { ToolRegistry } from '../../../src/tools/registry.js';
+import { type ToolContext } from '../../../src/tools/types.js';
+
+// A single component ('component-u1' / ref 'U1') placed inside the title
+// block of a 1000x700 mil sheet -- buildEngineSheetGeometry's keepout there
+// is {x: 550, y: -182, width: 450, height: 182} (see
+// schematic-layout-autofix.test.ts for the derivation), so this component
+// always yields exactly one TITLE_BLOCK_OVERLAP violation and one proposed
+// position move.
+const COMPONENT_ITEM = {
+  primitiveId: 'component-u1',
+  reference: 'U1',
+  component_kind: 'part',
+  x: 600,
+  y: -100,
+};
+const BOUNDS_ITEM = {
+  primitiveId: 'component-u1',
+  bounds: { minX: 600, maxX: 640, minY: -100, maxY: -80 },
+};
+
+interface BridgeFixtureOptions {
+  /** Every connectivity read taken after the first modifyPrimitive call reports the pin as disconnected. */
+  breakConnectivityAfterWrite?: boolean;
+}
+
+function buildBridgeMock(options: BridgeFixtureOptions = {}) {
+  // stableConnectivityRead (src/live/readback.ts) calls readConnectivity
+  // repeatedly until two *consecutive* reads match, so the fixture must key
+  // off whether a write has actually happened yet -- not off a raw call
+  // counter -- otherwise the pre-write "before" checkpoint never stabilizes
+  // on a single consistent value.
+  let writeHappened = false;
+  return vi.fn(async (method: string, params: any) => {
+    switch (method) {
+      case 'schematic.getSheetInfo':
+        return { pageSize: { width: 1000, height: 700, unit: 'mil' } };
+      case 'schematic.listComponents':
+        return { total: 1, items: [COMPONENT_ITEM] };
+      case 'schematic.primitiveBounds':
+        return { items: [BOUNDS_ITEM] };
+      case 'api.call':
+        return { result: [{ pinNumber: '1', pinName: 'A', x: 600, y: -100, rotation: 0 }] };
+      case 'schematic.listNets': {
+        const disconnected = options.breakConnectivityAfterWrite && writeHappened;
+        return disconnected ? [] : [{ netName: 'NET1', nodes: [{ component: 'U1', pin: '1' }] }];
+      }
+      case 'system.inspectWires':
+        return { total: 0, samples: [] };
+      case 'schematic.getPrimitiveSnapshot':
+        return { primitiveId: params?.primitiveId, position: { x: 600, y: -100 } };
+      case 'schematic.modifyPrimitive':
+        writeHappened = true;
+        return { ok: true };
+      case 'schematic.restorePrimitiveSnapshot':
+        return { ok: true };
+      default:
+        throw new Error(`Unexpected method ${method}`);
+    }
+  });
+}
+
+describe('easyeda_schematic_layout_autofix_apply', () => {
+  let registry: ToolRegistry;
+
+  beforeEach(() => {
+    registry = new ToolRegistry();
+    registerSchematicLayoutTools(registry, EnvSchema.parse({ NODE_ENV: 'test' }));
+  });
+
+  function makeContext(bridgeCall: ReturnType<typeof buildBridgeMock>): ToolContext {
+    return {
+      profile: 'pro',
+      bridge: { connected: true, call: bridgeCall },
+      config: { bridgeTimeoutMs: 1000, artifactDir: '.easyeda-mcp-pro/artifacts' },
+      vendors: { lcsc: null, jlcpcb: null, mouser: null, digikey: null },
+    };
+  }
+
+  it('is registered as confirmWrite:true, high risk', () => {
+    const tool = registry.get('easyeda_schematic_layout_autofix_apply');
+    expect(tool?.confirmWrite).toBe(true);
+    expect(tool?.risk).toBe('high');
+  });
+
+  it('rejects a call missing confirmWrite:true via the input schema', () => {
+    const tool = registry.get('easyeda_schematic_layout_autofix_apply');
+    const parsed = tool?.inputSchema?.safeParse({ projectId: 'project-1' });
+    expect(parsed?.success).toBe(false);
+  });
+
+  it('dryRun:true computes the preview without opening a transaction or writing', async () => {
+    const bridgeCall = buildBridgeMock();
+    const result = await registry
+      .get('easyeda_schematic_layout_autofix_apply')
+      ?.handler(makeContext(bridgeCall), {
+        projectId: 'project-dryrun',
+        confirmWrite: true,
+        dryRun: true,
+      });
+
+    expect(result).toMatchObject({
+      dryRun: true,
+      applied: false,
+      batchesVerified: 0,
+    });
+    expect(result.violations).toHaveLength(1);
+    expect(result.moves).toHaveLength(1);
+    expect(bridgeCall).not.toHaveBeenCalledWith('schematic.modifyPrimitive', expect.anything());
+    expect(bridgeCall).not.toHaveBeenCalledWith(
+      'schematic.getPrimitiveSnapshot',
+      expect.anything(),
+    );
+  });
+
+  it('applies the move and commits when connectivity stays stable across the write batch', async () => {
+    const bridgeCall = buildBridgeMock();
+    const result = await registry
+      .get('easyeda_schematic_layout_autofix_apply')
+      ?.handler(makeContext(bridgeCall), {
+        projectId: 'project-apply-stable',
+        confirmWrite: true,
+      });
+
+    expect(result.applied).toBe(true);
+    expect(result.batchesVerified).toBe(1);
+    expect(result.report.fixed).toHaveLength(1);
+    expect(result.report.remaining).toEqual([]);
+    expect(result.transactionState).toBe('committed');
+    expect(result.errorCode).toBeUndefined();
+    expect(bridgeCall).toHaveBeenCalledWith(
+      'schematic.modifyPrimitive',
+      expect.objectContaining({ primitiveId: 'component-u1' }),
+    );
+    expect(bridgeCall).not.toHaveBeenCalledWith(
+      'schematic.restorePrimitiveSnapshot',
+      expect.anything(),
+    );
+  });
+
+  it('rolls back and reports the failure when the move changes connectivity', async () => {
+    const bridgeCall = buildBridgeMock({ breakConnectivityAfterWrite: true });
+    const result = await registry
+      .get('easyeda_schematic_layout_autofix_apply')
+      ?.handler(makeContext(bridgeCall), {
+        projectId: 'project-apply-rollback',
+        confirmWrite: true,
+      });
+
+    expect(result.applied).toBe(false);
+    expect(result.errorCode).toBe('AUTOFIX_ROLLED_BACK');
+    expect(result.connectivityDiff?.equal).toBe(false);
+    // Rollback means nothing was actually fixed, regardless of what the
+    // pre-apply preview proposed.
+    expect(result.report.fixed).toEqual([]);
+    expect(bridgeCall).toHaveBeenCalledWith(
+      'schematic.restorePrimitiveSnapshot',
+      expect.anything(),
+    );
+  });
+
+  it('reports zero moves as applied:false without any modifyPrimitive calls', async () => {
+    // An allowlist that excludes 'component' primitives leaves the
+    // TITLE_BLOCK_OVERLAP violation detected but unresolvable.
+    const bridgeCall = buildBridgeMock();
+    const result = await registry
+      .get('easyeda_schematic_layout_autofix_apply')
+      ?.handler(makeContext(bridgeCall), {
+        projectId: 'project-apply-nomoves',
+        confirmWrite: true,
+        allowlist: { primitiveTypes: ['text'], properties: ['position'] },
+      });
+
+    expect(result.moves).toEqual([]);
+    expect(result.applied).toBe(false);
+    expect(bridgeCall).not.toHaveBeenCalledWith('schematic.modifyPrimitive', expect.anything());
+  });
+});


### PR DESCRIPTION
## Summary

Refs #273. Builds on the preview-only tool from #290, adding the write half: `easyeda_schematic_layout_autofix_apply`.

- New `applyLiveLayoutAutofix` (`src/schematic-model/live-layout-autofix.ts`) recomputes the preview against current live state, then -- unless `dryRun` is set -- runs it through the existing `applyLayoutAutofix` engine using the shared global `TransactionManager`, `ctx.bridge` as the `TransactionBridgeCaller`, and a `readConnectivity` closure built from the already-shipped `gatherLiveSchematicSnapshot` / `buildSchematicModel` / `createConnectivityFingerprint` pipeline.
- Any connectivity-fingerprint mismatch detected after a write batch, or any write failure, rolls the whole transaction back (`rollbackEasyedaTransaction`) and is reported through `errorCode`/`error` in the return value -- mirroring `handleSchematicBatchWrite`'s catch-and-report convention. Nothing is thrown as a raw MCP tool error.
- New tool registered `confirmWrite: true`, `risk: 'high'`, with `confirmWrite: z.literal(true)` required on every call (same pattern as every other write tool in this codebase, e.g. `easyeda_schematic_batch_write`).

## ⚠️ This PR does NOT close #273

Unit tests mock a pin going from connected to disconnected across the write batch and confirm the tool detects the mismatch, rolls back, and reports `AUTOFIX_ROLLED_BACK`. **That only proves the plumbing correctly maps a detected mismatch to a rollback** -- it is not proof that the real EasyEDA Pro runtime's rollback actually fires against a genuine connectivity break.

The known mechanism for a real break in this runtime is the same one that caused #253: two different-net pins landing on the exact same coordinate, which EasyEDA auto-merges. Proving the rollback live requires:
1. A disposable EasyEDA project containing a small **wired** circuit (not blank -- there must be something to break).
2. A move that deliberately drives that merge condition.
3. Confirming the tool detects the fingerprint mismatch, rolls back via `restorePrimitiveSnapshot`, and leaves the design byte-identical to before.

This needs the user to identify/approve a disposable wired test project and the usual stop-systemd/run-test-server/restore ritual. I'm not merging this as "done" for #273 -- flagging it as the remaining gate.

## Test plan

- [x] `pnpm format:check && pnpm typecheck && pnpm lint && pnpm lint:tools && pnpm verify:tool-coverage && pnpm test && pnpm build && pnpm check:metadata` all pass
- [x] `pnpm docs:build` passes
- [x] New unit tests: tool registered `confirmWrite:true`/`risk:high`; schema rejects a call missing `confirmWrite:true`; `dryRun:true` makes no writes; a clean apply commits; a zero-moves case makes no `modifyPrimitive` calls; a mocked connectivity break after the write triggers rollback and `AUTOFIX_ROLLED_BACK`
- [ ] **Live deliberate-connectivity-break rollback proof — not yet done, blocking #273 closure**
