### PR TITLE
fix(bridge): recover from silent EasyEDA register sockets

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -17,13 +17,13 @@ This document lists the tested and supported versions, environments, and clients
 
 ## 2. EasyEDA Pro Versions
 
-| EasyEDA Pro Version         | Tested Status        | Notes                                                                                                               |
-| :-------------------------- | :------------------- | :------------------------------------------------------------------------------------------------------------------ |
-| **v3.2.x** (Desktop / Web)  | **Supported**        | Requires **Allow External Interaction**. v3.2.148 needs the bridge open-callback fallback introduced for issue #47. |
-| **v2.2.x** (Desktop / Web)  | **Verified**         | Primary development target. Full compatibility.                                                                     |
-| **v2.1.x**                  | **Needs Validation** | Mostly compatible, but some schematic APIs may be missing.                                                          |
-| **v2.0.x**                  | **Needs Validation** | Underlying extension APIs might not expose required methods.                                                        |
-| **v1.x** (Standard Edition) | **Unsupported**      | Standard edition does not support the Pro extension platform.                                                       |
+| EasyEDA Pro Version         | Tested Status        | Notes                                                                                                                                                                                                                      |
+| :-------------------------- | :------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **v3.2.x** (Desktop / Web)  | **Supported**        | Requires **Allow External Interaction**. Some v3.2 runtimes accept `SYS_WebSocket.register()` without reporting open; the bridge safely closes that handle and retries with `SYS_WebSocket.create()` or browser WebSocket. |
+| **v2.2.x** (Desktop / Web)  | **Verified**         | Primary development target. Full compatibility.                                                                                                                                                                            |
+| **v2.1.x**                  | **Needs Validation** | Mostly compatible, but some schematic APIs may be missing.                                                                                                                                                                 |
+| **v2.0.x**                  | **Needs Validation** | Underlying extension APIs might not expose required methods.                                                                                                                                                               |
+| **v1.x** (Standard Edition) | **Unsupported**      | Standard edition does not support the Pro extension platform.                                                                                                                                                              |
 
 ---
 
@@ -43,11 +43,11 @@ This document lists the tested and supported versions, environments, and clients
 
 ## 4. Operating Systems
 
-| OS                                | Supported    | Notes                           |
-| :-------------------------------- | :----------- | :------------------------------ |
-| **Windows 10/11**                 | **Verified** | Tested with PowerShell and CMD. |
-| **macOS** (Intel / Apple Silicon) | **Verified** | Tested with zsh.                |
-| **Linux** (Ubuntu / Fedora)       | **Verified** | Tested with bash.               |
+| OS                                | Supported                                  | Notes                                                                                                                                                                                       |
+| :-------------------------------- | :----------------------------------------- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Windows 10/11**                 | **Verified**                               | Tested with PowerShell and CMD.                                                                                                                                                             |
+| **macOS** (Intel / Apple Silicon) | **Supported; release validation required** | Automated coverage models the EasyEDA Pro 3.2.149 silent-register behavior without an `eda` global. Packaged `.eext` validation on affected macOS hardware remains required before release. |
+| **Linux** (Ubuntu / Fedora)       | **Verified**                               | Tested with bash.                                                                                                                                                                           |
 
 ---
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -42,6 +42,7 @@ The AI client (e.g. Claude Desktop or Cursor) displays an error: `"Failed to sta
    bridge extension's version differs from the installed `easyeda-mcp-pro` package
    version. Update the extension in EasyEDA Pro (Settings → Extensions → Extension
    Manager) or reinstall `easyeda-bridge-extension.eext` from a matching release.
+6. **Read the connection phase**: Newer bridge builds append the last failed phase to the offline message. In particular, `SYS_WebSocket.register() ... did not invoke its open callback` means the EasyEDA runtime accepted the preferred registration API but never reported a usable socket. The extension closes that handle without sending and retries the same port through `SYS_WebSocket.create()` and then browser WebSocket. If no alternate API exists, the phase remains visible instead of being collapsed into the generic `no local server found` message. Other phase messages distinguish an unavailable socket API, an open timeout, a socket that opened without returning bridge `hello`, an early close, and an explicit socket error.
 
 ---
 

--- a/easyeda-bridge-extension/src/connection-policy.ts
+++ b/easyeda-bridge-extension/src/connection-policy.ts
@@ -7,6 +7,7 @@ export const BRIDGE_PORT = 49_620;
 export const PORT_SCAN_COUNT = 10;
 export const PRIMARY_CONNECT_TIMEOUT_MS = 8_000;
 export const FALLBACK_CONNECT_TIMEOUT_MS = 1_000;
+export const REGISTER_OPEN_CALLBACK_TIMEOUT_MS = 600;
 export const RECONNECT_BASE_MS = 500;
 export const RECONNECT_MAX_MS = 5_000;
 export const HEARTBEAT_INTERVAL_MS = 15_000;

--- a/easyeda-bridge-extension/src/index.ts
+++ b/easyeda-bridge-extension/src/index.ts
@@ -10,6 +10,7 @@ import {
   HEARTBEAT_INTERVAL_MS,
   isServerActivityMessage,
   reconnectDelayMs,
+  REGISTER_OPEN_CALLBACK_TIMEOUT_MS,
   shouldReconnectAfterSocketFailure,
 } from './connection-policy.js';
 import {
@@ -157,6 +158,26 @@ interface SocketHandle {
   raw?: EasyedaSocket | WebSocket;
 }
 
+interface CreateSocketOptions {
+  skipRegister?: boolean;
+}
+
+type LocalConnectionPhase =
+  | 'register-open-timeout'
+  | 'socket-api-unavailable'
+  | 'socket-open-timeout'
+  | 'hello-timeout'
+  | 'socket-closed'
+  | 'socket-error';
+
+interface LocalConnectionDiagnostic {
+  phase: LocalConnectionPhase;
+  port: number;
+  transport?: SocketHandle['type'];
+  message: string;
+  priority: number;
+}
+
 const BRIDGE_PROTOCOL = 'easyeda-mcp-pro.bridge';
 const BRIDGE_VERSION = '1.0.0';
 const BRIDGE_CONTRACT_VERSION = 1;
@@ -174,6 +195,7 @@ let manualDisconnectRequested = false;
 let reconnectTimer: RuntimeTimerHandle | null = null;
 let heartbeatTimer: RuntimeTimerHandle | null = null;
 let lastServerActivityMs = 0;
+let lastLocalConnectionDiagnostic: LocalConnectionDiagnostic | null = null;
 let externalInteractionWarningShown = false;
 // Updated from the server's `hello` message; matches BRIDGE_MAX_PAYLOAD_SIZE default
 // until the handshake completes.
@@ -196,6 +218,26 @@ const runtimeTimers = createRuntimeTimers(
   globalThis as any,
   SOCKET_ID,
 );
+
+function recordLocalConnectionDiagnostic(diagnostic: LocalConnectionDiagnostic): void {
+  log(`Local bridge connection phase ${diagnostic.phase}`, {
+    port: diagnostic.port,
+    transport: diagnostic.transport,
+    message: diagnostic.message,
+  });
+  const effectivePriority = diagnostic.priority + (diagnostic.port === preferredPort ? 1_000 : 0);
+  if (
+    !lastLocalConnectionDiagnostic ||
+    effectivePriority >= lastLocalConnectionDiagnostic.priority
+  ) {
+    lastLocalConnectionDiagnostic = { ...diagnostic, priority: effectivePriority };
+  }
+}
+
+function localConnectionDiagnosticSuffix(): string {
+  if (!lastLocalConnectionDiagnostic) return '';
+  return ` — ${lastLocalConnectionDiagnostic.message}`;
+}
 
 function showToast(message: string): void {
   const safeMessage = String(message);
@@ -684,6 +726,7 @@ function createSocket(
   onMessage: (data: string) => void,
   onClose: () => void,
   onError: (error: unknown) => void,
+  options: CreateSocketOptions = {},
 ): SocketHandle | null {
   const sysWs = getWsApi();
 
@@ -691,7 +734,7 @@ function createSocket(
   // Only the API's real connected callback may mark the socket open. Calling
   // onOpen speculatively while WebSocket.readyState is CONNECTING makes send()
   // throw and closes an otherwise healthy loopback connection.
-  if (sysWs?.register && sysWs.send) {
+  if (!options.skipRegister && sysWs?.register && sysWs.send) {
     let openFired = false;
     const fireOpen = (): void => {
       if (openFired) return;
@@ -1022,15 +1065,44 @@ async function connectToPort(
   return new Promise((resolve) => {
     let settled = false;
     let handle: SocketHandle | null = null;
+    let socketGeneration = 0;
+    let socketOpened = false;
+    let handshakeSent = false;
+    let registerFallbackTimer: RuntimeTimerHandle | null = null;
+
+    const clearRegisterFallback = (): void => {
+      if (!registerFallbackTimer) return;
+      runtimeTimers.clearTimeout(registerFallbackTimer);
+      registerFallbackTimer = null;
+    };
 
     const finish = (connected: boolean): void => {
       if (settled) return;
       settled = true;
+      clearRegisterFallback();
       runtimeTimers.clearTimeout(timeout);
       resolve(connected);
     };
 
     const timeout = runtimeTimers.setTimeout(() => {
+      clearRegisterFallback();
+      if (handshakeSent) {
+        recordLocalConnectionDiagnostic({
+          phase: 'hello-timeout',
+          port,
+          transport: handle?.type,
+          message: `Socket opened on port ${port}, but the MCP bridge hello was not received.`,
+          priority: 90,
+        });
+      } else if (handle?.type !== 'easyeda-register') {
+        recordLocalConnectionDiagnostic({
+          phase: 'socket-open-timeout',
+          port,
+          transport: handle?.type,
+          message: `The ${handle?.type ?? 'WebSocket'} path did not open on port ${port}.`,
+          priority: 50,
+        });
+      }
       if (socketHandle === handle) {
         socketHandle = null;
       }
@@ -1038,74 +1110,151 @@ async function connectToPort(
       finish(false);
     }, timeoutMs);
 
-    try {
-      handle = createSocket(
-        socketId,
-        url,
-        () => {
-          if (settled || runId !== connectRunId) {
-            closeHandle(handle);
-            return;
-          }
-          socketHandle = handle ?? { type: 'easyeda-register', id: socketId };
-          sendHandshake();
-        },
-        (data) => {
-          try {
-            const messageType = handleMessage(data);
-            if (messageType === 'hello' && runId === connectRunId && !settled) {
-              socketHandle = handle ?? { type: 'easyeda-register', id: socketId };
-              connectedPort = port;
-              connectionState = 'connected';
-              reconnectAttempts = 0;
-              manualDisconnectRequested = false;
-              startHeartbeat();
-              if (showSuccessToast) {
-                showToast(`MCP Bridge connected to local server`);
-              }
-              finish(true);
+    const startSocket = (options: CreateSocketOptions = {}): SocketHandle | null => {
+      const generation = ++socketGeneration;
+      socketOpened = false;
+      handshakeSent = false;
+      let attemptHandle: SocketHandle | null = null;
+      const isCurrentGeneration = (): boolean =>
+        runId === connectRunId && generation === socketGeneration;
+      const resolvedHandle = (): SocketHandle =>
+        attemptHandle ?? { type: 'easyeda-register', id: socketId };
+
+      try {
+        attemptHandle = createSocket(
+          socketId,
+          url,
+          () => {
+            if (settled || !isCurrentGeneration()) {
+              closeHandle(attemptHandle);
+              return;
             }
-          } catch (error) {
-            log('Bridge message error', error);
-          }
-        },
-        () => {
-          const wasActiveConnection = socketHandle === handle && connectionState === 'connected';
-          if (socketHandle === handle) {
-            stopHeartbeat();
-            socketHandle = null;
-            connectedPort = null;
-            connectionState = 'disconnected';
-          }
-          if (!settled) {
+            socketOpened = true;
+            clearRegisterFallback();
+            socketHandle = resolvedHandle();
+            handshakeSent = true;
+            log('Local bridge socket opened; sending handshake', {
+              port,
+              transport: socketHandle.type,
+            });
+            sendHandshake();
+          },
+          (data) => {
+            if (!isCurrentGeneration()) return;
+            try {
+              const messageType = handleMessage(data);
+              if (messageType === 'hello' && !settled) {
+                socketHandle = resolvedHandle();
+                connectedPort = port;
+                connectionState = 'connected';
+                reconnectAttempts = 0;
+                manualDisconnectRequested = false;
+                lastLocalConnectionDiagnostic = null;
+                startHeartbeat();
+                if (showSuccessToast) {
+                  showToast(`MCP Bridge connected to local server`);
+                }
+                finish(true);
+              }
+            } catch (error) {
+              log('Bridge message error', error);
+            }
+          },
+          () => {
+            if (!isCurrentGeneration()) return;
+            clearRegisterFallback();
+            const currentHandle = resolvedHandle();
+            const wasActiveConnection =
+              socketHandle === currentHandle && connectionState === 'connected';
+            if (!settled) {
+              recordLocalConnectionDiagnostic({
+                phase: 'socket-closed',
+                port,
+                transport: currentHandle.type,
+                message: `The ${currentHandle.type} path closed before the bridge handshake completed on port ${port}.`,
+                priority: 60,
+              });
+            }
+            if (socketHandle === currentHandle) {
+              stopHeartbeat();
+              socketHandle = null;
+              connectedPort = null;
+              connectionState = 'disconnected';
+            }
+            if (!settled) {
+              finish(false);
+            }
+            if (wasActiveConnection && !manualDisconnectRequested && runId === connectRunId) {
+              scheduleReconnect();
+            }
+          },
+          (error) => {
+            if (!isCurrentGeneration()) return;
+            clearRegisterFallback();
+            const currentHandle = resolvedHandle();
+            recordLocalConnectionDiagnostic({
+              phase: 'socket-error',
+              port,
+              transport: currentHandle.type,
+              message: `The ${currentHandle.type} path failed on port ${port}: ${bridgeErrorMessage(error)}`,
+              priority: 70,
+            });
+            if (socketHandle === currentHandle) {
+              socketHandle = null;
+            }
+            closeHandle(currentHandle);
+            finish(false);
+          },
+          options,
+        );
+      } catch (error) {
+        log('createSocket threw', error);
+        closeHandle(attemptHandle);
+        return null;
+      }
+
+      handle = attemptHandle;
+      if (!attemptHandle) {
+        recordLocalConnectionDiagnostic({
+          phase: 'socket-api-unavailable',
+          port,
+          message: `No usable EasyEDA or browser WebSocket API was available for port ${port}.`,
+          priority: 80,
+        });
+        return null;
+      }
+
+      if (!settled && attemptHandle.type === 'easyeda-register') {
+        const registerHandle = attemptHandle;
+        registerFallbackTimer = runtimeTimers.setTimeout(() => {
+          if (settled || !isCurrentGeneration() || socketOpened) return;
+          registerFallbackTimer = null;
+          recordLocalConnectionDiagnostic({
+            phase: 'register-open-timeout',
+            port,
+            transport: registerHandle.type,
+            message:
+              `SYS_WebSocket.register() accepted port ${port} but did not invoke its open callback; ` +
+              'the extension closed that handle and tried a safe alternate socket API.',
+            priority: 85,
+          });
+          closeHandle(registerHandle);
+          if (socketHandle === registerHandle) socketHandle = null;
+
+          const fallbackHandle = startSocket({ skipRegister: true });
+          if (!fallbackHandle) {
             finish(false);
           }
-          if (wasActiveConnection && !manualDisconnectRequested && runId === connectRunId) {
-            scheduleReconnect();
-          }
-        },
-        (error) => {
-          log(`Connection failed on port ${port}`, error);
-          if (socketHandle === handle) {
-            socketHandle = null;
-          }
-          closeHandle(handle);
-          finish(false);
-        },
-      );
-    } catch (error) {
-      log('createSocket threw', error);
-      closeHandle(handle);
-      finish(false);
-      return;
-    }
+        }, REGISTER_OPEN_CALLBACK_TIMEOUT_MS);
+      }
 
-    if (!handle) {
-      finish(false);
-    }
+      return attemptHandle;
+    };
+
+    handle = startSocket();
+    if (!handle) finish(false);
   });
 }
-
 async function connectInternal(mode: ConnectMode = 'manual'): Promise<void> {
   const manual = mode === 'manual';
 
@@ -1134,6 +1283,7 @@ async function connectInternal(mode: ConnectMode = 'manual'): Promise<void> {
 
   manualDisconnectRequested = false;
   connectionState = 'connecting';
+  lastLocalConnectionDiagnostic = null;
   const runId = ++connectRunId;
 
   if (manual) {
@@ -1158,7 +1308,7 @@ async function connectInternal(mode: ConnectMode = 'manual'): Promise<void> {
         connectionState = 'disconnected';
         socketHandle = null;
         connectedPort = null;
-        const message = `MCP Bridge offline: no local server found`;
+        const message = `MCP Bridge offline: no local server found${localConnectionDiagnosticSuffix()}`;
         if (manual) {
           showToast(message);
         } else {
@@ -1230,7 +1380,9 @@ function showStatusInternal(): void {
     return;
   }
 
-  showToast(`MCP Bridge disconnected | ${autoLabel} — click Connect to connect`);
+  showToast(
+    `MCP Bridge disconnected | ${autoLabel} — click Connect to connect${localConnectionDiagnosticSuffix()}`,
+  );
 }
 
 function scheduleReconnect(): void {

--- a/easyeda-bridge-extension/tests/build.test.ts
+++ b/easyeda-bridge-extension/tests/build.test.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { afterEach, describe, expect, it } from 'vitest';
+import { REGISTER_OPEN_CALLBACK_TIMEOUT_MS } from '../src/connection-policy.js';
 
 // Regression test for a real bug: the second esbuild call in build.mjs used
 // to pass a `define` object literal that REPLACED (rather than merged onto)
@@ -139,6 +140,167 @@ describe('build.mjs hot-swap define', () => {
     await (context as any).edaEsbuildExportName.disableAutoConnect();
     expect(storageState.autoConnect).toBe(false);
     expect(toastMessages.at(-1)).toContain('Auto-Connect: OFF');
+  });
+
+  it('falls back to sys_WebSocket.create when register never reports open', async () => {
+    const outDir = mkdtempSync(join(tmpdir(), 'ext-build-silent-register-'));
+    outDirs.push(outDir);
+    const bundle = buildInto(outDir, { MCP_DEV_HOTSWAP: '' });
+
+    const toastMessages: string[] = [];
+    const registerClosedIds: string[] = [];
+    const rawHandshakePayloads: Array<Record<string, unknown>> = [];
+    let registerCalls = 0;
+    let registerSendCalls = 0;
+    let createCalls = 0;
+    let createdSocket: FakeCreatedSocket | undefined;
+
+    class FakeCreatedSocket {
+      onopen: (() => void) | null = null;
+      onmessage: ((event: { data: string }) => void) | null = null;
+      onclose: (() => void) | null = null;
+      onerror: ((error: unknown) => void) | null = null;
+
+      constructor() {
+        createdSocket = this;
+        queueMicrotask(() => this.onopen?.());
+      }
+
+      send(payload: string): void {
+        const parsed = JSON.parse(payload) as Record<string, unknown>;
+        rawHandshakePayloads.push(parsed);
+        if (parsed.type === 'handshake') {
+          queueMicrotask(() => {
+            this.onmessage?.({
+              data: JSON.stringify({
+                type: 'hello',
+                contractVersion: 1,
+                supportedProtocolVersions: ['1.0.0'],
+              }),
+            });
+          });
+        }
+      }
+
+      close(): void {
+        this.onclose?.();
+      }
+    }
+
+    const nativeSetTimeout = setTimeout;
+    const nativeClearTimeout = clearTimeout;
+    const context = vm.createContext({
+      console,
+      crypto: webcrypto,
+      TextEncoder,
+      TextDecoder,
+      URL,
+      Promise,
+      setTimeout: (callback: () => void, delayMs: number) => {
+        if (delayMs === REGISTER_OPEN_CALLBACK_TIMEOUT_MS) return nativeSetTimeout(callback, 0);
+        if (delayMs >= 8_000) return nativeSetTimeout(callback, 20);
+        if (delayMs === 1_000) return nativeSetTimeout(callback, 10);
+        return { ignored: true, delayMs };
+      },
+      clearTimeout: (handle: unknown) => {
+        if (handle && typeof handle === 'object' && 'ignored' in handle) return;
+        nativeClearTimeout(handle as ReturnType<typeof setTimeout>);
+      },
+      setInterval: () => ({ ignored: true }),
+      clearInterval: () => undefined,
+      localStorage: {
+        getItem: () => 'false',
+        setItem: () => undefined,
+      },
+      SYS_Message: {
+        showToastMessage: (message: string) => toastMessages.push(message),
+      },
+      SYS_WebSocket: {
+        register: () => {
+          registerCalls += 1;
+          // EasyEDA Pro 3.2.149 on macOS can accept register() without
+          // invoking the optional connected callback.
+        },
+        send: () => {
+          registerSendCalls += 1;
+        },
+        close: (id: string) => registerClosedIds.push(id),
+        create: () => {
+          createCalls += 1;
+          return new FakeCreatedSocket();
+        },
+      },
+    });
+
+    vm.runInContext(bundle, context);
+    await (context as any).edaEsbuildExportName.connect();
+
+    expect(registerCalls).toBe(1);
+    expect(registerSendCalls).toBe(0);
+    expect(registerClosedIds).toHaveLength(1);
+    expect(createCalls).toBe(1);
+    expect(rawHandshakePayloads).toContainEqual(expect.objectContaining({ type: 'handshake' }));
+    expect(toastMessages).toContain('MCP Bridge connected to local server');
+
+    createdSocket?.onmessage?.({
+      data: JSON.stringify({ type: 'heartbeat', source: 'server' }),
+    });
+    expect(rawHandshakePayloads).toContainEqual(
+      expect.objectContaining({ type: 'heartbeat', source: 'extension' }),
+    );
+
+    createdSocket?.close();
+    (context as any).edaEsbuildExportName.showStatus();
+    expect(toastMessages.at(-1)).toContain('waiting for server');
+
+    (context as any).edaEsbuildExportName.disconnect();
+  });
+
+  it('reports the silent register phase when no alternate socket API is available', async () => {
+    const outDir = mkdtempSync(join(tmpdir(), 'ext-build-silent-register-offline-'));
+    outDirs.push(outDir);
+    const bundle = buildInto(outDir, { MCP_DEV_HOTSWAP: '' });
+
+    const toastMessages: string[] = [];
+    const nativeSetTimeout = setTimeout;
+    const nativeClearTimeout = clearTimeout;
+    const context = vm.createContext({
+      console,
+      crypto: webcrypto,
+      TextEncoder,
+      TextDecoder,
+      URL,
+      Promise,
+      setTimeout: (callback: () => void, delayMs: number) => {
+        if (delayMs === REGISTER_OPEN_CALLBACK_TIMEOUT_MS) return nativeSetTimeout(callback, 0);
+        if (delayMs >= 8_000) return nativeSetTimeout(callback, 4);
+        if (delayMs === 1_000) return nativeSetTimeout(callback, 2);
+        return { ignored: true, delayMs };
+      },
+      clearTimeout: (handle: unknown) => {
+        if (handle && typeof handle === 'object' && 'ignored' in handle) return;
+        nativeClearTimeout(handle as ReturnType<typeof setTimeout>);
+      },
+      setInterval: () => ({ ignored: true }),
+      clearInterval: () => undefined,
+      SYS_Message: {
+        showToastMessage: (message: string) => toastMessages.push(message),
+      },
+      SYS_WebSocket: {
+        register: () => undefined,
+        send: () => undefined,
+        close: () => undefined,
+      },
+    });
+
+    vm.runInContext(bundle, context);
+    await (context as any).edaEsbuildExportName.connect();
+
+    expect(toastMessages.at(-1)).toContain('MCP Bridge offline: no local server found');
+    expect(toastMessages.at(-1)).toContain('did not invoke its open callback');
+    expect(toastMessages.at(-1)).toContain('port 49620');
+
+    (context as any).edaEsbuildExportName.disconnect();
   });
 
   it('routes Remote Relay approval requests through the official EasyEDA confirmation dialog', async () => {

--- a/easyeda-bridge-extension/tests/socket-lifecycle.test.ts
+++ b/easyeda-bridge-extension/tests/socket-lifecycle.test.ts
@@ -12,6 +12,8 @@ describe('EasyEDA WebSocket lifecycle', () => {
     expect(source).toContain('sysWs.register(');
     expect(source).toContain('fireOpen,');
     expect(source).not.toContain('setTimeout(fireOpen');
-    expect(source).not.toContain('EASYEDA_REGISTER_OPEN_FALLBACK_MS');
+    expect(source).toContain('REGISTER_OPEN_CALLBACK_TIMEOUT_MS');
+    expect(source).toContain('startSocket({ skipRegister: true })');
+    expect(source).toContain('closeHandle(registerHandle)');
   });
 });


### PR DESCRIPTION
## Summary

- detect EasyEDA runtimes where `SYS_WebSocket.register()` accepts the connection request but never invokes its open callback
- close the silent register handle without sending on it, then retry the same port through `SYS_WebSocket.create()` and browser WebSocket
- preserve heartbeat, request, close, and reconnect handling after a fallback connection succeeds
- expose the last meaningful connection phase in logs and offline/status messages
- document the v3.2/macOS compatibility path and the remaining packaged-runtime validation requirement

## Root cause

The extension treated `SYS_WebSocket.register()` as the preferred transport and waited for its optional open callback before sending the bridge handshake. EasyEDA Pro 3.2.149 on macOS was reported to accept `register()` without invoking that callback. The previous speculative timer fallback had been removed because it could send while the socket was still connecting; after that removal, a silent register handle had no safe recovery path.

## Safe recovery behavior

1. Call `SYS_WebSocket.register()` first.
2. Wait 600 ms for a real open callback.
3. If no callback arrives, record the `register-open-timeout` phase.
4. Close the register handle without sending any handshake.
5. Retry the same port using `SYS_WebSocket.create()` and then browser WebSocket.
6. Send the handshake only from a real open event.
7. Ignore callbacks from stale transport generations.

This does **not** restore the unsafe speculative `send()` behavior.

## Diagnostics

Connection failures now identify phases such as:

- register accepted but open callback missing
- no alternate socket API available
- socket open timeout
- socket opened but bridge `hello` missing
- explicit socket error
- early socket close

The preferred configured port retains priority so later scan-port noise does not replace the most actionable diagnosis.

## Regression coverage

- RED before implementation: silent `register()` was retried across scan ports and `create()` was never called
- fallback succeeds in an EasyEDA-like context with no global `eda` object
- silent register handle receives no handshake and is explicitly closed
- handshake is sent through the real `create()` open event
- server heartbeat still receives an extension heartbeat response after connection
- close events still return the bridge to waiting/retry state
- when no alternate API exists, the offline toast names the silent-register phase and preferred port
- source guard continues to prohibit `setTimeout(fireOpen)` and speculative sends

## Verification

After rebasing onto the current `main` containing #313 and #314:

- server suite: **1,630 passed** across 138 files
- extension suite: **113 passed** across 8 files
- formatting, TypeScript, ESLint, tool metadata, profile coverage, server/extension builds, `.eext` packaging, metadata alignment, and documentation build passed
- `pnpm audit --prod`: **no known vulnerabilities**

## Remaining release validation

Automated tests model the reported EasyEDA Pro 3.2.149 macOS API behavior, including the missing global `eda` object and silent `register()` callback. A packaged `.eext` still needs manual validation on the affected macOS runtime, plus Windows/Linux smoke testing, before #307 should be closed.

Refs #307