### PR TITLE
fix(deps): remediate current dependency advisories

### DIFF
--- a/.github/dependency-audit-allowlist.json
+++ b/.github/dependency-audit-allowlist.json
@@ -1,0 +1,17 @@
+{
+  "schemaVersion": 1,
+  "exceptions": [
+    {
+      "advisory": "GHSA-frvp-7c67-39w9",
+      "package": "@hono/node-server",
+      "versions": ["1.19.14"],
+      "severity": "moderate",
+      "owner": "@oaslananka",
+      "reason": "The advisory affects the optional serve-static subpath on Windows. easyeda-mcp-pro does not serve files through @hono/node-server.",
+      "reachability": "@modelcontextprotocol/sdk@1.29.0 imports getRequestListener from the package root for Node.js/Web Standard request conversion. The vulnerable serveStatic implementation is published as the separate @hono/node-server/serve-static export and is not imported by the SDK transport or this repository.",
+      "trackingIssue": 334,
+      "reviewBy": "2026-08-10",
+      "expiresOn": "2026-08-15"
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - name: Validate Codecov configuration
         run: pnpm validate:codecov
-      - run: pnpm audit --audit-level low
+      - run: pnpm security:audit
       - run: pnpm peers check
       - run: pnpm format:check
       - run: pnpm typecheck

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Verify Quality Gates
         if: ${{ env.RELEASE_RUN == 'true' }}
         run: |
-          pnpm audit --audit-level low
+          pnpm security:audit
           pnpm peers check
           pnpm format:check
           pnpm typecheck

--- a/docs/adr/0002-dependency-management.md
+++ b/docs/adr/0002-dependency-management.md
@@ -41,3 +41,23 @@ We choose **Renovate** as our dependency automation provider.
 Renovate is the **only** tool that opens automated dependency-update pull requests in this repository, for both npm packages (`renovate.json` default manager) and GitHub Actions (`matchManagers: ["github-actions"]` group). A `.github/dependabot.yml` version-update config is intentionally **not** present, so that two bots cannot open competing or duplicate update PRs for the same dependency.
 
 GitHub's platform-level Dependabot features — dependency graph, Dependabot alerts, and Dependabot security updates — remain **enabled** as vulnerability _detection_ (Settings > Security & analysis; see `docs/REPOSITORY_GOVERNANCE.md#5-maintainer-setup-checklist`). Those features do not require a `dependabot.yml` file; only Dependabot's _version-update_ PR feature does, and that is the piece this repository delegates to Renovate.
+
+## Addendum: time-bounded audit exceptions (2026-07-22)
+
+`pnpm security:audit` is the blocking dependency-audit command for pull requests and releases. It
+runs `pnpm audit --json` and rejects every finding unless an exact, repository-owned exception is
+present in `.github/dependency-audit-allowlist.json`.
+
+Exceptions are deliberately narrow and fail closed:
+
+- high and critical advisories can never be allowlisted;
+- the advisory ID, package, resolved version, and severity must all match;
+- each entry must record an owner, reachability rationale, tracking issue, review date, and expiry;
+- new, changed, escalated, expired, or stale exceptions fail CI;
+- broad audit suppression flags are not permitted.
+
+The initial exception tracks `GHSA-frvp-7c67-39w9` in #334. The affected Windows path-traversal
+logic belongs to the separate `@hono/node-server/serve-static` export. This repository and
+`@modelcontextprotocol/sdk@1.29.0` use the package-root `getRequestListener` export for HTTP request
+conversion and do not import or configure `serveStatic`. The exception is therefore temporary,
+reviewed on 2026-08-10, and expires on 2026-08-15 while the upstream SDK migration path is tracked.

--- a/docs/development/security-tooling.md
+++ b/docs/development/security-tooling.md
@@ -103,3 +103,25 @@ pull-request context and remains authoritative in GitHub.
 - Trivy reports Docker/configuration and image findings.
 - Snyk and SonarQube Cloud remain external integrations rather than duplicate local gates.
 - actionlint and zizmor run both locally and in CI so workflow regressions are caught before merge.
+
+## Dependency audit policy
+
+Run the same dependency advisory gate used by CI and release automation:
+
+```bash
+pnpm security:audit
+```
+
+The command evaluates the complete `pnpm audit --json` result. It does not hide findings with a
+blanket ignore flag. A moderate advisory may be accepted only through an exact entry in
+`.github/dependency-audit-allowlist.json`; high and critical advisories always fail. Every exception
+must name the affected package and resolved version, document reachability, link a tracking issue,
+and include both review and expiry dates. Unexpected, changed, escalated, expired, or stale entries
+fail closed.
+
+The current `GHSA-frvp-7c67-39w9` exception is limited to
+`@hono/node-server@1.19.14`. The advisory affects the separate
+`@hono/node-server/serve-static` Windows file-serving implementation. The MCP SDK imports only
+`getRequestListener` from the package root, and easyeda-mcp-pro does not expose static file serving
+through Hono. Issue #334 owns upstream remediation; the exception must be reviewed by 2026-08-10
+and is automatically rejected after 2026-08-15.

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "eval:golden:update": "tsx scripts/run-evals.mts --update-baseline",
     "verify": "pnpm format:check && pnpm typecheck && pnpm typecheck:extension && pnpm lint && pnpm lint:tools && pnpm verify:tool-coverage && pnpm test && pnpm test:extension && pnpm build && pnpm build:extension && pnpm check:metadata && pnpm docs:build",
     "smoke:schematic-transactions": "tsx scripts/live-schematic-transaction-smoke.mts",
+    "security:audit": "node scripts/check-dependency-audit.mjs",
     "security:semgrep": "semgrep scan --config .semgrep.yml --error --metrics=off .",
     "security:semgrep:test": "node scripts/test-semgrep-rules.mjs",
     "security:snyk:oss": "corepack pnpm dlx snyk@1.1306.1 test --all-projects --severity-threshold=high",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  fast-uri: 3.1.4
+  hono: 4.12.31
   body-parser: 2.3.0
   vite: 7.3.5
   '@vitejs/plugin-vue': 6.0.7
@@ -446,7 +448,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: 4.12.31
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -1394,8 +1396,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.4:
+    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1486,8 +1488,8 @@ packages:
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
-  hono@4.12.25:
-    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
+  hono@4.12.31:
+    resolution: {integrity: sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==}
     engines: {node: '>=16.9.0'}
 
   hookable@5.5.3:
@@ -2688,9 +2690,9 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hono/node-server@1.19.14(hono@4.12.25)':
+  '@hono/node-server@1.19.14(hono@4.12.31)':
     dependencies:
-      hono: 4.12.25
+      hono: 4.12.31
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -2727,7 +2729,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.25)
+      '@hono/node-server': 1.19.14(hono@4.12.31)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -2737,7 +2739,7 @@ snapshots:
       eventsource-parser: 3.1.0
       express: 5.2.1
       express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.25
+      hono: 4.12.31
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -3281,7 +3283,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.4
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -3708,7 +3710,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.4: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3810,7 +3812,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
-  hono@4.12.25: {}
+  hono@4.12.31: {}
 
   hookable@5.5.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,8 @@ trustLockfile: false
 blockExoticSubdeps: true
 
 overrides:
+  fast-uri: 3.1.4
+  hono: 4.12.31
   body-parser: 2.3.0
   vite: 7.3.5
   '@vitejs/plugin-vue': 6.0.7

--- a/scripts/check-dependency-audit.mjs
+++ b/scripts/check-dependency-audit.mjs
@@ -95,7 +95,7 @@ const validateDate = (value, field, advisory) => {
 };
 
 const validateAllowlist = (allowlist) => {
-  if (!allowlist || allowlist.schemaVersion !== 1 || !Array.isArray(allowlist.exceptions)) {
+  if (allowlist?.schemaVersion !== 1 || !Array.isArray(allowlist?.exceptions)) {
     throw new Error('Dependency audit allowlist must use schemaVersion 1 and an exceptions array');
   }
 
@@ -177,18 +177,38 @@ const flattenFindings = (audit) => {
   return findings;
 };
 
+const getFindingPolicyError = (finding, exception, today) => {
+  if (finding.severity === 'high' || finding.severity === 'critical') {
+    return `High and critical advisories cannot be allowlisted: ${finding.advisory} (${finding.severity})`;
+  }
+  if (exception.severity !== finding.severity) {
+    return `Severity ${finding.severity} is not allowlisted for ${finding.advisory}; expected ${exception.severity}`;
+  }
+  if (!exception.versions.includes(finding.version)) {
+    return `Resolved version ${finding.version} is not allowlisted for ${finding.advisory} (${finding.package})`;
+  }
+  if (today > exception.expiresOn) {
+    return `Dependency audit exception expired for ${finding.advisory}: ${exception.expiresOn}`;
+  }
+  if (today > exception.reviewBy) {
+    return `Review date passed for ${finding.advisory}: ${exception.reviewBy} (owner ${exception.owner})`;
+  }
+  return undefined;
+};
+
+const exceptionKey = ({ advisory, package: packageName }) => `${advisory}\0${packageName}`;
+
 const evaluate = (audit, exceptions, today) => {
   const findings = flattenFindings(audit);
+  const exceptionsByKey = new Map(
+    exceptions.map((exception) => [exceptionKey(exception), exception]),
+  );
   const usedExceptions = new Set();
   const allowed = [];
   const errors = [];
 
   for (const finding of findings) {
-    const exception = exceptions.find(
-      (candidate) =>
-        candidate.advisory === finding.advisory && candidate.package === finding.package,
-    );
-
+    const exception = exceptionsByKey.get(exceptionKey(finding));
     if (!exception) {
       errors.push(
         `Unexpected dependency advisory ${finding.advisory}: ${finding.package}@${finding.version} (${finding.severity})`,
@@ -197,39 +217,12 @@ const evaluate = (audit, exceptions, today) => {
     }
 
     usedExceptions.add(exception);
-
-    if (finding.severity === 'high' || finding.severity === 'critical') {
-      errors.push(
-        `High and critical advisories cannot be allowlisted: ${finding.advisory} (${finding.severity})`,
-      );
-      continue;
+    const policyError = getFindingPolicyError(finding, exception, today);
+    if (policyError) {
+      errors.push(policyError);
+    } else {
+      allowed.push({ finding, exception });
     }
-    if (exception.severity !== finding.severity) {
-      errors.push(
-        `Severity ${finding.severity} is not allowlisted for ${finding.advisory}; expected ${exception.severity}`,
-      );
-      continue;
-    }
-    if (!exception.versions.includes(finding.version)) {
-      errors.push(
-        `Resolved version ${finding.version} is not allowlisted for ${finding.advisory} (${finding.package})`,
-      );
-      continue;
-    }
-    if (today > exception.expiresOn) {
-      errors.push(
-        `Dependency audit exception expired for ${finding.advisory}: ${exception.expiresOn}`,
-      );
-      continue;
-    }
-    if (today > exception.reviewBy) {
-      errors.push(
-        `Review date passed for ${finding.advisory}: ${exception.reviewBy} (owner ${exception.owner})`,
-      );
-      continue;
-    }
-
-    allowed.push({ finding, exception });
   }
 
   for (const exception of exceptions) {

--- a/scripts/check-dependency-audit.mjs
+++ b/scripts/check-dependency-audit.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const DEFAULT_ALLOWLIST = '.github/dependency-audit-allowlist.json';
+const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const GHSA_PATTERN = /^GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}$/i;
+
+const fail = (message) => {
+  console.error(message);
+  process.exitCode = 1;
+};
+
+const parseArguments = (argv) => {
+  const options = {
+    auditJsonPath: undefined,
+    allowlistPath: DEFAULT_ALLOWLIST,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === '--audit-json') {
+      options.auditJsonPath = argv[index + 1];
+      index += 1;
+    } else if (argument === '--allowlist') {
+      options.allowlistPath = argv[index + 1];
+      index += 1;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+
+  if (argv.includes('--audit-json') && !options.auditJsonPath) {
+    throw new Error('--audit-json requires a file path');
+  }
+  if (argv.includes('--allowlist') && !options.allowlistPath) {
+    throw new Error('--allowlist requires a file path');
+  }
+
+  return options;
+};
+
+const parseJsonFile = (path, description) => {
+  try {
+    return JSON.parse(readFileSync(resolve(path), 'utf8'));
+  } catch (error) {
+    throw new Error(`Unable to read ${description} at ${path}: ${error.message}`);
+  }
+};
+
+const runPnpmAudit = () => {
+  const command = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm';
+  const result = spawnSync(command, ['audit', '--json'], {
+    encoding: 'utf8',
+    maxBuffer: 20 * 1024 * 1024,
+  });
+
+  if (result.error) {
+    throw new Error(`Unable to run pnpm audit: ${result.error.message}`);
+  }
+  if (!result.stdout.trim()) {
+    throw new Error(
+      `pnpm audit produced no JSON output (exit ${result.status ?? 'unknown'}): ${result.stderr.trim()}`,
+    );
+  }
+  if (result.status !== 0 && result.status !== 1) {
+    throw new Error(
+      `pnpm audit failed before producing a usable result (exit ${result.status}): ${result.stderr.trim()}`,
+    );
+  }
+
+  try {
+    return JSON.parse(result.stdout);
+  } catch (error) {
+    throw new Error(`pnpm audit returned invalid JSON: ${error.message}`);
+  }
+};
+
+const requireNonEmptyString = (value, field, advisory) => {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`Dependency audit exception ${advisory} requires a non-empty ${field}`);
+  }
+};
+
+const validateDate = (value, field, advisory) => {
+  if (typeof value !== 'string' || !DATE_PATTERN.test(value)) {
+    throw new Error(`Dependency audit exception ${advisory} requires ${field} as YYYY-MM-DD`);
+  }
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+    throw new Error(`Dependency audit exception ${advisory} has invalid ${field}: ${value}`);
+  }
+};
+
+const validateAllowlist = (allowlist) => {
+  if (!allowlist || allowlist.schemaVersion !== 1 || !Array.isArray(allowlist.exceptions)) {
+    throw new Error('Dependency audit allowlist must use schemaVersion 1 and an exceptions array');
+  }
+
+  const seen = new Set();
+  for (const exception of allowlist.exceptions) {
+    const advisory = exception?.advisory ?? '<unknown>';
+    if (typeof advisory !== 'string' || !GHSA_PATTERN.test(advisory)) {
+      throw new Error(`Invalid dependency audit advisory identifier: ${advisory}`);
+    }
+    requireNonEmptyString(exception.package, 'package', advisory);
+    if (!Array.isArray(exception.versions) || exception.versions.length === 0) {
+      throw new Error(`Dependency audit exception ${advisory} requires explicit versions`);
+    }
+    for (const version of exception.versions) {
+      requireNonEmptyString(version, 'version', advisory);
+    }
+    requireNonEmptyString(exception.severity, 'severity', advisory);
+    requireNonEmptyString(exception.owner, 'owner', advisory);
+    requireNonEmptyString(exception.reason, 'reason', advisory);
+    requireNonEmptyString(exception.reachability, 'reachability', advisory);
+    if (!Number.isInteger(exception.trackingIssue) || exception.trackingIssue <= 0) {
+      throw new Error(`Dependency audit exception ${advisory} requires a positive trackingIssue`);
+    }
+    validateDate(exception.reviewBy, 'reviewBy', advisory);
+    validateDate(exception.expiresOn, 'expiresOn', advisory);
+    if (exception.reviewBy > exception.expiresOn) {
+      throw new Error(`Dependency audit exception ${advisory} reviewBy must not follow expiresOn`);
+    }
+
+    const key = `${advisory}\0${exception.package}`;
+    if (seen.has(key)) {
+      throw new Error(`Duplicate dependency audit exception: ${advisory} for ${exception.package}`);
+    }
+    seen.add(key);
+  }
+
+  return allowlist.exceptions;
+};
+
+const getToday = () => {
+  const value = process.env.DEPENDENCY_AUDIT_TODAY ?? new Date().toISOString().slice(0, 10);
+  if (!DATE_PATTERN.test(value)) {
+    throw new Error('DEPENDENCY_AUDIT_TODAY must use YYYY-MM-DD');
+  }
+  return value;
+};
+
+const flattenFindings = (audit) => {
+  if (
+    !audit ||
+    typeof audit !== 'object' ||
+    !audit.advisories ||
+    typeof audit.advisories !== 'object'
+  ) {
+    throw new Error('pnpm audit JSON is missing the advisories object');
+  }
+
+  const findings = [];
+  for (const advisory of Object.values(audit.advisories)) {
+    const advisoryId = advisory?.github_advisory_id;
+    const packageName = advisory?.module_name;
+    const severity = advisory?.severity;
+    if (!advisoryId || !packageName || !severity || !Array.isArray(advisory.findings)) {
+      throw new Error('pnpm audit JSON contains an incomplete advisory record');
+    }
+    for (const finding of advisory.findings) {
+      if (typeof finding?.version !== 'string' || finding.version === '') {
+        throw new Error(`pnpm audit finding ${advisoryId} is missing a resolved version`);
+      }
+      findings.push({
+        advisory: advisoryId,
+        package: packageName,
+        severity,
+        version: finding.version,
+        paths: Array.isArray(finding.paths) ? finding.paths : [],
+      });
+    }
+  }
+  return findings;
+};
+
+const evaluate = (audit, exceptions, today) => {
+  const findings = flattenFindings(audit);
+  const usedExceptions = new Set();
+  const allowed = [];
+  const errors = [];
+
+  for (const finding of findings) {
+    const exception = exceptions.find(
+      (candidate) =>
+        candidate.advisory === finding.advisory && candidate.package === finding.package,
+    );
+
+    if (!exception) {
+      errors.push(
+        `Unexpected dependency advisory ${finding.advisory}: ${finding.package}@${finding.version} (${finding.severity})`,
+      );
+      continue;
+    }
+
+    usedExceptions.add(exception);
+
+    if (finding.severity === 'high' || finding.severity === 'critical') {
+      errors.push(
+        `High and critical advisories cannot be allowlisted: ${finding.advisory} (${finding.severity})`,
+      );
+      continue;
+    }
+    if (exception.severity !== finding.severity) {
+      errors.push(
+        `Severity ${finding.severity} is not allowlisted for ${finding.advisory}; expected ${exception.severity}`,
+      );
+      continue;
+    }
+    if (!exception.versions.includes(finding.version)) {
+      errors.push(
+        `Resolved version ${finding.version} is not allowlisted for ${finding.advisory} (${finding.package})`,
+      );
+      continue;
+    }
+    if (today > exception.expiresOn) {
+      errors.push(
+        `Dependency audit exception expired for ${finding.advisory}: ${exception.expiresOn}`,
+      );
+      continue;
+    }
+    if (today > exception.reviewBy) {
+      errors.push(
+        `Review date passed for ${finding.advisory}: ${exception.reviewBy} (owner ${exception.owner})`,
+      );
+      continue;
+    }
+
+    allowed.push({ finding, exception });
+  }
+
+  for (const exception of exceptions) {
+    if (!usedExceptions.has(exception)) {
+      errors.push(
+        `Stale dependency audit exception ${exception.advisory} for ${exception.package}; remove it because the advisory is no longer reported`,
+      );
+    }
+  }
+
+  return { allowed, errors };
+};
+
+try {
+  const options = parseArguments(process.argv.slice(2));
+  const allowlist = parseJsonFile(options.allowlistPath, 'dependency audit allowlist');
+  const exceptions = validateAllowlist(allowlist);
+  const audit = options.auditJsonPath
+    ? parseJsonFile(options.auditJsonPath, 'pnpm audit JSON')
+    : runPnpmAudit();
+  const { allowed, errors } = evaluate(audit, exceptions, getToday());
+
+  if (errors.length > 0) {
+    for (const error of errors) fail(error);
+  } else if (allowed.length > 0) {
+    console.log(
+      `Allowed ${allowed.length} documented advisory finding${allowed.length === 1 ? '' : 's'}:`,
+    );
+    for (const { finding, exception } of allowed) {
+      console.log(
+        `- ${finding.advisory}: ${finding.package}@${finding.version} (${finding.severity}, #${exception.trackingIssue}, review by ${exception.reviewBy}, expires ${exception.expiresOn})`,
+      );
+    }
+  } else {
+    console.log('Dependency audit passed with no advisories.');
+  }
+} catch (error) {
+  fail(error instanceof Error ? error.message : String(error));
+}

--- a/tests/unit/repository/dependency-audit-policy.test.ts
+++ b/tests/unit/repository/dependency-audit-policy.test.ts
@@ -1,0 +1,177 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { afterEach, describe, expect, it } from 'vitest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../../..');
+const scriptPath = resolve(repoRoot, 'scripts/check-dependency-audit.mjs');
+const temporaryDirectories: string[] = [];
+
+interface AdvisoryOptions {
+  advisory?: string;
+  packageName?: string;
+  version?: string;
+  severity?: string;
+}
+
+const makeAudit = ({
+  advisory = 'GHSA-frvp-7c67-39w9',
+  packageName = '@hono/node-server',
+  version = '1.19.14',
+  severity = 'moderate',
+}: AdvisoryOptions = {}) => ({
+  advisories: {
+    '1124006': {
+      findings: [
+        {
+          version,
+          paths: ['.>@modelcontextprotocol/sdk>@hono/node-server'],
+          dev: false,
+          optional: false,
+          bundled: false,
+        },
+      ],
+      id: 1124006,
+      title: 'Test advisory',
+      module_name: packageName,
+      vulnerable_versions: '<2.0.5',
+      patched_versions: '>=2.0.5',
+      severity,
+      github_advisory_id: advisory,
+      url: `https://github.com/advisories/${advisory}`,
+    },
+  },
+  metadata: {
+    vulnerabilities: {
+      info: 0,
+      low: 0,
+      moderate: severity === 'moderate' ? 1 : 0,
+      high: severity === 'high' ? 1 : 0,
+      critical: severity === 'critical' ? 1 : 0,
+    },
+    dependencies: 1,
+    devDependencies: 0,
+    optionalDependencies: 0,
+    totalDependencies: 1,
+  },
+});
+
+const makeAllowlist = (overrides: Record<string, unknown> = {}) => ({
+  schemaVersion: 1,
+  exceptions: [
+    {
+      advisory: 'GHSA-frvp-7c67-39w9',
+      package: '@hono/node-server',
+      versions: ['1.19.14'],
+      severity: 'moderate',
+      owner: '@oaslananka',
+      reason: 'The affected serve-static subpath is not imported by this package.',
+      reachability:
+        'The MCP SDK imports getRequestListener from the package root; serve-static is a separate export.',
+      trackingIssue: 334,
+      reviewBy: '2026-08-10',
+      expiresOn: '2026-08-15',
+      ...overrides,
+    },
+  ],
+});
+
+const runPolicy = (audit: unknown, allowlist: unknown) => {
+  const directory = mkdtempSync(resolve(tmpdir(), 'dependency-audit-policy-'));
+  temporaryDirectories.push(directory);
+  const auditPath = resolve(directory, 'audit.json');
+  const allowlistPath = resolve(directory, 'allowlist.json');
+  writeFileSync(auditPath, `${JSON.stringify(audit, null, 2)}\n`);
+  writeFileSync(allowlistPath, `${JSON.stringify(allowlist, null, 2)}\n`);
+
+  return spawnSync(
+    process.execPath,
+    [scriptPath, '--audit-json', auditPath, '--allowlist', allowlistPath],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        DEPENDENCY_AUDIT_TODAY: '2026-07-22',
+      },
+    },
+  );
+};
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('dependency audit policy', () => {
+  it('allows one exact, documented, unexpired moderate advisory', () => {
+    const result = runPolicy(makeAudit(), makeAllowlist());
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Allowed 1 documented advisory finding');
+    expect(result.stdout).toContain('GHSA-frvp-7c67-39w9');
+    expect(result.stdout).toContain('#334');
+  });
+
+  it('rejects an unexpected advisory', () => {
+    const result = runPolicy(makeAudit({ advisory: 'GHSA-aaaa-bbbb-cccc' }), makeAllowlist());
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Unexpected dependency advisory');
+    expect(result.stderr).toContain('GHSA-aaaa-bbbb-cccc');
+  });
+
+  it('never allows high or critical advisories', () => {
+    const result = runPolicy(makeAudit({ severity: 'high' }), makeAllowlist({ severity: 'high' }));
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('High and critical advisories cannot be allowlisted');
+  });
+
+  it('rejects a finding whose resolved version is not explicitly allowed', () => {
+    const result = runPolicy(makeAudit({ version: '1.19.15' }), makeAllowlist());
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Resolved version 1.19.15 is not allowlisted');
+  });
+
+  it('rejects an exception after its review date', () => {
+    const result = runPolicy(makeAudit(), makeAllowlist({ reviewBy: '2026-07-21' }));
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Review date passed');
+  });
+
+  it('rejects an expired exception', () => {
+    const result = runPolicy(
+      makeAudit(),
+      makeAllowlist({ reviewBy: '2026-07-20', expiresOn: '2026-07-21' }),
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Dependency audit exception expired');
+  });
+
+  it('rejects stale exceptions after the advisory disappears', () => {
+    const result = runPolicy(
+      {
+        advisories: {},
+        metadata: {
+          vulnerabilities: { info: 0, low: 0, moderate: 0, high: 0, critical: 0 },
+          dependencies: 1,
+          devDependencies: 0,
+          optionalDependencies: 0,
+          totalDependencies: 1,
+        },
+      },
+      makeAllowlist(),
+    );
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('Stale dependency audit exception');
+  });
+});

--- a/tests/unit/repository/security-tooling-policy.test.ts
+++ b/tests/unit/repository/security-tooling-policy.test.ts
@@ -78,6 +78,7 @@ describe('repository security tooling policy', () => {
     expect(packageJson.scripts?.['security:snyk']).toBe(
       'pnpm security:snyk:oss && pnpm security:snyk:code',
     );
+    expect(packageJson.scripts?.['security:audit']).toBe('node scripts/check-dependency-audit.mjs');
     const workspace = readText('pnpm-workspace.yaml');
     expect(workspace).toContain('minimumReleaseAge: 4320');
     expect(workspace).toContain('minimumReleaseAgeStrict: true');
@@ -130,6 +131,32 @@ describe('repository security tooling policy', () => {
     expect(readText('.github/workflows/release-please.yml')).toContain(
       'if [[ "$RELEASE_CREATED" == "true" || -n "$MANUAL_TAG" ]]',
     );
+
+    const ciWorkflow = readText('.github/workflows/ci.yml');
+    const releaseWorkflow = readText('.github/workflows/release-please.yml');
+    expect(ciWorkflow).toContain('pnpm security:audit');
+    expect(releaseWorkflow).toContain('pnpm security:audit');
+    expect(ciWorkflow).not.toContain('pnpm audit --audit-level low');
+    expect(releaseWorkflow).not.toContain('pnpm audit --audit-level low');
+
+    const dependencyAuditAllowlist = JSON.parse(
+      readText('.github/dependency-audit-allowlist.json'),
+    ) as {
+      schemaVersion?: number;
+      exceptions?: Array<Record<string, unknown>>;
+    };
+    expect(dependencyAuditAllowlist.schemaVersion).toBe(1);
+    expect(dependencyAuditAllowlist.exceptions).toHaveLength(1);
+    expect(dependencyAuditAllowlist.exceptions?.[0]).toMatchObject({
+      advisory: 'GHSA-frvp-7c67-39w9',
+      package: '@hono/node-server',
+      versions: ['1.19.14'],
+      severity: 'moderate',
+      owner: '@oaslananka',
+      trackingIssue: 334,
+      reviewBy: '2026-08-10',
+      expiresOn: '2026-08-15',
+    });
   });
 
   it('hardens release and benchmark dependency installation', () => {


### PR DESCRIPTION
## Summary

- pin `fast-uri` to `3.1.4` and `hono` to `4.12.31` through the existing pnpm workspace override policy
- refresh only the affected lockfile records
- replace broad `pnpm audit --audit-level low` calls with a repository-owned, fail-closed audit policy
- document one exact, time-bounded exception for `GHSA-frvp-7c67-39w9`
- enforce the same policy in pull-request CI and release verification

## Security impact

Before this change, the dependency audit reported:

- 2 high-severity `fast-uri` advisories
- 3 moderate-severity `hono` advisories
- 1 moderate-severity `@hono/node-server` advisory

After this change:

- 0 critical advisories
- 0 high advisories
- 1 documented moderate advisory: `GHSA-frvp-7c67-39w9`

The remaining advisory affects the separate `@hono/node-server/serve-static` Windows file-serving export. `@modelcontextprotocol/sdk@1.29.0` imports only `getRequestListener` from the package root for Node.js/Web Standard request conversion, and easyeda-mcp-pro does not import or configure `serveStatic`.

The exception is intentionally narrow:

- exact advisory: `GHSA-frvp-7c67-39w9`
- exact package/version: `@hono/node-server@1.19.14`
- moderate severity only
- owner: `@oaslananka`
- review by: `2026-08-10`
- expires: `2026-08-15`
- tracking issue: #334

High and critical advisories cannot be allowlisted. Unexpected, changed, escalated, expired, or stale exceptions fail CI.

## Dependency diff

- `fast-uri`: `3.1.2` → `3.1.4`
- `hono`: `4.12.25` → `4.12.31`

No direct dependency range was changed, and no unrelated lockfile refresh was performed.

## Verification

Executed on Node.js `v24.18.0` with pnpm `11.5.1`:

- `pnpm install --frozen-lockfile`
- `pnpm security:audit`
- dependency policy tests: 15 passed
- targeted HTTP and Remote Relay suite: 12 files / 109 tests passed
- extension Remote Relay client suite: 1 file / 7 tests passed
- `pnpm verify`
  - server: 146 files / 1,702 tests passed
  - extension: 8 files / 123 tests passed
  - formatting, type checking, linting, builds, metadata checks, extension packaging, and docs build passed
- `pnpm pack --dry-run`
- `git diff --check`

The GitHub Actions matrix remains responsible for Node.js 26, Windows, macOS, CodeQL, and the full static-security jobs.

Closes #333
Closes #334
