### PR TITLE
fix(bridge): stop truncating normalized API values

### DIFF
--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -664,44 +664,47 @@ function normalizeValue(value: unknown, depth = 3, seen = new WeakSet<object>())
   if (depth <= 0) return '[MaxDepth]';
 
   seen.add(value);
-
-  if (Array.isArray(value)) {
-    return value.slice(0, 100).map((item) => normalizeValue(item, depth - 1, seen));
-  }
-
-  const output: Record<string, JsonValue | undefined> = {};
-  const ctorName = (value as { constructor?: { name?: string } }).constructor?.name;
-  if (ctorName && ctorName !== 'Object') output.__class = ctorName;
-
-  const getterNames = getFunctionNames(value)
-    .filter((name) => name.startsWith('getState_'))
-    .slice(0, 80);
-  if (getterNames.length > 0) {
-    const state: Record<string, JsonValue | undefined> = {};
-    for (const getterName of getterNames) {
-      const getter = readMember(value, getterName);
-      if (typeof getter !== 'function') continue;
-      try {
-        state[getterName.replace(/^getState_/, '')] = normalizeValue(
-          getter.call(value),
-          depth - 1,
-          seen,
-        );
-      } catch (error) {
-        state[getterName.replace(/^getState_/, '')] = `ERROR: ${String(error)}`;
-      }
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item) => normalizeValue(item, depth - 1, seen));
     }
-    output.state = state;
+
+    const output: Record<string, JsonValue | undefined> = {};
+    const ctorName = (value as { constructor?: { name?: string } }).constructor?.name;
+    if (ctorName && ctorName !== 'Object') output.__class = ctorName;
+
+    const getterNames = getFunctionNames(value).filter((name) => name.startsWith('getState_'));
+    if (getterNames.length > 0) {
+      const state: Record<string, JsonValue | undefined> = {};
+      for (const getterName of getterNames) {
+        const getter = readMember(value, getterName);
+        if (typeof getter !== 'function') continue;
+        try {
+          state[getterName.replace(/^getState_/, '')] = normalizeValue(
+            getter.call(value),
+            depth - 1,
+            seen,
+          );
+        } catch (error) {
+          state[getterName.replace(/^getState_/, '')] = `ERROR: ${String(error)}`;
+        }
+      }
+      output.state = state;
+    }
+
+    const methodNames = getFunctionNames(value);
+    if (methodNames.length > 0) output.__methods = methodNames;
+
+    for (const key of Object.keys(value)) {
+      output[key] = normalizeValue((value as Record<string, unknown>)[key], depth - 1, seen);
+    }
+
+    return output;
+  } finally {
+    // Track only the active recursion path. Repeated references are valid data;
+    // only a reference back into the current path is a true cycle.
+    seen.delete(value);
   }
-
-  const methodNames = getFunctionNames(value).slice(0, 120);
-  if (methodNames.length > 0) output.__methods = methodNames;
-
-  for (const key of Object.keys(value).slice(0, 80)) {
-    output[key] = normalizeValue((value as Record<string, unknown>)[key], depth - 1, seen);
-  }
-
-  return output;
 }
 
 function normalizeStandalone(value: unknown, depth = 4): JsonValue {

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -436,6 +436,55 @@ describe('createDispatcher', () => {
     expect(result.resolvedPath).toBe('eda.SCH_PrimitiveWire.getAll');
   });
 
+  it('api.call normalization preserves complete arrays, objects, state, and method metadata', async () => {
+    const shared = { marker: 'shared' };
+    const introspected: Record<string, unknown> = Object.fromEntries(
+      Array.from({ length: 90 }, (_, index) => [`key${index}`, index]),
+    );
+    for (let index = 0; index < 90; index += 1) {
+      introspected[`getState_Field${index}`] = () => index;
+    }
+    for (let index = 0; index < 130; index += 1) {
+      introspected[`method${index}`] = () => index;
+    }
+
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        SCH_PrimitiveWire: {
+          getAll: async () => ({
+            items: Array.from({ length: 151 }, (_, index) => index),
+            introspected,
+            repeatedReferences: [shared, shared],
+          }),
+        },
+      }),
+    );
+    const response = (await dispatcher.dispatch('api.call', {
+      path: 'SCH_PrimitiveWire.getAll',
+      args: [],
+    })) as {
+      result: {
+        items: number[];
+        introspected: {
+          key89: number;
+          state: Record<string, unknown>;
+          __methods: string[];
+        };
+        repeatedReferences: Array<Record<string, unknown>>;
+      };
+    };
+
+    expect(response.result.items).toHaveLength(151);
+    expect(response.result.items.at(-1)).toBe(150);
+    expect(response.result.introspected.key89).toBe(89);
+    expect(response.result.introspected.state.Field89).toBe(89);
+    expect(response.result.introspected.__methods).toContain('method129');
+    expect(response.result.repeatedReferences).toEqual([
+      { marker: 'shared' },
+      { marker: 'shared' },
+    ]);
+  });
+
   it('system.getStatus reports capabilities equal to methodList and the build id', async () => {
     const dispatcher = createDispatcher(makeToolkit({}));
     const status = (await dispatcher.dispatch('system.getStatus', {})) as {


### PR DESCRIPTION
## Summary
- remove fixed item caps from normalized arrays, object keys, state getters, and method metadata
- treat only active recursion-path references as circular
- add regression coverage for 151-item arrays and wide runtime objects

## Verification
- `pnpm lint`
- `pnpm typecheck`
- `pnpm typecheck:extension`
- `pnpm test` (1598 tests)
- `pnpm test:extension` (104 tests)
- `pnpm build`
- `pnpm build:extension`

Closes #295
