### PR TITLE
fix(ci): restore Sonar security gate

### DIFF
--- a/.github/workflows/golden-benchmark.yml
+++ b/.github/workflows/golden-benchmark.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: '24'
           cache: pnpm
 
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Run golden eval benchmark (non-live, mocked-fixture tier)
         run: pnpm exec tsx scripts/run-evals.mts --output .easyeda-mcp-pro/evals/ci-latest.json
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -106,9 +106,14 @@ jobs:
 
       - name: Generate CycloneDX SBOM
         if: ${{ env.RELEASE_RUN == 'true' }}
-        run: |
-          npm install --ignore-scripts --no-save --package-lock-only 2>/dev/null || true
-          npx --yes @cyclonedx/cyclonedx-npm@5.0.0 --ignore-npm-errors --output-format JSON --output-file sbom.json
+        # anchore/sbom-action v0.24.0
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610
+        with:
+          path: .
+          format: cyclonedx-json
+          output-file: sbom.json
+          upload-artifact: false
+          upload-release-assets: false
 
       - name: Upload SBOM Artifact
         if: ${{ env.RELEASE_RUN == 'true' }}

--- a/tests/unit/repository/security-tooling-policy.test.ts
+++ b/tests/unit/repository/security-tooling-policy.test.ts
@@ -84,6 +84,21 @@ describe('repository security tooling policy', () => {
     expect(workflow).not.toContain('SEMGREP_APP_TOKEN');
   });
 
+  it('hardens release and benchmark dependency installation', () => {
+    const releaseWorkflow = readText('.github/workflows/release-please.yml');
+    const benchmarkWorkflow = readText('.github/workflows/golden-benchmark.yml');
+
+    expect(releaseWorkflow).toContain(
+      'uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610',
+    );
+    expect(releaseWorkflow).toContain('format: cyclonedx-json');
+    expect(releaseWorkflow).toContain('output-file: sbom.json');
+    expect(releaseWorkflow).toContain('upload-artifact: false');
+    expect(releaseWorkflow).toContain('upload-release-assets: false');
+    expect(releaseWorkflow).not.toContain('npx --yes @cyclonedx/cyclonedx-npm');
+    expect(benchmarkWorkflow).toContain('pnpm install --frozen-lockfile --ignore-scripts');
+  });
+
   it('documents hook setup, Snyk authentication, controlled bypass, and Sonar Connected Mode', () => {
     const guide = readText('docs/development/security-tooling.md');
 


### PR DESCRIPTION
## Summary

- replace the release-time on-demand `npx` SBOM install with the pinned `anchore/sbom-action` v0.24.0 commit
- disable lifecycle scripts during the golden benchmark dependency install
- add a repository policy regression test for both controls

## Root cause

The merged PR #325 passed its pull-request SonarQube Cloud analysis, but the subsequent `main` analysis uses the previous-version new-code window. That window still contained two `githubactions:S6505` vulnerabilities:

1. on-demand `npx` execution in the release SBOM step
2. a benchmark dependency install without `--ignore-scripts`

Those two findings lowered the `main` new-code security rating to C.

## Verification

- clean `pnpm install --frozen-lockfile --ignore-scripts` passed
- golden benchmark passed: 16/16 scenarios, score 96.88, 0 safety violations
- actionlint 1.7.12 passed
- pre-commit 4.6.0 hooks passed
- Semgrep rule tests 3/3 passed; full scan reported 0 findings
- repository policy tests 7/7 passed
- full `pnpm verify` passed
  - server: 139 files / 1,657 tests
  - extension: 8 files / 116 tests