### PR TITLE
fix(design-rules): expose lookup input schema

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -704,66 +704,22 @@ Returns a JSON object matching the schema:
 
 ### Input Parameters
 
-This tool accepts one of several shapes, selected by the `topic` field:
-
-**When `topic` is 'trace-width':**
-
-| Parameter          | Type            | Required    | Description |
-| ------------------ | --------------- | ----------- | ----------- |
-| `topic`            | `'trace-width'` | Yes         |             |
-| `currentA`         | `number`        | Yes         |             |
-| `temperatureRiseC` | `number`        | Yes         |             |
-| `layer`            | `'external'     | 'internal'` | Yes         |     |
-| `copperWeightOz`   | `number`        | Yes         |             |
-
-**When `topic` is 'max-current':**
-
-| Parameter          | Type            | Required    | Description |
-| ------------------ | --------------- | ----------- | ----------- |
-| `topic`            | `'max-current'` | Yes         |             |
-| `traceWidthMils`   | `number`        | Yes         |             |
-| `temperatureRiseC` | `number`        | Yes         |             |
-| `layer`            | `'external'     | 'internal'` | Yes         |     |
-| `copperWeightOz`   | `number`        | Yes         |             |
-
-**When `topic` is 'clearance':**
-
-| Parameter  | Type          | Required    | Description |
-| ---------- | ------------- | ----------- | ----------- |
-| `topic`    | `'clearance'` | Yes         |             |
-| `voltageV` | `number`      | Yes         |             |
-| `location` | `'external'   | 'internal'` | Yes         |     |
-
-**When `topic` is 'protocol-routing':**
-
-| Parameter  | Type                 | Required | Description |
-| ---------- | -------------------- | -------- | ----------- |
-| `topic`    | `'protocol-routing'` | Yes      |             |
-| `protocol` | `'usb2'              | 'usb3'   | 'rs485'     | 'i2c' | 'spi' | 'uart' | 'ethernet-10-100' | 'ethernet-1000' (optional)` | No  |     |
-
-**When `topic` is 'decoupling':**
-
-| Parameter  | Type             | Required | Description |
-| ---------- | ---------------- | -------- | ----------- |
-| `topic`    | `'decoupling'`   | Yes      |             |
-| `category` | `'digital-logic' | 'mcu'    | 'analog'    | 'rf' | 'crystal-oscillator' | 'power-regulator' (optional)` | No  |     |
-
-**When `topic` is 'bulk-capacitance':**
-
-| Parameter                  | Type                 | Required | Description |
-| -------------------------- | -------------------- | -------- | ----------- |
-| `topic`                    | `'bulk-capacitance'` | Yes      |             |
-| `loadA`                    | `number`             | Yes      |             |
-| `minBulkCapacitanceUfPerA` | `number (optional)`  | No       |             |
-| `minBulkCapacitanceUf`     | `number (optional)`  | No       |             |
-
-**When `topic` is 'dfm-checklist':**
-
-| Parameter  | Type                | Required   | Description |
-| ---------- | ------------------- | ---------- | ----------- |
-| `topic`    | `'dfm-checklist'`   | Yes        |             |
-| `category` | `'clearance'        | 'drilling' | 'copper'    | 'solder-mask' | 'silkscreen' | 'panelization' | 'assembly' (optional)` | No  |     |
-| `id`       | `string (optional)` | No         |             |
+| Parameter                  | Type                | Required               | Description                                                               |
+| -------------------------- | ------------------- | ---------------------- | ------------------------------------------------------------------------- |
+| `topic`                    | `'trace-width'      | 'max-current'          | 'clearance'                                                               | 'protocol-routing'                                                  | 'decoupling'         | 'bulk-capacitance' | 'dfm-checklist'`  | Yes                         | Reference topic to look up. |
+| `currentA`                 | `number (optional)` | No                     | Required when topic is trace-width. Load current in amperes.              |
+| `traceWidthMils`           | `number (optional)` | No                     | Required when topic is max-current. Trace width in mils.                  |
+| `temperatureRiseC`         | `number (optional)` | No                     | Required for trace-width and max-current. Allowed temperature rise in °C. |
+| `layer`                    | `'external'         | 'internal' (optional)` | No                                                                        | Required for trace-width and max-current. Conductor layer location. |
+| `copperWeightOz`           | `number (optional)` | No                     | Required for trace-width and max-current. Copper weight in oz/ft².        |
+| `voltageV`                 | `number (optional)` | No                     | Required when topic is clearance. Working voltage in volts.               |
+| `location`                 | `'external'         | 'internal' (optional)` | No                                                                        | Required when topic is clearance. Clearance location.               |
+| `protocol`                 | `'usb2'             | 'usb3'                 | 'rs485'                                                                   | 'i2c'                                                               | 'spi'                | 'uart'             | 'ethernet-10-100' | 'ethernet-1000' (optional)` | No                          | Optional protocol filter when topic is protocol-routing. |
+| `category`                 | `'digital-logic'    | 'mcu'                  | 'analog'                                                                  | 'rf'                                                                | 'crystal-oscillator' | 'power-regulator'  | 'clearance'       | 'drilling'                  | 'copper'                    | 'solder-mask'                                            | 'silkscreen' | 'panelization' | 'assembly' (optional)` | No  | Optional category filter for decoupling or dfm-checklist. |
+| `loadA`                    | `number (optional)` | No                     | Required when topic is bulk-capacitance. Load current in amperes.         |
+| `minBulkCapacitanceUfPerA` | `number (optional)` | No                     | Optional minimum bulk capacitance per ampere in µF/A.                     |
+| `minBulkCapacitanceUf`     | `number (optional)` | No                     | Optional absolute minimum bulk capacitance in µF.                         |
+| `id`                       | `string (optional)` | No                     | Optional DFM checklist item id.                                           |
 
 ### Output Format
 

--- a/src/tools/L1_design_rules.ts
+++ b/src/tools/L1_design_rules.ts
@@ -49,24 +49,33 @@ const dfmCategorySchema = z.enum([
   'assembly',
 ]);
 
-const inputSchema = z.discriminatedUnion('topic', [
+const currentASchema = z.number().positive();
+const temperatureRiseCSchema = z.number().positive();
+const copperWeightOzSchema = z.number().positive();
+const traceWidthMilsSchema = z.number().positive();
+const voltageVSchema = z.number().nonnegative();
+const loadASchema = z.number().positive();
+const minBulkCapacitanceUfPerASchema = z.number().positive();
+const minBulkCapacitanceUfSchema = z.number().positive();
+
+const lookupInputSchema = z.discriminatedUnion('topic', [
   z.object({
     topic: z.literal('trace-width'),
-    currentA: z.number().positive(),
-    temperatureRiseC: z.number().positive(),
+    currentA: currentASchema,
+    temperatureRiseC: temperatureRiseCSchema,
     layer: conductorLayerSchema,
-    copperWeightOz: z.number().positive(),
+    copperWeightOz: copperWeightOzSchema,
   }),
   z.object({
     topic: z.literal('max-current'),
-    traceWidthMils: z.number().positive(),
-    temperatureRiseC: z.number().positive(),
+    traceWidthMils: traceWidthMilsSchema,
+    temperatureRiseC: temperatureRiseCSchema,
     layer: conductorLayerSchema,
-    copperWeightOz: z.number().positive(),
+    copperWeightOz: copperWeightOzSchema,
   }),
   z.object({
     topic: z.literal('clearance'),
-    voltageV: z.number().nonnegative(),
+    voltageV: voltageVSchema,
     location: conductorLayerSchema,
   }),
   z.object({
@@ -79,9 +88,9 @@ const inputSchema = z.discriminatedUnion('topic', [
   }),
   z.object({
     topic: z.literal('bulk-capacitance'),
-    loadA: z.number().positive(),
-    minBulkCapacitanceUfPerA: z.number().positive().optional(),
-    minBulkCapacitanceUf: z.number().positive().optional(),
+    loadA: loadASchema,
+    minBulkCapacitanceUfPerA: minBulkCapacitanceUfPerASchema.optional(),
+    minBulkCapacitanceUf: minBulkCapacitanceUfSchema.optional(),
   }),
   z.object({
     topic: z.literal('dfm-checklist'),
@@ -89,6 +98,71 @@ const inputSchema = z.discriminatedUnion('topic', [
     id: z.string().optional(),
   }),
 ]);
+
+const inputSchema = z
+  .object({
+    topic: z
+      .enum([
+        'trace-width',
+        'max-current',
+        'clearance',
+        'protocol-routing',
+        'decoupling',
+        'bulk-capacitance',
+        'dfm-checklist',
+      ])
+      .describe('Reference topic to look up.'),
+    currentA: currentASchema
+      .optional()
+      .describe('Required when topic is trace-width. Load current in amperes.'),
+    traceWidthMils: traceWidthMilsSchema
+      .optional()
+      .describe('Required when topic is max-current. Trace width in mils.'),
+    temperatureRiseC: temperatureRiseCSchema
+      .optional()
+      .describe('Required for trace-width and max-current. Allowed temperature rise in °C.'),
+    layer: conductorLayerSchema
+      .optional()
+      .describe('Required for trace-width and max-current. Conductor layer location.'),
+    copperWeightOz: copperWeightOzSchema
+      .optional()
+      .describe('Required for trace-width and max-current. Copper weight in oz/ft².'),
+    voltageV: voltageVSchema
+      .optional()
+      .describe('Required when topic is clearance. Working voltage in volts.'),
+    location: conductorLayerSchema
+      .optional()
+      .describe('Required when topic is clearance. Clearance location.'),
+    protocol: protocolKeySchema
+      .optional()
+      .describe('Optional protocol filter when topic is protocol-routing.'),
+    category: z
+      .union([decouplingCategorySchema, dfmCategorySchema])
+      .optional()
+      .describe('Optional category filter for decoupling or dfm-checklist.'),
+    loadA: loadASchema
+      .optional()
+      .describe('Required when topic is bulk-capacitance. Load current in amperes.'),
+    minBulkCapacitanceUfPerA: minBulkCapacitanceUfPerASchema
+      .optional()
+      .describe('Optional minimum bulk capacitance per ampere in µF/A.'),
+    minBulkCapacitanceUf: minBulkCapacitanceUfSchema
+      .optional()
+      .describe('Optional absolute minimum bulk capacitance in µF.'),
+    id: z.string().optional().describe('Optional DFM checklist item id.'),
+  })
+  .superRefine((value, ctx) => {
+    const parsed = lookupInputSchema.safeParse(value);
+    if (parsed.success) return;
+
+    for (const issue of parsed.error.issues) {
+      ctx.addIssue({
+        code: 'custom',
+        path: issue.path,
+        message: issue.message,
+      });
+    }
+  });
 
 const traceWidthResultSchema = z.object({
   requiredAreaMils2: z.number(),
@@ -173,7 +247,7 @@ const outputSchema = z.object({
   error: z.string().optional(),
 });
 
-type LookupInput = z.infer<typeof inputSchema>;
+type LookupInput = z.infer<typeof lookupInputSchema>;
 type LookupOutput = z.infer<typeof outputSchema>;
 
 function handleLookup(input: LookupInput): LookupOutput {
@@ -272,12 +346,18 @@ function registerDesignRulesTools(
     inputSchema,
     outputSchema,
     handler: async (_ctx: ToolContext, params: unknown) => {
-      const input = params as LookupInput;
+      const topic =
+        typeof params === 'object' &&
+        params !== null &&
+        'topic' in params &&
+        typeof params.topic === 'string'
+          ? params.topic
+          : 'unknown';
       try {
-        return handleLookup(input);
+        return handleLookup(lookupInputSchema.parse(params));
       } catch (err) {
         return {
-          topic: input.topic,
+          topic,
           error: err instanceof Error ? err.message : String(err),
         };
       }

--- a/tests/unit/tools/design-rules.test.ts
+++ b/tests/unit/tools/design-rules.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { ToolRegistry } from '../../../src/tools/registry.js';
 import { type ToolContext } from '../../../src/tools/types.js';
 import { registerDesignRulesTools } from '../../../src/tools/L1_design_rules.js';
@@ -39,6 +42,50 @@ describe('Design Rules Tools', () => {
     expect(tool!.risk).toBe('low');
     expect(tool!.confirmWrite).toBe(false);
     expect(tool!.annotations.readOnlyHint).toBe(true);
+  });
+
+  it('publishes the complete input signature through MCP tools/list', async () => {
+    const server = new McpServer({ name: 'design-rules-schema-test', version: '1.0.0' });
+    const client = new Client({ name: 'design-rules-schema-client', version: '1.0.0' });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    registry.registerAllOnServer(server, context);
+
+    try {
+      await server.connect(serverTransport);
+      await client.connect(clientTransport);
+
+      const listed = await client.listTools();
+      const tool = listed.tools.find(
+        (candidate) => candidate.name === 'easyeda_design_rules_lookup',
+      );
+      const properties = tool?.inputSchema.properties as Record<string, unknown> | undefined;
+
+      expect(tool?.inputSchema.type).toBe('object');
+      expect(properties).toBeDefined();
+      expect(Object.keys(properties ?? {})).toEqual(
+        expect.arrayContaining([
+          'topic',
+          'currentA',
+          'traceWidthMils',
+          'temperatureRiseC',
+          'layer',
+          'copperWeightOz',
+          'voltageV',
+          'location',
+          'protocol',
+          'category',
+          'loadA',
+          'minBulkCapacitanceUfPerA',
+          'minBulkCapacitanceUf',
+          'id',
+        ]),
+      );
+      expect(tool?.inputSchema.required).toContain('topic');
+      expect(properties?.currentA).toMatchObject({ type: 'number' });
+      expect(properties?.copperWeightOz).toMatchObject({ type: 'number' });
+    } finally {
+      await Promise.allSettled([client.close(), server.close()]);
+    }
   });
 
   describe('topic: trace-width', () => {


### PR DESCRIPTION
## Summary
- publish `easyeda_design_rules_lookup` with a top-level object schema so MCP clients receive all parameter types
- preserve topic-specific validation through the existing discriminated union
- add an in-memory MCP `tools/list` regression test

## Verification
- `pnpm lint`
- `pnpm test` (1599 tests)
- `pnpm build`

Closes #292
