### PR TITLE
fix(security): require authentication for non-loopback bridge listeners

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,7 @@ MCP_V2_EXPERIMENTAL=false
 MCP_RAW_EXEC_EXPERIMENTAL=false
 
 # ── Bridge ─────────────────────────────────────────────────
+# Non-loopback bridge listeners require a strong BRIDGE_TOKEN for pairing.
 BRIDGE_HOST=127.0.0.1
 BRIDGE_PORT=49620
 BRIDGE_PORT_SCAN=49620-49629

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -26,12 +26,16 @@ Please report vulnerabilities privately via [GitHub Security Advisories](https:/
 
 ## Safe Config Enforcement
 
-In `production` mode the server enforces:
+At startup the server enforces:
+
+- non-loopback `BRIDGE_HOST` requires a non-empty `BRIDGE_TOKEN` for pairing
+- all environment variables are validated through a strict Zod schema
+
+In `production` mode the server additionally enforces:
 
 - `BRIDGE_RAW_EXEC_ENABLED` must be `false`
 - `JLCPCB_ENABLE_ORDERING` requires `JLCPCB_MODE=approved_api`
 - `HTTP_HOST` bound to `127.0.0.1` unless `OAUTH_ENABLED` is `true`
-- All env vars validated through a strict Zod schema at startup
 
 ## Response Process
 

--- a/src/cli/local-setup.ts
+++ b/src/cli/local-setup.ts
@@ -7,7 +7,7 @@ import { promisify } from 'node:util';
 import { ToolRegistry } from '../tools/registry.js';
 import { registerBuiltinTools } from '../tools/register.js';
 import { type ToolProfile } from '../config/profiles.js';
-import { EnvSchema, type EnvConfig } from '../config/env.js';
+import { EnvSchema, getBridgePairingConfigIssue, type EnvConfig } from '../config/env.js';
 import { parsePortScanSpec } from '../bridge/manager.js';
 
 type CliCommand =
@@ -511,10 +511,16 @@ async function checkTcpPort(host: string, port: number, timeoutMs = 2000): Promi
 
 function parseCliEnv(): { config?: EnvConfig; issues: string[] } {
   const result = EnvSchema.safeParse(process.env);
-  if (result.success) return { config: result.data, issues: [] };
-  return {
-    issues: result.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`),
-  };
+  if (!result.success) {
+    return {
+      issues: result.error.issues.map((issue) => `${issue.path.join('.')}: ${issue.message}`),
+    };
+  }
+
+  const bridgePairingIssue = getBridgePairingConfigIssue(result.data);
+  if (bridgePairingIssue) return { issues: [bridgePairingIssue] };
+
+  return { config: result.data, issues: [] };
 }
 
 function readPackageInfo(packageRoot: string): PackageInfo {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -177,12 +177,28 @@ export function loadEnvConfig(): EnvConfig {
   return result.data;
 }
 
-/** Check whether HTTP_HOST refers to a loopback address. */
+/** Check whether a host refers to a loopback address. */
 function isLoopbackHost(host: string): boolean {
   return host === '127.0.0.1' || host === 'localhost' || host === '::1';
 }
 
+export function getBridgePairingConfigIssue(config: EnvConfig): string | undefined {
+  if (isLoopbackHost(config.BRIDGE_HOST) || config.BRIDGE_TOKEN) return undefined;
+  return (
+    'SAFETY: BRIDGE_HOST is not a loopback address but BRIDGE_TOKEN is empty. ' +
+    'Non-loopback bridge listeners require a pairing token. ' +
+    'Set BRIDGE_TOKEN to a strong secret or use BRIDGE_HOST=127.0.0.1 for local operation.'
+  );
+}
+
 export function validateSafeConfig(config: EnvConfig): void {
+  // ── Bridge pairing policy ────────────────────────────────
+  const bridgePairingIssue = getBridgePairingConfigIssue(config);
+  if (bridgePairingIssue) {
+    console.error(bridgePairingIssue);
+    process.exit(1);
+  }
+
   // ── CORS / origin policy ─────────────────────────────────
   if (config.TRANSPORT === 'http' && !isLoopbackHost(config.HTTP_HOST) && !config.ALLOWED_ORIGINS) {
     // Logger not yet initialized — env config is loaded first

--- a/tests/unit/cli/local-setup.test.ts
+++ b/tests/unit/cli/local-setup.test.ts
@@ -368,6 +368,19 @@ describe('local setup CLI helpers', () => {
       });
     });
 
+    it('reports a non-loopback bridge without a pairing token as unsafe', async () => {
+      await withEnv(
+        { BRIDGE_HOST: '0.0.0.0', BRIDGE_TOKEN: '', BRIDGE_PORT_SCAN: '1' },
+        async () => {
+          const report = await createDoctorReport();
+
+          expect(report.envValid).toBe(false);
+          expect(report.envIssues.join(' ')).toContain('BRIDGE_TOKEN');
+          expect(report.toolCounts).toBeUndefined();
+        },
+      );
+    });
+
     it('surfaces environment validation issues and omits tool counts', async () => {
       await withEnv({ HTTP_PORT: 'not-a-number', BRIDGE_PORT_SCAN: '1' }, async () => {
         const report = await createDoctorReport();

--- a/tests/unit/config/env.test.ts
+++ b/tests/unit/config/env.test.ts
@@ -279,6 +279,8 @@ describe('validateSafeConfig', () => {
     OAUTH_ISSUER: '',
     OAUTH_AUDIENCE: 'easyeda-mcp-pro',
     HTTP_PORT: 3000,
+    BRIDGE_HOST: '127.0.0.1',
+    BRIDGE_TOKEN: '',
     BRIDGE_RAW_EXEC_ENABLED: false,
     JLCPCB_ENABLE_ORDERING: false,
     JLCPCB_MODE: 'disabled' as const,
@@ -363,6 +365,39 @@ describe('validateSafeConfig', () => {
         OAUTH_AUDIENCE: 'my-app',
         HTTP_HOST: '0.0.0.0',
         ALLOWED_ORIGINS: 'https://example.com',
+      }),
+    ).not.toThrow();
+  });
+
+  it('should reject a non-loopback bridge without a pairing token', () => {
+    expect(() =>
+      validateSafeConfig({
+        ...baseConfig,
+        BRIDGE_HOST: '0.0.0.0',
+        BRIDGE_TOKEN: '',
+      }),
+    ).toThrow('process.exit called');
+  });
+
+  it.each(['127.0.0.1', 'localhost', '::1'])(
+    'should allow loopback bridge host %s without a pairing token',
+    (bridgeHost) => {
+      expect(() =>
+        validateSafeConfig({
+          ...baseConfig,
+          BRIDGE_HOST: bridgeHost,
+          BRIDGE_TOKEN: '',
+        }),
+      ).not.toThrow();
+    },
+  );
+
+  it('should allow a non-loopback bridge when a pairing token is configured', () => {
+    expect(() =>
+      validateSafeConfig({
+        ...baseConfig,
+        BRIDGE_HOST: '0.0.0.0',
+        BRIDGE_TOKEN: 'test-pairing-secret',
       }),
     ).not.toThrow();
   });


### PR DESCRIPTION
## Summary
- require `EASYEDA_BRIDGE_TOKEN` when the bridge binds to a non-loopback host
- preserve tokenless local development for loopback listeners
- update local setup guidance, `.env.example`, and security documentation
- add RED→GREEN regression coverage for environment validation and local setup output

## Verification
- `pnpm verify`
- 138 server test files / 1,613 server tests passed
- 8 extension test files / 111 extension tests passed
- TypeScript, ESLint, format, metadata, server build, extension build, `.eext` packaging, and documentation build passed

Fixes #308