### PR TITLE
fix(bridge): resolve browser WebSocket through globalThis

### DIFF
--- a/easyeda-bridge-extension/src/index.ts
+++ b/easyeda-bridge-extension/src/index.ts
@@ -770,10 +770,13 @@ function createSocket(
     }
   }
 
-  // Last resort: raw browser WebSocket (works outside extension sandbox)
-  if (typeof WebSocket !== 'undefined') {
+  // Last resort: raw browser WebSocket (works outside extension sandbox).
+  // Resolve via globalThis because some EasyEDA runtimes shadow the bare
+  // WebSocket identifier while preserving the constructor on the global.
+  const BrowserWebSocketCtor = (globalThis as { WebSocket?: typeof WebSocket }).WebSocket;
+  if (typeof BrowserWebSocketCtor === 'function') {
     try {
-      const socket = new WebSocket(url);
+      const socket = new BrowserWebSocketCtor(url);
       socket.onopen = onOpen;
       socket.onmessage = (event) => onMessage(String(event.data));
       socket.onclose = onClose;

--- a/easyeda-bridge-extension/tests/build.test.ts
+++ b/easyeda-bridge-extension/tests/build.test.ts
@@ -256,6 +256,81 @@ describe('build.mjs hot-swap define', () => {
     (context as any).edaEsbuildExportName.disconnect();
   });
 
+  it('uses globalThis.WebSocket when the bare identifier is shadowed', async () => {
+    const outDir = mkdtempSync(join(tmpdir(), 'ext-build-shadowed-websocket-'));
+    outDirs.push(outDir);
+    const bundle = buildInto(outDir, { MCP_DEV_HOTSWAP: '' });
+
+    const toastMessages: string[] = [];
+    const handshakePayloads: Array<Record<string, unknown>> = [];
+    let constructorCalls = 0;
+
+    class FakeBrowserWebSocket {
+      onopen: (() => void) | null = null;
+      onmessage: ((event: { data: string }) => void) | null = null;
+      onclose: (() => void) | null = null;
+      onerror: ((error: unknown) => void) | null = null;
+
+      constructor(_url: string) {
+        constructorCalls += 1;
+        queueMicrotask(() => this.onopen?.());
+      }
+
+      send(payload: string): void {
+        const parsed = JSON.parse(payload) as Record<string, unknown>;
+        handshakePayloads.push(parsed);
+        if (parsed.type === 'handshake') {
+          queueMicrotask(() => {
+            this.onmessage?.({
+              data: JSON.stringify({
+                type: 'hello',
+                contractVersion: 1,
+                supportedProtocolVersions: ['1.0.0'],
+              }),
+            });
+          });
+        }
+      }
+
+      close(): void {
+        this.onclose?.();
+      }
+    }
+
+    const context = vm.createContext({
+      console,
+      crypto: webcrypto,
+      TextEncoder,
+      TextDecoder,
+      URL,
+      Promise,
+      setTimeout,
+      clearTimeout,
+      setInterval: () => ({ ignored: true }),
+      clearInterval: () => undefined,
+      localStorage: {
+        getItem: () => 'false',
+        setItem: () => undefined,
+      },
+      SYS_Message: {
+        showToastMessage: (message: string) => toastMessages.push(message),
+      },
+      WebSocket: FakeBrowserWebSocket,
+    });
+
+    vm.runInContext(
+      `(function (WebSocket) {\n${bundle}\nglobalThis.__shadowedWebSocketExport = edaEsbuildExportName;\n}).call(globalThis, undefined);`,
+      context,
+    );
+    await (context as any).__shadowedWebSocketExport.connect();
+
+    expect(constructorCalls).toBe(1);
+    expect(handshakePayloads).toContainEqual(expect.objectContaining({ type: 'handshake' }));
+    expect(toastMessages).toContain('MCP Bridge connected to local server');
+
+    (context as any).__shadowedWebSocketExport.disconnect();
+  });
+
   it('reports the silent register phase when no alternate socket API is available', async () => {
     const outDir = mkdtempSync(join(tmpdir(), 'ext-build-silent-register-offline-'));
     outDirs.push(outDir);


### PR DESCRIPTION
## Summary

Follow-up to #307 and the macOS validation from @EvanDataForge.

EasyEDA Pro 3.2.149 on macOS can execute the extension in a scope where the bare `WebSocket` identifier is shadowed while `globalThis.WebSocket` remains available and functional. The local bridge fallback previously checked and constructed the bare identifier, so it reported `socket-api-unavailable` without attempting the working browser socket path.

This PR:

- resolves the last-resort browser constructor through `globalThis.WebSocket`
- preserves the existing `SYS_WebSocket.register()` → `SYS_WebSocket.create()` → browser fallback order
- preserves real-open-only handshake behavior
- adds a bundled-runtime regression test that lexically shadows `WebSocket` while leaving `globalThis.WebSocket` intact
- verifies the browser path opens, sends the handshake, receives `hello`, and reports connected

## TDD evidence

Before the production change, the new regression test failed with:

- zero browser constructor calls
- `socket-api-unavailable` across the port scan

After the change, the same test observes:

- one `globalThis.WebSocket` construction on port 49620
- a browser-transport handshake
- bridge `hello` acceptance
- the connected toast

## Verification

Fresh full verification on Node.js `24.18.0` / pnpm `11.5.1`:

- formatting and TypeScript checks passed
- ESLint and tool metadata/coverage checks passed
- **1,647 server tests passed**
- **114 extension tests passed**
- server and extension builds passed
- `.eext` packaging and metadata alignment passed
- docs build passed

Packaged release-candidate artifact:

- size: `155575` bytes
- SHA-256: `0bc56b5be3212b44bd4919a4c3d778aa17b7f945ce86c26f8abd060f349737be`

## Release gate

Do not close #307 solely from CI. Before release/merge completion, validate this PR's packaged `.eext` on the originally affected macOS Apple Silicon + EasyEDA Pro `3.2.149.88089769` environment, including Manual Connect, heartbeat, and Auto-Connect after server restart.

The additional functional findings were split into dedicated issues:

- #318 — empty schematic sheet info
- #319 — collision scan timeout
- #320 — net-detail timeout
