### PR TITLE
fix(schematic): recover focused sheet metadata

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -3324,7 +3324,13 @@ Returns a JSON object matching the schema:
   origin: any(optional);
   grid: any(optional);
   raw: any(optional);
+  metadata_source: string(optional);
+  focused_document: any(optional);
+  diagnostics: any(optional);
+  geometry_available: boolean;
+  warning: string(optional);
   not_available: boolean(optional);
+  error_code: string(optional);
   error: string(optional);
 }
 ```

--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -1325,26 +1325,140 @@ async function primitiveBoundsApi(primitiveIds: unknown): Promise<unknown> {
   return { items, combined };
 }
 
-async function getSchematicSheetInfoApi(): Promise<unknown> {
-  const currentPage = await callFirst([
-    'DMT_Schematic.getCurrentSchematicPageInfo',
-    'dmt_Schematic.getCurrentSchematicPageInfo',
-  ]);
-  let pages: unknown = [];
+type SheetInfoSource = 'current_page' | 'focused_document' | 'current_schematic_page_list';
+
+type SheetInfoAttempt = {
+  stage: string;
+  status: 'value' | 'empty' | 'unavailable';
+  error?: string;
+};
+
+function asNonEmptyRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value) || Object.keys(value).length === 0) return undefined;
+  return value;
+}
+
+function asRecordArray(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is Record<string, unknown> => isRecord(item));
+}
+
+async function trySheetInfoCall(
+  stage: string,
+  paths: string[],
+  attempts: SheetInfoAttempt[],
+  ...args: unknown[]
+): Promise<unknown> {
   try {
-    pages = await callFirst([
-      'DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo',
-      'DMT_Schematic.getAllSchematicPagesInfo',
-      'dmt_Schematic.getCurrentSchematicAllSchematicPagesInfo',
-      'dmt_Schematic.getAllSchematicPagesInfo',
-    ]);
-  } catch (err) {
-    logRecoverableError('failed to read schematic pages list', err);
+    const value = normalizeValue(await callFirst(paths, ...args), 5);
+    const meaningful = Array.isArray(value)
+      ? value.length > 0
+      : Boolean(asNonEmptyRecord(value)) || (value !== null && value !== undefined);
+    attempts.push({ stage, status: meaningful ? 'value' : 'empty' });
+    return value;
+  } catch (error) {
+    attempts.push({
+      stage,
+      status: 'unavailable',
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return undefined;
+  }
+}
+
+async function getSchematicSheetInfoApi(): Promise<unknown> {
+  const attempts: SheetInfoAttempt[] = [];
+  let source: SheetInfoSource | undefined;
+
+  let currentPage = asNonEmptyRecord(
+    await trySheetInfoCall('current_page', ['DMT_Schematic.getCurrentSchematicPageInfo'], attempts),
+  );
+  if (currentPage) source = 'current_page';
+
+  let pages = asRecordArray(
+    await trySheetInfoCall(
+      'current_page_list',
+      ['DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo'],
+      attempts,
+    ),
+  );
+  if (pages.length === 0) {
+    pages = asRecordArray(
+      await trySheetInfoCall('all_page_list', ['DMT_Schematic.getAllSchematicPagesInfo'], attempts),
+    );
+  }
+
+  const focusedDocument = asNonEmptyRecord(
+    await trySheetInfoCall(
+      'focused_document',
+      ['DMT_SelectControl.getCurrentDocumentInfo'],
+      attempts,
+    ),
+  );
+  const focusedPageUuid =
+    typeof focusedDocument?.uuid === 'string' && focusedDocument.uuid.trim()
+      ? focusedDocument.uuid
+      : undefined;
+
+  let currentSchematic: Record<string, unknown> | undefined;
+  if (!currentPage || pages.length === 0) {
+    currentSchematic = asNonEmptyRecord(
+      await trySheetInfoCall(
+        'current_schematic',
+        ['DMT_Schematic.getCurrentSchematicInfo'],
+        attempts,
+      ),
+    );
+  }
+
+  if (!currentPage && focusedPageUuid) {
+    currentPage = asNonEmptyRecord(
+      await trySheetInfoCall(
+        'focused_document_page',
+        ['DMT_Schematic.getSchematicPageInfo'],
+        attempts,
+        focusedPageUuid,
+      ),
+    );
+    if (currentPage) source = 'focused_document';
+  }
+
+  const schematicPages = asRecordArray(currentSchematic?.page);
+  if (pages.length === 0 && schematicPages.length > 0) pages = schematicPages;
+
+  if (!currentPage && focusedPageUuid && pages.length > 0) {
+    currentPage = pages.find((page) => page.uuid === focusedPageUuid);
+    if (currentPage) source = 'focused_document';
+  }
+
+  if (!currentPage && pages.length === 1 && currentSchematic) {
+    currentPage = pages[0];
+    source = 'current_schematic_page_list';
+  }
+
+  const diagnostics = {
+    stage: 'focused_sheet_resolution',
+    currentPageAvailable: Boolean(currentPage),
+    pageListAvailable: pages.length > 0,
+    focusedDocumentAvailable: Boolean(focusedDocument),
+    attempts,
+  };
+
+  if (!currentPage) {
+    throw newBridgeError(
+      'SHEET_INFO_UNAVAILABLE',
+      'EasyEDA did not expose metadata for the focused schematic page.',
+      'Focus the schematic editor tab and retry. The diagnostics identify which runtime paths were empty or unavailable.',
+      diagnostics,
+    );
   }
 
   return {
-    currentPage: normalizeValue(currentPage, 5),
-    pages: normalizeValue(pages, 4),
+    currentPage,
+    pages,
+    source,
+    focusedDocument,
+    diagnostics,
   };
 }
 

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -318,6 +318,77 @@ describe('createDispatcher', () => {
     expect(create).toHaveBeenCalled();
   });
 
+  it('schematic.getSheetInfo recovers the focused page through DMT_SelectControl', async () => {
+    const focusedPage = {
+      itemType: 3,
+      uuid: 'page-1',
+      name: 'Sheet 1',
+      parentSchematicUuid: 'sch-1',
+      showTitleBlock: true,
+      titleBlockData: {},
+    };
+    const getSchematicPageInfo = vi.fn(async (uuid: string) =>
+      uuid === 'page-1' ? focusedPage : undefined,
+    );
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        DMT_SelectControl: {
+          getCurrentDocumentInfo: async () => ({
+            documentType: 3,
+            uuid: 'page-1',
+            tabId: 'tab-1',
+            parentProjectUuid: 'project-1',
+          }),
+        },
+        DMT_Schematic: {
+          getCurrentSchematicPageInfo: async () => null,
+          getCurrentSchematicAllSchematicPagesInfo: async () => [],
+          getCurrentSchematicInfo: async () => ({
+            uuid: 'sch-1',
+            name: 'Main',
+            page: [focusedPage],
+            parentProjectUuid: 'project-1',
+          }),
+          getSchematicPageInfo,
+        },
+      }),
+    );
+
+    await expect(dispatcher.dispatch('schematic.getSheetInfo', {})).resolves.toMatchObject({
+      currentPage: focusedPage,
+      pages: [focusedPage],
+      source: 'focused_document',
+      focusedDocument: { uuid: 'page-1', tabId: 'tab-1' },
+      diagnostics: {
+        currentPageAvailable: true,
+        pageListAvailable: true,
+      },
+    });
+    expect(getSchematicPageInfo).toHaveBeenCalledWith('page-1');
+  });
+
+  it('schematic.getSheetInfo rejects an empty focused-sheet response with diagnostics', async () => {
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        DMT_SelectControl: { getCurrentDocumentInfo: async () => undefined },
+        DMT_Schematic: {
+          getCurrentSchematicPageInfo: async () => null,
+          getCurrentSchematicAllSchematicPagesInfo: async () => [],
+          getCurrentSchematicInfo: async () => undefined,
+        },
+      }),
+    );
+
+    await expect(dispatcher.dispatch('schematic.getSheetInfo', {})).rejects.toMatchObject({
+      code: 'SHEET_INFO_UNAVAILABLE',
+      data: {
+        stage: 'focused_sheet_resolution',
+        currentPageAvailable: false,
+        pageListAvailable: false,
+      },
+    });
+  });
+
   // DATA-LOSS INCIDENT (2026-07-07, live-reproduced on a real project): the
   // first implementation round-tripped the FULL getCurrentSchematicPageInfo()
   // snapshot back through modifySchematicPageTitleBlock. That silently wiped

--- a/src/bridge/cdp-manager.ts
+++ b/src/bridge/cdp-manager.ts
@@ -478,14 +478,67 @@ export class CdpBridgeManager extends EventEmitter {
       `
       (async () => {
         ${this.runtimePrelude()}
-        const currentPage = await callFirst(['DMT_Schematic.getCurrentSchematicPageInfo','dmt_Schematic.getCurrentSchematicPageInfo']);
-        let pages = [];
-        try {
-          pages = await callFirst(['DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo','DMT_Schematic.getAllSchematicPagesInfo','dmt_Schematic.getCurrentSchematicAllSchematicPagesInfo','dmt_Schematic.getAllSchematicPagesInfo']);
-        } catch (error) {
-          pages = { warning: String(error && error.message || error) };
+        const attempts = [];
+        const asRecord = (value) => value && typeof value === 'object' && !Array.isArray(value) && Object.keys(value).length > 0 ? value : undefined;
+        const asRecordArray = (value) => Array.isArray(value) ? value.filter((item) => item && typeof item === 'object' && !Array.isArray(item)) : [];
+        const tryCall = async (stage, paths, ...args) => {
+          try {
+            const value = await callFirst(paths, ...args);
+            const meaningful = Array.isArray(value) ? value.length > 0 : Boolean(asRecord(value)) || (value !== null && value !== undefined);
+            attempts.push({ stage, status: meaningful ? 'value' : 'empty' });
+            return value;
+          } catch (error) {
+            attempts.push({ stage, status: 'unavailable', error: String(error && error.message || error) });
+            return undefined;
+          }
+        };
+
+        let source;
+        let currentPage = asRecord(await tryCall('current_page', ['DMT_Schematic.getCurrentSchematicPageInfo','dmt_Schematic.getCurrentSchematicPageInfo']));
+        if (currentPage) source = 'current_page';
+
+        let pages = asRecordArray(await tryCall('current_page_list', ['DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo','dmt_Schematic.getCurrentSchematicAllSchematicPagesInfo']));
+        if (pages.length === 0) {
+          pages = asRecordArray(await tryCall('all_page_list', ['DMT_Schematic.getAllSchematicPagesInfo','dmt_Schematic.getAllSchematicPagesInfo']));
         }
-        return { currentPage, pages };
+
+        const focusedDocument = asRecord(await tryCall('focused_document', ['DMT_SelectControl.getCurrentDocumentInfo','dmt_SelectControl.getCurrentDocumentInfo']));
+        const focusedPageUuid = typeof focusedDocument?.uuid === 'string' && focusedDocument.uuid.trim() ? focusedDocument.uuid : undefined;
+        let currentSchematic;
+        if (!currentPage || pages.length === 0) {
+          currentSchematic = asRecord(await tryCall('current_schematic', ['DMT_Schematic.getCurrentSchematicInfo','dmt_Schematic.getCurrentSchematicInfo']));
+        }
+
+        if (!currentPage && focusedPageUuid) {
+          currentPage = asRecord(await tryCall('focused_document_page', ['DMT_Schematic.getSchematicPageInfo','dmt_Schematic.getSchematicPageInfo'], focusedPageUuid));
+          if (currentPage) source = 'focused_document';
+        }
+
+        const schematicPages = asRecordArray(currentSchematic?.page);
+        if (pages.length === 0 && schematicPages.length > 0) pages = schematicPages;
+        if (!currentPage && focusedPageUuid && pages.length > 0) {
+          currentPage = pages.find((page) => page.uuid === focusedPageUuid);
+          if (currentPage) source = 'focused_document';
+        }
+        if (!currentPage && pages.length === 1 && currentSchematic) {
+          currentPage = pages[0];
+          source = 'current_schematic_page_list';
+        }
+
+        const diagnostics = {
+          stage: 'focused_sheet_resolution',
+          currentPageAvailable: Boolean(currentPage),
+          pageListAvailable: pages.length > 0,
+          focusedDocumentAvailable: Boolean(focusedDocument),
+          attempts,
+        };
+        if (!currentPage) {
+          const error = new Error('EasyEDA did not expose metadata for the focused schematic page.');
+          error.code = 'SHEET_INFO_UNAVAILABLE';
+          error.data = diagnostics;
+          throw error;
+        }
+        return { currentPage, pages, source, focusedDocument, diagnostics };
       })()
     `,
     );

--- a/src/tools/L1_schematic_read.ts
+++ b/src/tools/L1_schematic_read.ts
@@ -650,7 +650,7 @@ function registerSchematicReadTools(
     risk: 'low',
     confirmWrite: false,
     group: 'schematic',
-    version: '1.0.0',
+    version: '1.1.0',
     annotations: {
       readOnlyHint: true,
       idempotentHint: true,
@@ -672,7 +672,13 @@ function registerSchematicReadTools(
       origin: z.unknown().optional(),
       grid: z.unknown().optional(),
       raw: z.unknown().optional(),
+      metadata_source: z.string().optional(),
+      focused_document: z.unknown().optional(),
+      diagnostics: z.unknown().optional(),
+      geometry_available: z.boolean(),
+      warning: z.string().optional(),
       not_available: z.boolean().optional(),
+      error_code: z.string().optional(),
       error: z.string().optional(),
     }),
     handler: async (ctx: ToolContext, params: unknown) => {
@@ -683,12 +689,40 @@ function registerSchematicReadTools(
           result && typeof result === 'object' && !Array.isArray(result)
             ? (result as Record<string, unknown>)
             : {};
-        const current =
-          root.currentPage &&
-          typeof root.currentPage === 'object' &&
-          !Array.isArray(root.currentPage)
-            ? (root.currentPage as Record<string, unknown>)
-            : root;
+        const isNonEmptyRecord = (value: unknown): value is Record<string, unknown> =>
+          Boolean(
+            value &&
+            typeof value === 'object' &&
+            !Array.isArray(value) &&
+            Object.keys(value as Record<string, unknown>).length > 0,
+          );
+        const wrappedCurrent = isNonEmptyRecord(root.currentPage) ? root.currentPage : undefined;
+        const hasLegacyDirectSheetData = [
+          'uuid',
+          'name',
+          'width',
+          'height',
+          'pageWidth',
+          'pageHeight',
+          'paperWidth',
+          'paperHeight',
+          'frame',
+          'titleBlock',
+          'origin',
+          'canvasOrigin',
+          'grid',
+          'gridSize',
+        ].some((key) => root[key] !== undefined && root[key] !== null);
+        const current = wrappedCurrent ?? (hasLegacyDirectSheetData ? root : undefined);
+        if (!current) {
+          return {
+            project_id: projectId,
+            geometry_available: false,
+            not_available: true,
+            diagnostics: root.diagnostics,
+            error: 'EasyEDA did not expose metadata for the focused schematic page.',
+          };
+        }
         const readNumber = (keys: string[]): number | undefined => {
           for (const key of keys) {
             const value = current[key] ?? root[key];
@@ -707,23 +741,51 @@ function registerSchematicReadTools(
           }
           return undefined;
         };
+        const width = readNumber(['width', 'pageWidth', 'paperWidth', 'w']);
+        const height = readNumber(['height', 'pageHeight', 'paperHeight', 'h']);
+        const unit = readString(['unit', 'units', 'pageUnit']);
+        const frame = current.frame ?? current.titleBlock ?? root.frame;
+        const origin = current.origin ?? current.canvasOrigin ?? root.origin;
+        const grid = current.grid ?? current.gridSize ?? root.grid;
+        const geometryAvailable =
+          width !== undefined ||
+          height !== undefined ||
+          unit !== undefined ||
+          frame !== undefined ||
+          origin !== undefined ||
+          grid !== undefined;
+        const pageSize =
+          width !== undefined || height !== undefined || unit !== undefined
+            ? { width, height, unit }
+            : undefined;
         return {
           project_id: projectId,
           sheet: current,
-          page_size: {
-            width: readNumber(['width', 'pageWidth', 'paperWidth', 'w']),
-            height: readNumber(['height', 'pageHeight', 'paperHeight', 'h']),
-            unit: readString(['unit', 'units', 'pageUnit']),
-          },
-          frame: current.frame ?? current.titleBlock ?? root.frame,
-          origin: current.origin ?? current.canvasOrigin ?? root.origin,
-          grid: current.grid ?? current.gridSize ?? root.grid,
+          ...(pageSize ? { page_size: pageSize } : {}),
+          ...(frame !== undefined ? { frame } : {}),
+          ...(origin !== undefined ? { origin } : {}),
+          ...(grid !== undefined ? { grid } : {}),
           raw: result,
+          ...(typeof root.source === 'string' ? { metadata_source: root.source } : {}),
+          ...(root.focusedDocument !== undefined ? { focused_document: root.focusedDocument } : {}),
+          ...(root.diagnostics !== undefined ? { diagnostics: root.diagnostics } : {}),
+          geometry_available: geometryAvailable,
+          ...(geometryAvailable
+            ? {}
+            : {
+                warning:
+                  'Focused schematic page identity is available, but this EasyEDA runtime did not expose page geometry.',
+              }),
         };
       } catch (err) {
+        const record =
+          err && typeof err === 'object' ? (err as Record<string, unknown>) : undefined;
         return {
           project_id: projectId,
+          geometry_available: false,
           not_available: true,
+          error_code: typeof record?.code === 'string' ? record.code : undefined,
+          diagnostics: record?.data,
           error: err instanceof Error ? err.message : String(err),
         };
       }

--- a/tests/unit/bridge/cdp-manager-sheet-info.test.ts
+++ b/tests/unit/bridge/cdp-manager-sheet-info.test.ts
@@ -1,0 +1,65 @@
+import vm from 'node:vm';
+import { describe, expect, it } from 'vitest';
+import { EnvSchema } from '../../../src/config/env.js';
+import { CdpBridgeManager } from '../../../src/bridge/cdp-manager.js';
+
+function sheetInfoExpression(): string {
+  const config = EnvSchema.parse({ NODE_ENV: 'test' });
+  const manager = new CdpBridgeManager(config);
+  return (manager as unknown as { sheetInfoExpression(): string }).sheetInfoExpression();
+}
+
+describe('CdpBridgeManager sheet info fallback', () => {
+  it('resolves a focused schematic page through DMT_SelectControl', async () => {
+    const page = {
+      uuid: 'page-1',
+      name: 'Sheet 1',
+      parentSchematicUuid: 'sch-1',
+      showTitleBlock: true,
+      titleBlockData: {},
+    };
+    const context = vm.createContext({
+      eda: {
+        DMT_SelectControl: {
+          getCurrentDocumentInfo: async () => ({ uuid: 'page-1', tabId: 'tab-1' }),
+        },
+        DMT_Schematic: {
+          getCurrentSchematicPageInfo: async () => null,
+          getCurrentSchematicAllSchematicPagesInfo: async () => [],
+          getAllSchematicPagesInfo: async () => [],
+          getCurrentSchematicInfo: async () => ({ uuid: 'sch-1', page: [page] }),
+          getSchematicPageInfo: async (uuid: string) => (uuid === 'page-1' ? page : undefined),
+        },
+      },
+    });
+
+    const result = await vm.runInContext(sheetInfoExpression(), context);
+
+    expect(result).toMatchObject({
+      currentPage: page,
+      pages: [page],
+      source: 'focused_document',
+      focusedDocument: { uuid: 'page-1', tabId: 'tab-1' },
+      diagnostics: { currentPageAvailable: true, pageListAvailable: true },
+    });
+  });
+
+  it('rejects empty focused-sheet metadata instead of returning a valid empty object', async () => {
+    const context = vm.createContext({
+      eda: {
+        DMT_SelectControl: { getCurrentDocumentInfo: async () => undefined },
+        DMT_Schematic: {
+          getCurrentSchematicPageInfo: async () => null,
+          getCurrentSchematicAllSchematicPagesInfo: async () => [],
+          getAllSchematicPagesInfo: async () => [],
+          getCurrentSchematicInfo: async () => undefined,
+        },
+      },
+    });
+
+    await expect(vm.runInContext(sheetInfoExpression(), context)).rejects.toMatchObject({
+      code: 'SHEET_INFO_UNAVAILABLE',
+      data: { stage: 'focused_sheet_resolution', currentPageAvailable: false },
+    });
+  });
+});

--- a/tests/unit/tools/schematic.test.ts
+++ b/tests/unit/tools/schematic.test.ts
@@ -92,6 +92,55 @@ describe('Schematic Tools', () => {
     });
   });
 
+  it('easyeda_schematic_sheet_info reports focused page identity without inventing geometry', async () => {
+    const tool = registry.get('easyeda_schematic_sheet_info');
+    bridgeCall.mockResolvedValue({
+      currentPage: {
+        uuid: 'page-1',
+        name: 'Sheet 1',
+        parentSchematicUuid: 'sch-1',
+        showTitleBlock: true,
+      },
+      pages: [{ uuid: 'page-1', name: 'Sheet 1' }],
+      source: 'focused_document',
+      focusedDocument: { uuid: 'page-1', tabId: 'tab-1' },
+      diagnostics: { currentPageAvailable: true, pageListAvailable: true },
+    });
+
+    const result = await tool?.handler(context, { projectId: 'proj-123' });
+
+    expect(result).toMatchObject({
+      project_id: 'proj-123',
+      sheet: { uuid: 'page-1', name: 'Sheet 1' },
+      metadata_source: 'focused_document',
+      geometry_available: false,
+      warning:
+        'Focused schematic page identity is available, but this EasyEDA runtime did not expose page geometry.',
+    });
+    expect(result).not.toHaveProperty('page_size');
+    expect(result).not.toHaveProperty('not_available');
+  });
+
+  it('easyeda_schematic_sheet_info rejects empty metadata as unavailable', async () => {
+    const tool = registry.get('easyeda_schematic_sheet_info');
+    bridgeCall.mockResolvedValue({
+      currentPage: null,
+      pages: [],
+      diagnostics: { currentPageAvailable: false, pageListAvailable: false },
+    });
+
+    const result = await tool?.handler(context, { projectId: 'proj-123' });
+
+    expect(result).toMatchObject({
+      project_id: 'proj-123',
+      not_available: true,
+      geometry_available: false,
+      error: 'EasyEDA did not expose metadata for the focused schematic page.',
+    });
+    expect(result).not.toHaveProperty('sheet');
+    expect(result).not.toHaveProperty('page_size');
+  });
+
   it('easyeda_schematic_place_component should call bridge and return success', async () => {
     const tool = registry.get('easyeda_schematic_place_component');
     bridgeCall.mockResolvedValue({ componentId: 'comp-123' });


### PR DESCRIPTION
## Summary

Fixes #318 by treating an empty `getCurrentSchematicPageInfo()` result as a failed primary path and recovering the focused schematic page through the documented active-document APIs.

On EasyEDA Pro 3.2.149 for macOS, the schematic editor can be open and focused while `DMT_Schematic.getCurrentSchematicPageInfo()` returns `null` and the current page-list call returns `[]`. The previous bridge accepted that pair as valid metadata, which produced:

```json
{ "sheet": { "currentPage": null, "pages": [] }, "page_size": {} }
```

This PR:

- reads `DMT_SelectControl.getCurrentDocumentInfo()` to identify the last-focused editor document
- resolves its UUID through `DMT_Schematic.getSchematicPageInfo()`
- falls back to `DMT_Schematic.getCurrentSchematicInfo().page` for the page list
- uses a single page from the current schematic only when it is unambiguous
- applies the same fallback behavior to the CDP bridge path
- rejects truly empty metadata with structured `SHEET_INFO_UNAVAILABLE` diagnostics
- records every attempted runtime stage as `value`, `empty`, or `unavailable`
- stops returning an empty `page_size` object as though geometry were known
- reports `geometry_available: false` with an explicit warning when page identity is available but the runtime exposes no verified schematic geometry API
- exposes metadata source, focused-document information, and diagnostics in the MCP tool output
- bumps `easyeda_schematic_sheet_info` to schema version `1.1.0`

## TDD evidence

Before implementation:

- the extension returned `{ currentPage: null, pages: [] }` even when the focused document UUID could resolve the active page
- a completely empty runtime response resolved successfully instead of producing an actionable error
- the server returned `page_size: {}` and omitted any geometry-availability signal
- the CDP fallback repeated the same empty-result behavior

After implementation, coverage verifies:

- the focused document UUID resolves the correct schematic page
- the current schematic page list is used as a secondary source
- empty metadata rejects with `SHEET_INFO_UNAVAILABLE` and `focused_sheet_resolution` diagnostics
- both the extension and CDP paths behave consistently
- page identity is returned without inventing width, height, frame, origin, or grid
- empty wrapper metadata is surfaced as unavailable rather than valid sheet data

## Verification

Fresh full verification on Node.js `24.18.0` / pnpm `11.5.1`:

- formatting, TypeScript, extension typecheck, ESLint, tool metadata and coverage passed
- **139 server test files / 1,651 tests passed**
- **8 extension test files / 116 tests passed**
- server and extension builds passed
- `.eext` packaging and metadata alignment passed
- generated tool reference is committed
- docs build passed

Packaged validation artifact:

- size: `156912` bytes
- SHA-256: `b8d0d32f1f5a6e69e8a149e0df7d3527def606004ad0b0b472a78fb75b6489f7`

## Runtime validation gate

Please validate on the original macOS Apple Silicon + EasyEDA Pro `3.2.149.88089769` environment:

1. focus an open schematic editor tab;
2. run `easyeda_schematic_sheet_info`;
3. confirm `sheet.uuid` and `sheet.name` identify the focused page;
4. confirm `metadata_source` is meaningful and `not_available` is absent;
5. expect `geometry_available: false` plus the explicit warning unless that runtime exposes real page geometry;
6. with no schematic editor focused, confirm the tool returns structured unavailable diagnostics instead of empty sheet/page-size objects.

Linux/Windows smoke validation is also requested before closing the issue.