### PR TITLE
fix(bridge): align extension registry and modernize actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+      time: '06:00'
+      timezone: Europe/Istanbul
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/agent-runtime-config.yml
+++ b/.github/workflows/agent-runtime-config.yml
@@ -32,8 +32,8 @@ jobs:
   validate:
     runs-on: ubuntu-24.04
     steps:
-      # actions/checkout v4.3.1
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      # actions/checkout v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       - name: Validate JSON files
         run: |
           python3 -m json.tool .claude-plugin/plugin.json >/dev/null

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Assign to oaslananka
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         continue-on-error: true
         with:
           script: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
             node-version: '26'
           - os: windows-latest
             node-version: '24'
-          - os: macos-latest
+          - os: macos-26
             node-version: '24'
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       # actions/checkout v6.0.3
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       # pnpm/action-setup v6.0.8
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
       # actions/setup-node v6.4.0
@@ -55,8 +55,8 @@ jobs:
           npm pack --pack-destination artifacts
       - name: Upload PR test artifact
         if: github.event_name == 'pull_request'
-        # actions/upload-artifact v4
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # actions/upload-artifact v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: easyeda-mcp-pro-pr-${{ github.event.pull_request.number }}
           path: |
@@ -98,7 +98,7 @@ jobs:
 
     steps:
       # actions/checkout v6.0.3
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       # pnpm/action-setup v6.0.8
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
       # actions/setup-node v6.4.0
@@ -125,7 +125,7 @@ jobs:
 
     steps:
       # actions/checkout v6.0.3
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       # pnpm/action-setup v6.0.8
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
       # actions/setup-node v6.4.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -18,7 +18,7 @@ jobs:
     if: github.repository_owner == 'oaslananka'
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
       - uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        # actions/checkout v4.1.1
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        # actions/checkout v7.0.0
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Install pnpm
         # pnpm/action-setup v4.0.0

--- a/.github/workflows/golden-benchmark.yml
+++ b/.github/workflows/golden-benchmark.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       # actions/checkout v6.0.3
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       # pnpm/action-setup v6.0.8
       - uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
       # actions/setup-node v6.4.0
@@ -33,8 +33,8 @@ jobs:
 
       - name: Upload benchmark report
         if: always()
-        # actions/upload-artifact v4
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # actions/upload-artifact v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: golden-benchmark-report
           path: .easyeda-mcp-pro/evals/ci-latest.json

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -45,20 +45,20 @@ jobs:
         id: status
         run: |
           if [ "${{ steps.release.outputs.release_created }}" = "true" ] || [ -n "${{ github.event.inputs.tag_name }}" ]; then
-            echo "RELEASE_RUN=true" >> $GITHUB_ENV
+            echo "RELEASE_RUN=true" >> "$GITHUB_ENV"
             if [ -n "${{ github.event.inputs.tag_name }}" ]; then
-              echo "RELEASE_TAG=${{ github.event.inputs.tag_name }}" >> $GITHUB_ENV
+              echo "RELEASE_TAG=${{ github.event.inputs.tag_name }}" >> "$GITHUB_ENV"
             else
-              echo "RELEASE_TAG=${{ steps.release.outputs.tag_name }}" >> $GITHUB_ENV
+              echo "RELEASE_TAG=${{ steps.release.outputs.tag_name }}" >> "$GITHUB_ENV"
             fi
           else
-            echo "RELEASE_RUN=false" >> $GITHUB_ENV
+            echo "RELEASE_RUN=false" >> "$GITHUB_ENV"
           fi
 
-      # actions/checkout v4.1.1
+      # actions/checkout v7.0.0
       - name: Checkout Code
         if: ${{ env.RELEASE_RUN == 'true' }}
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       # pnpm/action-setup v4.0.0
       - name: Setup pnpm
@@ -112,15 +112,15 @@ jobs:
 
       - name: Upload SBOM Artifact
         if: ${{ env.RELEASE_RUN == 'true' }}
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sbom
           path: sbom.json
 
       - name: Attach Build Provenance (SLSA + Sigstore)
         if: ${{ env.RELEASE_RUN == 'true' }}
-        # actions/attest-build-provenance v2.4.0
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be
+        # actions/attest-build-provenance v4.1.1
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373
         with:
           subject-path: |
             dist/**
@@ -182,11 +182,11 @@ jobs:
       contents: read
       packages: write
     steps:
-      # actions/checkout v4.1.1
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      # actions/checkout v7.0.0
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -197,16 +197,16 @@ jobs:
         run: |
           RAW_TAG="${{ needs.release-please.outputs.tag_name }}"
           CLEAN_VER="${RAW_TAG##*v}"
-          echo "version=${CLEAN_VER}" >> $GITHUB_OUTPUT
+          echo "version=${CLEAN_VER}" >> "$GITHUB_OUTPUT"
           if [[ "$CLEAN_VER" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            echo "major_minor=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
+            echo "major_minor=${BASH_REMATCH[1]}.${BASH_REMATCH[2]}" >> "$GITHUB_OUTPUT"
           else
-            echo "major_minor=${CLEAN_VER}" >> $GITHUB_OUTPUT
+            echo "major_minor=${CLEAN_VER}" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Extract metadata for Docker
         id: meta
-        uses: docker/metadata-action@8e5442c4ef9f78752691e2d8f8d19755c6f78e81 # v5.5.1
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
@@ -215,13 +215,13 @@ jobs:
             type=raw,value=latest
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           push: true

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       # actions/checkout v6.0.3
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           persist-credentials: false
 
@@ -35,8 +35,8 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF results
-        # actions/upload-artifact v4
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        # actions/upload-artifact v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: SARIF file
           path: results.sarif

--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -96,6 +96,7 @@ const METHOD_LIST: readonly string[] = [
   'schematic.listRectangles',
   'schematic.modifyPrimitive',
   'schematic.placeComponent',
+  'schematic.primitiveBounds',
   'schematic.recreatePrimitiveSnapshot',
   'schematic.restorePrimitiveSnapshot',
   'schematic.searchDevice',

--- a/tests/unit/extension/method-list-parity.test.ts
+++ b/tests/unit/extension/method-list-parity.test.ts
@@ -1,0 +1,29 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { EasyedaApiMethodSchema } from '../../../src/bridge/types.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const dispatcherSourcePath = resolve(
+  __dirname,
+  '../../../easyeda-bridge-extension/src/dispatcher.ts',
+);
+
+function extractDispatcherMethodList(source: string): string[] {
+  const match = source.match(/const METHOD_LIST:[\s\S]*?= \[([\s\S]*?)\];/);
+  if (!match) throw new Error('Could not locate dispatcher METHOD_LIST');
+  return [...match[1].matchAll(/'([^']+)'/g)].map((entry) => entry[1]);
+}
+
+describe('extension dispatcher method registry parity', () => {
+  it('matches the server EasyedaApiMethodSchema exactly', () => {
+    const extensionMethods = extractDispatcherMethodList(
+      readFileSync(dispatcherSourcePath, 'utf8'),
+    );
+    const serverMethods = [...EasyedaApiMethodSchema.options];
+
+    expect(new Set(extensionMethods).size).toBe(extensionMethods.length);
+    expect([...extensionMethods].sort()).toEqual([...serverMethods].sort());
+  });
+});


### PR DESCRIPTION
## Summary

- add the implemented `schematic.primitiveBounds` endpoint to the extension dispatcher's advertised method registry
- add a regression test that requires exact parity between the server API schema and extension `METHOD_LIST`
- upgrade every direct Node.js 20 GitHub Action pin to its current Node.js 24 release
- upgrade the release provenance and Docker action stack to Node.js 24-compatible releases
- add weekly Dependabot monitoring for GitHub Actions
- quote GitHub environment/output files so `actionlint` is warning-free

## Live finding

After installing the v0.34.1 extension package, the server reported:

- extension method-list hash: `d2e328c1327cd37c`
- server registry hash: `3775409d36313038`

The exact set difference was `schematic.primitiveBounds`. Its dispatcher implementation already existed; only the advertised registry entry was missing.

## Verification

- `actionlint`
- all workflow YAML files parsed successfully
- all direct JavaScript action pins resolve to Node.js 24; relevant composite actions resolve internally to Node.js 24 actions
- root tests: 137 files / 1601 tests
- extension tests: 8 files / 107 tests
- typecheck and extension typecheck
- ESLint and Prettier
- tool metadata lint and tool coverage verification
- server build, extension build, extension package verification, metadata check
