### PR TITLE
fix(visual): capture requested canvas regions reliably

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -549,13 +549,13 @@ Returns a JSON object matching the schema:
 
 ### Input Parameters
 
-| Parameter | Type                | Required | Description |
-| --------- | ------------------- | -------- | ----------- |
-| `left`    | `number`            | Yes      |             |
-| `right`   | `number`            | Yes      |             |
-| `top`     | `number`            | Yes      |             |
-| `bottom`  | `number`            | Yes      |             |
-| `tabId`   | `string (optional)` | No       |             |
+| Parameter | Type                | Required | Description                                            |
+| --------- | ------------------- | -------- | ------------------------------------------------------ |
+| `left`    | `number`            | Yes      | First horizontal edge in document/canvas coordinates.  |
+| `right`   | `number`            | Yes      | Second horizontal edge; either edge order is accepted. |
+| `top`     | `number`            | Yes      | First vertical edge in document/canvas coordinates.    |
+| `bottom`  | `number`            | Yes      | Second vertical edge; either edge order is accepted.   |
+| `tabId`   | `string (optional)` | No       |                                                        |
 
 ### Output Format
 

--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -565,6 +565,64 @@ async function normalizeBinaryResultSafely(
   return normalized;
 }
 
+interface CanvasRegion {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+function normalizeCanvasRegion(value: CanvasRegion): CanvasRegion {
+  const coordinates = [value.left, value.right, value.top, value.bottom];
+  if (!coordinates.every(Number.isFinite)) {
+    throw newBridgeError(
+      'INVALID_PARAMS',
+      'Capture region coordinates must be finite numbers.',
+      'Provide finite left, right, top, and bottom document coordinates.',
+    );
+  }
+
+  const region = {
+    left: Math.min(value.left, value.right),
+    right: Math.max(value.left, value.right),
+    top: Math.max(value.top, value.bottom),
+    bottom: Math.min(value.top, value.bottom),
+  };
+  if (region.left === region.right || region.top === region.bottom) {
+    throw newBridgeError(
+      'INVALID_PARAMS',
+      'Capture region must have non-zero width and height.',
+      'Expand the bounds around the component before capturing it.',
+    );
+  }
+  return region;
+}
+
+async function waitForCanvasPaint(): Promise<void> {
+  const requestFrame = (globalThis as { requestAnimationFrame?: (callback: () => void) => number })
+    .requestAnimationFrame;
+  if (typeof requestFrame === 'function') {
+    await new Promise<void>((resolve) => {
+      let settled = false;
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timeout);
+        resolve();
+      };
+      // A minimized/background Electron window can suspend animation frames.
+      // Keep capture bounded instead of waiting indefinitely for repaint.
+      const timeout = setTimeout(finish, 75);
+      requestFrame.call(globalThis, () => requestFrame.call(globalThis, finish));
+    });
+    return;
+  }
+
+  // Vitest/Node and older extension shells may not expose requestAnimationFrame.
+  // A macrotask still lets an asynchronously scheduled canvas update settle.
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
 function withClassNameVariants(paths: string[]): string[] {
   const variants: string[] = [];
   for (const path of paths) {
@@ -4276,14 +4334,24 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
       return normalizeBinaryResultSafely(blob, 'capture.png');
     }
     case 'canvas.captureRegion': {
-      const { left, right, top, bottom, tabId } = params as {
-        left: number;
-        right: number;
-        top: number;
-        bottom: number;
-        tabId?: string;
-      };
-      await callFirst(['DMT_EditorControl.zoomToRegion'], left, right, top, bottom, tabId);
+      const { tabId } = params as { tabId?: string };
+      const region = normalizeCanvasRegion(params as unknown as CanvasRegion);
+      const zoomed = await callFirst(
+        ['DMT_EditorControl.zoomToRegion'],
+        region.left,
+        region.right,
+        region.top,
+        region.bottom,
+        tabId,
+      );
+      if (zoomed === false) {
+        throw newBridgeError(
+          'EASYEDA_API_ERROR',
+          'EasyEDA could not zoom to the requested capture region.',
+          'Verify that the target tab is open and the region uses document/canvas coordinates.',
+        );
+      }
+      await waitForCanvasPaint();
       const blob = await callFirst(['DMT_EditorControl.getCurrentRenderedAreaImage'], tabId);
       return normalizeBinaryResultSafely(blob, 'capture-region.png');
     }

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -485,6 +485,81 @@ describe('createDispatcher', () => {
     ]);
   });
 
+  it('canvas.captureRegion normalizes bounds before capturing the settled viewport', async () => {
+    const callOrder: string[] = [];
+    const zoomToRegion = vi.fn(async () => {
+      callOrder.push('zoom');
+      return true;
+    });
+    const getCurrentRenderedAreaImage = vi.fn(async () => {
+      callOrder.push('capture');
+      return new Blob(['png'], { type: 'image/png' });
+    });
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        DMT_EditorControl: { zoomToRegion, getCurrentRenderedAreaImage },
+      }),
+    );
+
+    const result = (await dispatcher.dispatch('canvas.captureRegion', {
+      left: 100,
+      right: 0,
+      top: 0,
+      bottom: 50,
+      tabId: 'tab-1',
+    })) as { base64: string; fileName: string; byteLength: number };
+
+    expect(zoomToRegion).toHaveBeenCalledWith(0, 100, 50, 0, 'tab-1');
+    expect(getCurrentRenderedAreaImage).toHaveBeenCalledWith('tab-1');
+    expect(callOrder).toEqual(['zoom', 'capture']);
+    expect(result).toMatchObject({
+      base64: Buffer.from('png').toString('base64'),
+      fileName: 'capture-region.png',
+      byteLength: 3,
+    });
+  });
+
+  it('canvas.captureRegion rejects zero-area bounds without touching the editor', async () => {
+    const zoomToRegion = vi.fn(async () => true);
+    const getCurrentRenderedAreaImage = vi.fn(async () => new Blob(['png']));
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        DMT_EditorControl: { zoomToRegion, getCurrentRenderedAreaImage },
+      }),
+    );
+
+    await expect(
+      dispatcher.dispatch('canvas.captureRegion', {
+        left: 10,
+        right: 10,
+        top: 20,
+        bottom: 0,
+      }),
+    ).rejects.toMatchObject({ code: 'INVALID_PARAMS' });
+    expect(zoomToRegion).not.toHaveBeenCalled();
+    expect(getCurrentRenderedAreaImage).not.toHaveBeenCalled();
+  });
+
+  it('canvas.captureRegion does not capture when EasyEDA rejects the zoom', async () => {
+    const zoomToRegion = vi.fn(async () => false);
+    const getCurrentRenderedAreaImage = vi.fn(async () => new Blob(['png']));
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        DMT_EditorControl: { zoomToRegion, getCurrentRenderedAreaImage },
+      }),
+    );
+
+    await expect(
+      dispatcher.dispatch('canvas.captureRegion', {
+        left: 0,
+        right: 10,
+        top: 10,
+        bottom: 0,
+      }),
+    ).rejects.toMatchObject({ code: 'EASYEDA_API_ERROR' });
+    expect(getCurrentRenderedAreaImage).not.toHaveBeenCalled();
+  });
+
   it('system.getStatus reports capabilities equal to methodList and the build id', async () => {
     const dispatcher = createDispatcher(makeToolkit({}));
     const status = (await dispatcher.dispatch('system.getStatus', {})) as {

--- a/src/tools/L1_visual.ts
+++ b/src/tools/L1_visual.ts
@@ -99,6 +99,26 @@ function readPngDimensions(base64: string): { width: number; height: number } | 
   return width > 0 && height > 0 ? { width, height } : undefined;
 }
 
+interface CanvasRegion {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+function normalizeCanvasRegion(region: CanvasRegion): CanvasRegion {
+  const normalized = {
+    left: Math.min(region.left, region.right),
+    right: Math.max(region.left, region.right),
+    top: Math.max(region.top, region.bottom),
+    bottom: Math.min(region.top, region.bottom),
+  };
+  if (normalized.left === normalized.right || normalized.top === normalized.bottom) {
+    throw new Error('Capture region must have non-zero width and height.');
+  }
+  return normalized;
+}
+
 function registerVisualTools(
   registry: { register: (def: ToolDefinition) => void },
   _config: EnvConfig,
@@ -161,10 +181,10 @@ function registerVisualTools(
       idempotentHint: false,
     },
     inputSchema: z.object({
-      left: z.number(),
-      right: z.number(),
-      top: z.number(),
-      bottom: z.number(),
+      left: z.number().describe('First horizontal edge in document/canvas coordinates.'),
+      right: z.number().describe('Second horizontal edge; either edge order is accepted.'),
+      top: z.number().describe('First vertical edge in document/canvas coordinates.'),
+      bottom: z.number().describe('Second vertical edge; either edge order is accepted.'),
       tabId: z.string().optional(),
     }),
     outputSchema: captureOutputSchema,
@@ -179,11 +199,9 @@ function registerVisualTools(
         tabId?: string;
       };
       try {
+        const region = normalizeCanvasRegion({ left, right, top, bottom });
         const result = await ctx.bridge.call('canvas.captureRegion', {
-          left,
-          right,
-          top,
-          bottom,
+          ...region,
           tabId,
         });
         return buildCaptureOutput(result);

--- a/tests/unit/tools/visual.test.ts
+++ b/tests/unit/tools/visual.test.ts
@@ -109,7 +109,7 @@ describe('Visual Tools', () => {
   });
 
   describe('easyeda_canvas_capture_region', () => {
-    it('zooms to the region and returns the captured image', async () => {
+    it('normalizes the region bounds and returns the captured image', async () => {
       const tool = registry.get('easyeda_canvas_capture_region');
       expect(tool).toBeDefined();
 
@@ -120,8 +120,8 @@ describe('Visual Tools', () => {
       });
 
       const result = await tool?.handler(context, {
-        left: 0,
-        right: 100,
+        left: 100,
+        right: 0,
         top: 0,
         bottom: 50,
         tabId: 'tab-1',
@@ -130,11 +130,29 @@ describe('Visual Tools', () => {
       expect(bridgeCall).toHaveBeenCalledWith('canvas.captureRegion', {
         left: 0,
         right: 100,
-        top: 0,
-        bottom: 50,
+        top: 50,
+        bottom: 0,
         tabId: 'tab-1',
       });
       expect(result).toMatchObject({ captured: true, image_base64: 'cmVnaW9uLWJ5dGVz' });
+    });
+
+    it('rejects a zero-area region before calling the bridge', async () => {
+      const tool = registry.get('easyeda_canvas_capture_region');
+
+      const result = await tool?.handler(context, {
+        left: 10,
+        right: 10,
+        top: 20,
+        bottom: 0,
+      });
+
+      expect(bridgeCall).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        captured: false,
+        not_available: true,
+        error: 'Capture region must have non-zero width and height.',
+      });
     });
 
     it('reports not_available on bridge error', async () => {


### PR DESCRIPTION
## Summary
- canonicalize capture bounds before calling EasyEDA's `zoomToRegion`
- reject zero-area regions and failed zoom operations instead of capturing a misleading viewport
- wait for the canvas repaint before reading the rendered image, with a bounded fallback for background windows
- document edge-order behavior and add MCP/extension regression tests

## Verification
- `pnpm format:check`
- `pnpm lint`
- `pnpm lint:tools`
- `pnpm typecheck`
- `pnpm typecheck:extension`
- `pnpm verify:tool-coverage`
- `pnpm test` (1599 tests)
- `pnpm test:coverage` (88% statements, 75.96% branches)
- `pnpm test:extension` (106 tests)
- `pnpm build`
- `pnpm build:extension`
- `pnpm verify:extension`
- `pnpm check:metadata`
- `pnpm docs:build`

Closes #294
