### PR TITLE
fix(schematic): bound collision scan RPCs

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -2539,6 +2539,8 @@ Returns a JSON object matching the schema:
   project_id: string;
   collisions: object[];
   collision_count: number;
+  scan_complete: boolean;
+  scan_diagnostics: object (optional);
   success: boolean;
   error: string (optional);
 }

--- a/src/tools/L1_schematic_read.ts
+++ b/src/tools/L1_schematic_read.ts
@@ -3,7 +3,10 @@ import { type ToolDefinition, type ToolContext } from './types.js';
 import { type EnvConfig } from '../config/env.js';
 import { readStable } from '../live/readback.js';
 import { fetchComponentPins } from './schematic-helpers.js';
-import { scanSheetForPinCollisions } from '../workflows/collision.js';
+import {
+  collisionScanErrorMessage,
+  scanSheetForPinCollisionsDetailed,
+} from '../workflows/collision.js';
 import { planSafeSchematicRegion } from '../workflows/schematic-safe-region.js';
 import {
   auditImportedDesign,
@@ -1030,7 +1033,7 @@ function registerSchematicReadTools(
     risk: 'low',
     confirmWrite: false,
     group: 'schematic',
-    version: '1.0.0',
+    version: '1.1.0',
     annotations: {
       readOnlyHint: true,
       idempotentHint: true,
@@ -1054,24 +1057,73 @@ function registerSchematicReadTools(
         }),
       ),
       collision_count: z.number().int().nonnegative(),
+      scan_complete: z.boolean(),
+      scan_diagnostics: z
+        .object({
+          stage: z.enum(['complete', 'component_enumeration', 'pin_lookup']),
+          component_count: z.number().int().nonnegative(),
+          components_scanned: z.number().int().nonnegative(),
+          failed_component_count: z.number().int().nonnegative(),
+          failed_components: z.array(
+            z.object({
+              primitive_id: z.string(),
+              error: z.string(),
+            }),
+          ),
+          duration_ms: z.number().int().nonnegative(),
+          component_enumeration_ms: z.number().int().nonnegative(),
+          pin_lookup_ms: z.number().int().nonnegative(),
+          concurrency: z.number().int().positive(),
+          per_call_timeout_ms: z.number().int().positive(),
+          overall_timeout_ms: z.number().int().positive(),
+          stage_error: z.string().optional(),
+        })
+        .optional(),
       success: z.boolean(),
       error: z.string().optional(),
     }),
     handler: async (ctx: ToolContext, params: unknown) => {
       const { projectId } = params as { projectId: string };
       try {
-        const collisions = await scanSheetForPinCollisions(ctx, projectId);
+        const scan = await scanSheetForPinCollisionsDetailed(ctx, projectId);
+        const diagnostics = scan.diagnostics;
+        const scanDiagnostics = {
+          stage: diagnostics.stage,
+          component_count: diagnostics.componentCount,
+          components_scanned: diagnostics.componentsScanned,
+          failed_component_count: diagnostics.failedComponents.length,
+          failed_components: diagnostics.failedComponents.map((failure) => ({
+            primitive_id: failure.primitiveId,
+            error: failure.error,
+          })),
+          duration_ms: diagnostics.durationMs,
+          component_enumeration_ms: diagnostics.componentEnumerationMs,
+          pin_lookup_ms: diagnostics.pinLookupMs,
+          concurrency: diagnostics.concurrency,
+          per_call_timeout_ms: diagnostics.perCallTimeoutMs,
+          overall_timeout_ms: diagnostics.overallTimeoutMs,
+          stage_error: diagnostics.stageError,
+        };
+        const complete = diagnostics.stage === 'complete';
         return {
           project_id: projectId,
-          collisions,
-          collision_count: collisions.length,
-          success: true,
+          collisions: scan.collisions,
+          collision_count: scan.collisions.length,
+          scan_complete: complete,
+          scan_diagnostics: scanDiagnostics,
+          success: complete,
+          error: complete
+            ? undefined
+            : diagnostics.stage === 'component_enumeration' && diagnostics.stageError
+              ? diagnostics.stageError
+              : collisionScanErrorMessage(diagnostics),
         };
       } catch (err) {
         return {
           project_id: projectId,
           collisions: [],
           collision_count: 0,
+          scan_complete: false,
           success: false,
           error: err instanceof Error ? err.message : String(err),
         };

--- a/src/tools/schematic-helpers.ts
+++ b/src/tools/schematic-helpers.ts
@@ -30,11 +30,15 @@ function asString(value: unknown): string | undefined {
 export async function fetchComponentPins(
   ctx: ToolContext,
   primitiveId: string,
+  opts?: { timeoutMs?: number },
 ): Promise<BridgeSchematicPin[]> {
-  const result = await ctx.bridge.call<{ path: string; args: unknown[] }, unknown>('api.call', {
+  const params = {
     path: 'SCH_PrimitiveComponent.getAllPinsByPrimitiveId',
     args: [primitiveId],
-  });
+  };
+  const result = opts
+    ? await ctx.bridge.call<{ path: string; args: unknown[] }, unknown>('api.call', params, opts)
+    : await ctx.bridge.call<{ path: string; args: unknown[] }, unknown>('api.call', params);
   const resultObj = result as { result?: Array<Record<string, unknown>> } | undefined;
   const pins = Array.isArray(resultObj?.result) ? resultObj.result : [];
   return pins.map((p: Record<string, unknown>) => {

--- a/src/workflows/collision.ts
+++ b/src/workflows/collision.ts
@@ -33,24 +33,96 @@ interface SheetComponentRef {
   primitiveId: string;
 }
 
+export interface CollisionScanFailure {
+  primitiveId: string;
+  error: string;
+}
+
+export interface CollisionScanDiagnostics {
+  stage: 'complete' | 'component_enumeration' | 'pin_lookup';
+  componentCount: number;
+  componentsScanned: number;
+  failedComponents: CollisionScanFailure[];
+  durationMs: number;
+  componentEnumerationMs: number;
+  pinLookupMs: number;
+  concurrency: number;
+  perCallTimeoutMs: number;
+  overallTimeoutMs: number;
+  stageError?: string;
+}
+
+export interface CollisionScanResult {
+  collisions: PinCollision[];
+  diagnostics: CollisionScanDiagnostics;
+}
+
+interface CollisionScanBudget {
+  startedAt: number;
+  deadlineAt: number;
+  concurrency: number;
+  perCallTimeoutMs: number;
+  overallTimeoutMs: number;
+}
+
+interface PointBucket {
+  x: number;
+  y: number;
+  pins: CollisionPinRef[];
+}
+
+interface PinMapBuildResult {
+  map: Map<string, PointBucket>;
+  componentsScanned: number;
+  failedComponents: CollisionScanFailure[];
+}
+
+export const COLLISION_SCAN_CONCURRENCY = 4;
+export const COLLISION_PIN_LOOKUP_TIMEOUT_MS = 5_000;
+export const COLLISION_SCAN_TIMEOUT_MS = 20_000;
+
 /** Round to the same precision the bridge's own coordinate-key helper uses. */
 function pointKey(x: number, y: number): string {
   return `${Math.round(x * 1000) / 1000},${Math.round(y * 1000) / 1000}`;
+}
+
+function createScanBudget(): CollisionScanBudget {
+  const startedAt = Date.now();
+  return {
+    startedAt,
+    deadlineAt: startedAt + COLLISION_SCAN_TIMEOUT_MS,
+    concurrency: COLLISION_SCAN_CONCURRENCY,
+    perCallTimeoutMs: COLLISION_PIN_LOOKUP_TIMEOUT_MS,
+    overallTimeoutMs: COLLISION_SCAN_TIMEOUT_MS,
+  };
+}
+
+function remainingCallTimeoutMs(budget: CollisionScanBudget): number {
+  const remainingMs = budget.deadlineAt - Date.now();
+  if (remainingMs <= 0) return 0;
+  return Math.max(1, Math.min(budget.perCallTimeoutMs, remainingMs));
+}
+
+function overallDeadlineError(stage: string, budget: CollisionScanBudget): string {
+  return `Collision scan overall deadline of ${budget.overallTimeoutMs}ms expired during ${stage}`;
 }
 
 /** Page through `schematic.listComponents` and return every component's primitiveId. */
 async function listAllComponentIds(
   ctx: ToolContext,
   projectId: string,
+  budget: CollisionScanBudget,
 ): Promise<SheetComponentRef[]> {
   const pageSize = 500;
   const all: SheetComponentRef[] = [];
   let offset = 0;
   for (;;) {
+    const timeoutMs = remainingCallTimeoutMs(budget);
+    if (timeoutMs === 0) throw new Error(overallDeadlineError('component enumeration', budget));
     const result = await ctx.bridge.call<
       { projectId: string; limit: number; offset: number },
       { total?: number; items?: Array<{ primitiveId?: string }> }
-    >('schematic.listComponents', { projectId, limit: pageSize, offset });
+    >('schematic.listComponents', { projectId, limit: pageSize, offset }, { timeoutMs });
     const items = result?.items ?? [];
     for (const item of items) {
       if (item.primitiveId) all.push({ primitiveId: item.primitiveId });
@@ -63,35 +135,72 @@ async function listAllComponentIds(
 }
 
 /**
- * Build a coordinate -> pins map for the given components. Fetches every component's
- * pin list individually (one bridge round-trip each) — intentionally unfiltered by net
- * membership, since that's exactly the blind spot this closes.
+ * Build a coordinate -> pins map with a bounded worker pool. Each component lookup receives
+ * an explicit bridge deadline and failures are retained so callers can return partial,
+ * actionable diagnostics instead of abandoning the entire scan at the first stalled RPC.
  */
-interface PointBucket {
-  x: number;
-  y: number;
-  pins: CollisionPinRef[];
-}
-
 async function buildPinCoordinateMap(
   ctx: ToolContext,
   components: SheetComponentRef[],
-): Promise<Map<string, PointBucket>> {
+  budget: CollisionScanBudget,
+): Promise<PinMapBuildResult> {
   const map = new Map<string, PointBucket>();
-  for (const component of components) {
-    const pins = await fetchComponentPins(ctx, component.primitiveId);
-    for (const pin of pins) {
-      const key = pointKey(pin.x, pin.y);
-      const bucket = map.get(key) ?? { x: pin.x, y: pin.y, pins: [] };
-      bucket.pins.push({
-        primitiveId: component.primitiveId,
-        pinNumber: pin.pinNumber,
-        pinName: pin.pinName,
-      });
-      map.set(key, bucket);
+  const failedComponents: CollisionScanFailure[] = [];
+  let componentsScanned = 0;
+  let nextIndex = 0;
+
+  const worker = async (): Promise<void> => {
+    for (;;) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= components.length) return;
+
+      const component = components[index];
+      if (!component) return;
+      const timeoutMs = remainingCallTimeoutMs(budget);
+      if (timeoutMs === 0) {
+        failedComponents.push({
+          primitiveId: component.primitiveId,
+          error: overallDeadlineError('pin lookup', budget),
+        });
+        continue;
+      }
+
+      try {
+        const pins = await fetchComponentPins(ctx, component.primitiveId, { timeoutMs });
+        componentsScanned += 1;
+        for (const pin of pins) {
+          const key = pointKey(pin.x, pin.y);
+          const bucket = map.get(key) ?? { x: pin.x, y: pin.y, pins: [] };
+          bucket.pins.push({
+            primitiveId: component.primitiveId,
+            pinNumber: pin.pinNumber,
+            pinName: pin.pinName,
+          });
+          map.set(key, bucket);
+        }
+      } catch (error) {
+        failedComponents.push({
+          primitiveId: component.primitiveId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
-  }
-  return map;
+  };
+
+  const workerCount = Math.min(budget.concurrency, components.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+
+  const componentOrder = new Map(
+    components.map((component, index) => [component.primitiveId, index] as const),
+  );
+  failedComponents.sort(
+    (a, b) =>
+      (componentOrder.get(a.primitiveId) ?? Number.MAX_SAFE_INTEGER) -
+      (componentOrder.get(b.primitiveId) ?? Number.MAX_SAFE_INTEGER),
+  );
+
+  return { map, componentsScanned, failedComponents };
 }
 
 function collisionsFromMap(
@@ -108,18 +217,88 @@ function collisionsFromMap(
   return collisions;
 }
 
+export function collisionScanErrorMessage(diagnostics: CollisionScanDiagnostics): string {
+  if (diagnostics.stage === 'component_enumeration') {
+    return `Collision scan incomplete during component enumeration: ${diagnostics.stageError ?? 'unknown bridge error'}.`;
+  }
+  const failedIds = diagnostics.failedComponents.map((failure) => failure.primitiveId).join(', ');
+  return (
+    `Collision scan incomplete: ${diagnostics.failedComponents.length}/${diagnostics.componentCount} ` +
+    `component pin lookups failed${failedIds ? ` (${failedIds})` : ''}. Partial collision results are included.`
+  );
+}
+
 /**
- * Full-sheet pin-coordinate collision scan. Read-only — used both standalone
- * (`easyeda_schematic_check_collisions`) and as the basis for the workflow-apply
- * reconcile step below.
+ * Full-sheet pin-coordinate collision scan with timing and failure diagnostics.
+ * Successful pin lookups are still analyzed when another component stalls.
+ */
+export async function scanSheetForPinCollisionsDetailed(
+  ctx: ToolContext,
+  projectId: string,
+): Promise<CollisionScanResult> {
+  const budget = createScanBudget();
+  const enumerationStartedAt = Date.now();
+  let components: SheetComponentRef[];
+
+  try {
+    components = await listAllComponentIds(ctx, projectId, budget);
+  } catch (error) {
+    const now = Date.now();
+    return {
+      collisions: [],
+      diagnostics: {
+        stage: 'component_enumeration',
+        componentCount: 0,
+        componentsScanned: 0,
+        failedComponents: [],
+        durationMs: now - budget.startedAt,
+        componentEnumerationMs: now - enumerationStartedAt,
+        pinLookupMs: 0,
+        concurrency: budget.concurrency,
+        perCallTimeoutMs: budget.perCallTimeoutMs,
+        overallTimeoutMs: budget.overallTimeoutMs,
+        stageError: error instanceof Error ? error.message : String(error),
+      },
+    };
+  }
+
+  const enumerationFinishedAt = Date.now();
+  const pinLookupStartedAt = enumerationFinishedAt;
+  const pinMap = await buildPinCoordinateMap(ctx, components, budget);
+  const finishedAt = Date.now();
+  const complete = pinMap.failedComponents.length === 0;
+
+  return {
+    collisions: collisionsFromMap(pinMap.map),
+    diagnostics: {
+      stage: complete ? 'complete' : 'pin_lookup',
+      componentCount: components.length,
+      componentsScanned: pinMap.componentsScanned,
+      failedComponents: pinMap.failedComponents,
+      durationMs: finishedAt - budget.startedAt,
+      componentEnumerationMs: enumerationFinishedAt - enumerationStartedAt,
+      pinLookupMs: finishedAt - pinLookupStartedAt,
+      concurrency: budget.concurrency,
+      perCallTimeoutMs: budget.perCallTimeoutMs,
+      overallTimeoutMs: budget.overallTimeoutMs,
+    },
+  };
+}
+
+/**
+ * Strict compatibility wrapper used by safety-sensitive workflows. Standalone tooling uses
+ * the detailed variant so it can expose partial results, while placement reconciliation must
+ * fail closed when any component was not inspected.
  */
 export async function scanSheetForPinCollisions(
   ctx: ToolContext,
   projectId: string,
 ): Promise<PinCollision[]> {
-  const components = await listAllComponentIds(ctx, projectId);
-  const map = await buildPinCoordinateMap(ctx, components);
-  return collisionsFromMap(map);
+  const result = await scanSheetForPinCollisionsDetailed(ctx, projectId);
+  if (result.diagnostics.stage !== 'complete') {
+    throw new Error(collisionScanErrorMessage(result.diagnostics));
+  }
+  return result.collisions;
 }
 
 export interface ReconcilePlacementResult {
@@ -152,11 +331,28 @@ export async function reconcilePlacementCollisions(
     return { unresolvedCollisions: [], movedComponents };
   }
 
-  const components = await listAllComponentIds(ctx, projectId);
+  const enumerationBudget = createScanBudget();
+  const components = await listAllComponentIds(ctx, projectId, enumerationBudget);
 
   for (let attempt = 0; attempt <= NUDGE_ATTEMPTS; attempt += 1) {
-    const map = await buildPinCoordinateMap(ctx, components);
-    const collisions = collisionsFromMap(map, candidateSet);
+    const pinMap = await buildPinCoordinateMap(ctx, components, createScanBudget());
+    if (pinMap.failedComponents.length > 0) {
+      throw new Error(
+        collisionScanErrorMessage({
+          stage: 'pin_lookup',
+          componentCount: components.length,
+          componentsScanned: pinMap.componentsScanned,
+          failedComponents: pinMap.failedComponents,
+          durationMs: 0,
+          componentEnumerationMs: 0,
+          pinLookupMs: 0,
+          concurrency: COLLISION_SCAN_CONCURRENCY,
+          perCallTimeoutMs: COLLISION_PIN_LOOKUP_TIMEOUT_MS,
+          overallTimeoutMs: COLLISION_SCAN_TIMEOUT_MS,
+        }),
+      );
+    }
+    const collisions = collisionsFromMap(pinMap.map, candidateSet);
     if (collisions.length === 0) {
       return { unresolvedCollisions: [], movedComponents };
     }

--- a/tests/unit/tools/schematic.test.ts
+++ b/tests/unit/tools/schematic.test.ts
@@ -1408,6 +1408,48 @@ describe('Schematic Tools', () => {
       expect(result.collisions).toEqual([]);
     });
 
+    it('returns partial collisions and actionable diagnostics when one pin lookup times out', async () => {
+      const tool = registry.get('easyeda_schematic_check_collisions');
+      bridgeCall.mockImplementation(
+        async (method: string, params: any, opts?: { timeoutMs?: number }) => {
+          if (method === 'schematic.listComponents') {
+            return {
+              total: 3,
+              items: [{ primitiveId: 'A' }, { primitiveId: 'B' }, { primitiveId: 'C' }],
+            };
+          }
+          if (method === 'api.call') {
+            expect(opts?.timeoutMs).toBeGreaterThan(0);
+            const primitiveId = params.args?.[0];
+            if (primitiveId === 'B') {
+              throw new Error('Bridge method "api.call" timed out after 5000ms');
+            }
+            return {
+              result: [{ pinNumber: '1', pinName: primitiveId, x: 10, y: 10 }],
+            };
+          }
+          return {};
+        },
+      );
+
+      const result = (await tool?.handler(context, { projectId: 'proj-1' })) as any;
+
+      expect(result).toMatchObject({
+        success: false,
+        scan_complete: false,
+        collision_count: 1,
+        scan_diagnostics: {
+          stage: 'pin_lookup',
+          component_count: 3,
+          components_scanned: 2,
+          failed_component_count: 1,
+          failed_components: [{ primitive_id: 'B' }],
+          concurrency: 4,
+        },
+      });
+      expect(result.error).toContain('incomplete');
+    });
+
     it('returns success=false on bridge error', async () => {
       const tool = registry.get('easyeda_schematic_check_collisions');
       bridgeCall.mockRejectedValue(new Error('bridge down'));

--- a/tests/unit/workflows/collision.test.ts
+++ b/tests/unit/workflows/collision.test.ts
@@ -182,6 +182,37 @@ describe('scanSheetForPinCollisions', () => {
     expect(collisions).toHaveLength(1);
   });
 
+  it('uses bounded concurrency and per-call deadlines for a moderate component graph', async () => {
+    const ids = Array.from({ length: 9 }, (_, index) => `comp-${index + 1}`);
+    let activePinLookups = 0;
+    let maxActivePinLookups = 0;
+
+    bridgeCall.mockImplementation(
+      async (method: string, params: any, opts?: { timeoutMs?: number }) => {
+        if (method === 'schematic.listComponents') {
+          return { total: ids.length, items: ids.map((primitiveId) => ({ primitiveId })) };
+        }
+        if (method === 'api.call') {
+          expect(opts?.timeoutMs).toBeGreaterThan(0);
+          expect(opts?.timeoutMs).toBeLessThanOrEqual(5_000);
+          activePinLookups += 1;
+          maxActivePinLookups = Math.max(maxActivePinLookups, activePinLookups);
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          activePinLookups -= 1;
+          const index = ids.indexOf(params.args[0]);
+          return { result: [pin('1', 'P1', index * 10, index * 10)] };
+        }
+        return undefined;
+      },
+    );
+
+    const ctx = makeCtx(bridgeCall);
+    await expect(scanSheetForPinCollisions(ctx, 'proj-1')).resolves.toEqual([]);
+
+    expect(maxActivePinLookups).toBeGreaterThan(1);
+    expect(maxActivePinLookups).toBeLessThanOrEqual(4);
+  });
+
   it('paginates through multiple pages of components', async () => {
     // Simulate 2 pages: first returns 1 item (total=2), second returns 1 item
     bridgeCall.mockImplementation(async (method: string, params: any) => {


### PR DESCRIPTION
## Summary

Fixes #319 by replacing the unbounded serial per-component pin scan with a bounded worker pool and explicit operation deadlines.

The previous collision path fetched every component's pins one-by-one through `api.call`. A stalled native pin lookup consumed the full bridge timeout before the next component was attempted; multiple stalls could therefore accumulate into the reported four-minute MCP timeout.

This PR:

- limits pin lookups to **4 concurrent bridge RPCs**
- applies a **5-second per-call timeout**
- applies a **20-second overall scan deadline**, shared by enumeration and pin lookup
- keeps successful pin results when another component times out
- returns partial collisions with structured stage/timing/failure diagnostics
- keeps placement reconciliation fail-closed when any component could not be inspected
- bumps `easyeda_schematic_check_collisions` to schema version `1.1.0`

## TDD evidence

The new regression tests failed before implementation because:

- pin RPCs were serial and had no explicit timeout option
- the first timeout discarded all partial scan results
- the tool returned no stalled-component or stage diagnostics

After implementation, coverage verifies:

- a moderate 9-component graph uses more than one and no more than four concurrent pin lookups
- every pin lookup receives an explicit deadline
- one timed-out component does not prevent other components from being inspected
- collisions among successfully inspected components are returned as partial results
- diagnostics identify the `pin_lookup` stage, failed component ID, counts, concurrency, and timing budgets

## Verification

Fresh full verification on Node.js `24.18.0` / pnpm `11.5.1`:

- formatting, TypeScript, extension typecheck, ESLint, tool metadata and coverage passed
- **138 server test files / 1,649 tests passed**
- **8 extension test files / 114 tests passed**
- server and extension builds passed
- `.eext` packaging and metadata alignment passed
- docs build passed

## Runtime validation gate

Please validate on the original macOS Apple Silicon + EasyEDA Pro `3.2.149.88089769` project with roughly 9 components / 25 connections:

1. run `easyeda_schematic_check_collisions` on the affected project;
2. confirm it returns within the 20-second operation bound rather than reaching the four-minute client timeout;
3. confirm `scan_complete` and `scan_diagnostics` accurately report success or the stalled component;
4. confirm health and canvas tools remain responsive.

Linux/Windows smoke validation is also requested before treating the runtime acceptance criteria as complete.