### PR TITLE
fix(schematic): bound net-detail reads

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -3020,6 +3020,11 @@ Returns a JSON object matching the schema:
   node_count: number;
   nodes: object[];
   not_available: boolean (optional);
+  timed_out: boolean (optional);
+  error_code: string (optional);
+  timeout_stage: string (optional);
+  timeout_component: string (optional);
+  error: string (optional);
 }
 ```
 

--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -820,6 +820,97 @@ type SchematicPoint = { x: number; y: number };
 type SchematicNetNode = { component: string; pin: string; x?: number; y?: number; source?: string };
 type SchematicNetEntry = { netName: string; nodes: SchematicNetNode[] };
 
+type NetDetailStage =
+  | 'component_enumeration'
+  | 'component_pin_read'
+  | 'net_catalog_read'
+  | 'wire_read'
+  | 'coordinate_pin_read';
+
+type NetDetailBudget = {
+  netName: string;
+  startedAt: number;
+  deadlineAt: number;
+  operationTimeoutMs: number;
+};
+
+const NET_DETAIL_DEFAULT_TIMEOUT_MS = 15_000;
+const NET_DETAIL_MAX_TIMEOUT_MS = 20_000;
+const NET_DETAIL_STAGE_TIMEOUT_MS = 5_000;
+
+function createNetDetailBudget(netName: string, requestedTimeoutMs: unknown): NetDetailBudget {
+  const numericTimeout =
+    typeof requestedTimeoutMs === 'number' && Number.isFinite(requestedTimeoutMs)
+      ? Math.trunc(requestedTimeoutMs)
+      : NET_DETAIL_DEFAULT_TIMEOUT_MS;
+  const operationTimeoutMs = Math.max(1, Math.min(NET_DETAIL_MAX_TIMEOUT_MS, numericTimeout));
+  const startedAt = Date.now();
+  return {
+    netName,
+    startedAt,
+    deadlineAt: startedAt + operationTimeoutMs,
+    operationTimeoutMs,
+  };
+}
+
+function isNetDetailTimeout(error: unknown): boolean {
+  return isRecord(error) && error.code === 'NET_DETAIL_TIMEOUT';
+}
+
+async function awaitNetDetailStage<T>(
+  budget: NetDetailBudget | undefined,
+  stage: NetDetailStage,
+  operation: () => PromiseLike<T> | T,
+  context: Record<string, unknown> = {},
+): Promise<T> {
+  if (!budget) return await operation();
+
+  const remainingMs = budget.deadlineAt - Date.now();
+  const stageTimeoutMs = Math.min(NET_DETAIL_STAGE_TIMEOUT_MS, remainingMs);
+  if (stageTimeoutMs <= 0) {
+    throw newBridgeError(
+      'NET_DETAIL_TIMEOUT',
+      `Net detail scan timed out before ${stage} while resolving "${budget.netName}".`,
+      'Retry with the affected schematic focused; inspect the timeout stage and component in error data.',
+      {
+        stage,
+        netName: budget.netName,
+        elapsedMs: Date.now() - budget.startedAt,
+        operationTimeoutMs: budget.operationTimeoutMs,
+        ...context,
+      },
+    );
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      Promise.resolve().then(operation),
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          reject(
+            newBridgeError(
+              'NET_DETAIL_TIMEOUT',
+              `Net detail scan timed out during ${stage} while resolving "${budget.netName}".`,
+              'Retry with the affected schematic focused; inspect the timeout stage and component in error data.',
+              {
+                stage,
+                netName: budget.netName,
+                elapsedMs: Date.now() - budget.startedAt,
+                operationTimeoutMs: budget.operationTimeoutMs,
+                stageTimeoutMs,
+                ...context,
+              },
+            ),
+          );
+        }, stageTimeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}
+
 type DisjointSet = {
   parent: Map<string, string>;
   find: (key: string) => string;
@@ -973,6 +1064,7 @@ function addUnnamedWireNetLabels(
 async function addCoordinateFallbackNets(
   netMap: Map<string, SchematicNetNode[]>,
   comps: unknown[],
+  budget?: NetDetailBudget,
 ): Promise<void> {
   const schWireClass = readFirstPath<any>([
     'SCH_PrimitiveWire',
@@ -981,7 +1073,7 @@ async function addCoordinateFallbackNets(
   ]);
   if (!schWireClass || typeof schWireClass.getAll !== 'function') return;
 
-  const wires = await schWireClass.getAll();
+  const wires = await awaitNetDetailStage(budget, 'wire_read', () => schWireClass.getAll());
   const wireItems = Array.isArray(wires) ? wires : [];
   if (wireItems.length === 0) return;
 
@@ -1039,7 +1131,12 @@ async function addCoordinateFallbackNets(
     if (!ref || typeof (component as { getAllPins?: unknown }).getAllPins !== 'function') continue;
 
     try {
-      const pins = await (component as { getAllPins: () => Promise<unknown[]> }).getAllPins();
+      const pins = await awaitNetDetailStage(
+        budget,
+        'coordinate_pin_read',
+        () => (component as { getAllPins: () => Promise<unknown[]> }).getAllPins(),
+        { component: ref },
+      );
       for (const pin of pins || []) {
         const pinNumber = readStringMemberOrState(pin, 'pinNumber', 'PinNumber');
         const point = readPrimitivePoint(pin);
@@ -1058,6 +1155,7 @@ async function addCoordinateFallbackNets(
         }
       }
     } catch (error) {
+      if (isNetDetailTimeout(error)) throw error;
       logRecoverableError('failed to inspect schematic component pins for coordinate nets', error);
     }
   }
@@ -1348,7 +1446,7 @@ async function getSchematicSheetInfoApi(): Promise<unknown> {
   };
 }
 
-async function listNetsApi(): Promise<unknown> {
+async function listNetsApi(budget?: NetDetailBudget): Promise<unknown> {
   const schCompClass = readFirstPath<any>([
     'SCH_PrimitiveComponent',
     'SCH_PrimitiveComponent3',
@@ -1360,7 +1458,9 @@ async function listNetsApi(): Promise<unknown> {
     throw new Error('SCH_PrimitiveComponent class not found in EasyEDA Pro API');
   }
 
-  const comps = await schCompClass.getAll(undefined, true);
+  const comps = await awaitNetDetailStage(budget, 'component_enumeration', () =>
+    schCompClass.getAll(undefined, true),
+  );
   const netMap = new Map<string, SchematicNetNode[]>();
 
   for (const c of comps || []) {
@@ -1368,7 +1468,9 @@ async function listNetsApi(): Promise<unknown> {
     if (!ref || typeof c.getAllPins !== 'function') continue;
 
     try {
-      const pins = await c.getAllPins();
+      const pins = await awaitNetDetailStage(budget, 'component_pin_read', () => c.getAllPins(), {
+        component: ref,
+      });
       for (const p of pins || []) {
         if (typeof p.getState_PinNumber !== 'function') continue;
         const pinNum = p.getState_PinNumber();
@@ -1386,25 +1488,30 @@ async function listNetsApi(): Promise<unknown> {
         }
       }
     } catch (e) {
+      if (isNetDetailTimeout(e)) throw e;
       logRecoverableError('failed to inspect schematic component pins', e);
     }
   }
 
   if (schNetClass && typeof schNetClass.getAllNets === 'function') {
     try {
-      const allNets = await schNetClass.getAllNets();
+      const allNets = await awaitNetDetailStage(budget, 'net_catalog_read', () =>
+        schNetClass.getAllNets(),
+      );
       for (const n of allNets || []) {
         const netName = n.netName || n.net;
         if (netName) ensureNetEntry(netMap, String(netName));
       }
     } catch (e) {
+      if (isNetDetailTimeout(e)) throw e;
       logRecoverableError('failed to inspect schematic nets', e);
     }
   }
 
   try {
-    await addCoordinateFallbackNets(netMap, comps || []);
+    await addCoordinateFallbackNets(netMap, comps || [], budget);
   } catch (error) {
+    if (isNetDetailTimeout(error)) throw error;
     logRecoverableError('failed to infer schematic nets from wire coordinates', error);
   }
 
@@ -3348,7 +3455,11 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
       return listNetsApi();
     case 'schematic.getNetDetail': {
       const netName = params.netName as string;
-      const allNets = (await listNetsApi()) as Array<{ netName: string; nodes: unknown[] }>;
+      const budget = createNetDetailBudget(netName, params.operationTimeoutMs);
+      const allNets = (await listNetsApi(budget)) as Array<{
+        netName: string;
+        nodes: unknown[];
+      }>;
       const match = allNets.find((n) => n.netName === netName);
       if (!match)
         throw newBridgeError(

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -201,6 +201,67 @@ describe('createDispatcher', () => {
     );
   });
 
+  it('returns a requested net detail within the bounded scan path', async () => {
+    const pin = {
+      getState_PinNumber: () => '1',
+      getState_X: () => 100,
+      getState_Y: () => 200,
+      getState_OtherProperty: () => ({ net: 'VBUS' }),
+    };
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        SCH_PrimitiveComponent: {
+          getAll: async () => [fakeSchematicPart('U1', [pin])],
+        },
+      }),
+    );
+
+    await expect(
+      dispatcher.dispatch('schematic.getNetDetail', {
+        netName: 'VBUS',
+        operationTimeoutMs: 1_000,
+      }),
+    ).resolves.toEqual({
+      netName: 'VBUS',
+      nodes: [{ component: 'U1', pin: '1' }],
+    });
+  });
+
+  it('bounds schematic.getNetDetail when a native component pin read never settles', async () => {
+    const stalledPart = {
+      getState_Designator: () => 'U1',
+      getState_ComponentType: () => 'part',
+      getAllPins: () => new Promise<never>(() => {}),
+    };
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        SCH_PrimitiveComponent: { getAll: async () => [stalledPart] },
+      }),
+    );
+
+    const outcome = await Promise.race([
+      dispatcher
+        .dispatch('schematic.getNetDetail', { netName: 'VBUS', operationTimeoutMs: 20 })
+        .then((value) => ({ kind: 'resolved' as const, value }))
+        .catch((error: unknown) => ({ kind: 'rejected' as const, error })),
+      new Promise<{ kind: 'outer-timeout' }>((resolve) =>
+        setTimeout(() => resolve({ kind: 'outer-timeout' }), 100),
+      ),
+    ]);
+
+    expect(outcome).toMatchObject({
+      kind: 'rejected',
+      error: {
+        code: 'NET_DETAIL_TIMEOUT',
+        data: {
+          stage: 'component_pin_read',
+          component: 'U1',
+          netName: 'VBUS',
+        },
+      },
+    });
+  });
+
   it('schematic.listNets reports pins joined only by an unnamed wire', async () => {
     const u1 = fakeSchematicPart('U1', [fakeSchematicPin('XL1', 100, 200)]);
     const x1 = fakeSchematicPart('X1', [fakeSchematicPin('1', 300, 200)]);

--- a/src/tools/L1_schematic_read.ts
+++ b/src/tools/L1_schematic_read.ts
@@ -519,7 +519,7 @@ function registerSchematicReadTools(
     risk: 'low',
     confirmWrite: false,
     group: 'schematic',
-    version: '1.0.0',
+    version: '1.1.0',
     annotations: {
       readOnlyHint: true,
       idempotentHint: true,
@@ -539,11 +539,20 @@ function registerSchematicReadTools(
         }),
       ),
       not_available: z.boolean().optional(),
+      timed_out: z.boolean().optional(),
+      error_code: z.string().optional(),
+      timeout_stage: z.string().optional(),
+      timeout_component: z.string().optional(),
+      error: z.string().optional(),
     }),
     handler: async (ctx: ToolContext, params: unknown) => {
       const { projectId, netName } = params as { projectId: string; netName: string };
       try {
-        const result = await ctx.bridge.call('schematic.getNetDetail', { projectId, netName });
+        const result = await ctx.bridge.call(
+          'schematic.getNetDetail',
+          { projectId, netName, operationTimeoutMs: 15_000 },
+          { timeoutMs: 20_000 },
+        );
         const net = result as {
           netName?: string;
           nodes?: Array<{ component?: string; pin?: string }>;
@@ -567,13 +576,26 @@ function registerSchematicReadTools(
           })),
         };
       } catch (err) {
+        const record =
+          err && typeof err === 'object' ? (err as Record<string, unknown>) : undefined;
+        const errorCode = typeof record?.code === 'string' ? record.code : undefined;
+        const data =
+          record?.data && typeof record.data === 'object'
+            ? (record.data as Record<string, unknown>)
+            : undefined;
+        const message = err instanceof Error ? err.message : String(err);
+        const timedOut = errorCode === 'NET_DETAIL_TIMEOUT' || /timed out/i.test(message);
         return {
           project_id: projectId,
           net_name: netName,
           node_count: 0,
           nodes: [],
           not_available: true,
-          error: err instanceof Error ? err.message : String(err),
+          timed_out: timedOut || undefined,
+          error_code: errorCode,
+          timeout_stage: typeof data?.stage === 'string' ? data.stage : undefined,
+          timeout_component: typeof data?.component === 'string' ? data.component : undefined,
+          error: message,
         };
       }
     },

--- a/tests/unit/tools/schematic.test.ts
+++ b/tests/unit/tools/schematic.test.ts
@@ -56,10 +56,11 @@ describe('Schematic Tools', () => {
       netName: 'GND',
     });
 
-    expect(bridgeCall).toHaveBeenCalledWith('schematic.getNetDetail', {
-      projectId: 'proj-123',
-      netName: 'GND',
-    });
+    expect(bridgeCall).toHaveBeenCalledWith(
+      'schematic.getNetDetail',
+      { projectId: 'proj-123', netName: 'GND', operationTimeoutMs: 15_000 },
+      { timeoutMs: 20_000 },
+    );
 
     expect(result).toMatchObject({
       project_id: 'proj-123',
@@ -69,6 +70,40 @@ describe('Schematic Tools', () => {
         { component_ref: 'R1', pin: '2' },
         { component_ref: 'C1', pin: '1' },
       ],
+    });
+  });
+
+  it('easyeda_schematic_net_detail applies a bounded bridge deadline and returns timeout diagnostics', async () => {
+    const tool = registry.get('easyeda_schematic_net_detail');
+    const timeoutError = Object.assign(
+      new Error('Net detail timed out during component pin read'),
+      {
+        code: 'NET_DETAIL_TIMEOUT',
+        data: { stage: 'component_pin_read', component: 'U1', netName: 'VBUS' },
+      },
+    );
+    bridgeCall.mockRejectedValue(timeoutError);
+
+    const result = await tool?.handler(context, {
+      projectId: 'proj-123',
+      netName: 'VBUS',
+    });
+
+    expect(bridgeCall).toHaveBeenCalledWith(
+      'schematic.getNetDetail',
+      { projectId: 'proj-123', netName: 'VBUS', operationTimeoutMs: 15_000 },
+      { timeoutMs: 20_000 },
+    );
+    expect(result).toMatchObject({
+      project_id: 'proj-123',
+      net_name: 'VBUS',
+      node_count: 0,
+      nodes: [],
+      not_available: true,
+      timed_out: true,
+      error_code: 'NET_DETAIL_TIMEOUT',
+      timeout_stage: 'component_pin_read',
+      timeout_component: 'U1',
     });
   });
 


### PR DESCRIPTION
## Summary

Fixes #320 by adding explicit, stage-aware deadlines to `schematic.getNetDetail` in both the extension runtime and server tool layer.

The previous implementation fulfilled a single net-detail request by rebuilding the complete schematic net map. It awaited component enumeration, every component's native `getAllPins()`, the net catalogue, wire enumeration, and coordinate-fallback pin reads without an operation budget. If any EasyEDA native promise never settled, the request remained pending until the MCP client's four-minute timeout.

This PR:

- applies a **15-second extension operation budget** to net-detail scans
- caps each native stage at **5 seconds** and the extension budget at **20 seconds**
- applies a separate **20-second bridge RPC deadline** on the server
- reports structured `NET_DETAIL_TIMEOUT` errors with the exact stage and component
- covers component enumeration, primary pin reads, net catalogue reads, wire reads, and coordinate-fallback pin reads
- exposes `timed_out`, `error_code`, `timeout_stage`, `timeout_component`, and `error` in the MCP tool response
- preserves the existing unbounded/best-effort behavior of the broader `schematic.listNets` API; the stricter deadline is scoped to net-detail requests
- bumps `easyeda_schematic_net_detail` to schema version `1.1.0`

## TDD evidence

Before implementation:

- a dispatcher test with `U1.getAllPins()` returning a never-settling promise reached the test's external 100 ms guard instead of returning a bridge error
- the server tool called `schematic.getNetDetail` without explicit operation or bridge deadlines
- timeout stage/component fields were unavailable

After implementation:

- the same stalled native promise rejects with `NET_DETAIL_TIMEOUT`
- error data identifies `stage: component_pin_read`, `component: U1`, and `netName: VBUS`
- a normal `VBUS` net detail still returns its connected node
- the MCP tool applies the 15/20-second layered deadlines and preserves the structured diagnostics

## Verification

Fresh full verification on Node.js `24.18.0` / pnpm `11.5.1`:

- formatting, TypeScript, extension typecheck, ESLint, tool metadata and coverage passed
- **138 server test files / 1,648 tests passed**
- **8 extension test files / 116 tests passed**
- server and extension builds passed
- `.eext` packaging and metadata alignment passed
- generated tool reference is committed
- docs build passed

Packaged validation artifact:

- size: `157076` bytes
- SHA-256: `24fc7007466491a2dc08b308083413bcc38dc80b8f82cc6b07e104032d7e71ce`

## Runtime validation gate

Please validate the packaged build on the original macOS Apple Silicon + EasyEDA Pro `3.2.149.88089769` project:

1. run `easyeda_schematic_net_detail({ projectId: "ZigbeeAkkupack", netName: "VBUS" })`;
2. confirm it returns a valid detail or structured timeout within 20 seconds, never the four-minute client timeout;
3. if it times out, capture `error_code`, `timeout_stage`, and `timeout_component`;
4. confirm health and canvas requests remain responsive before and after the call.