### PR TITLE
ci(security): add scheduled dependency advisory monitoring

### DIFF
--- a/.github/workflows/dependency-advisory-monitor.yml
+++ b/.github/workflows/dependency-advisory-monitor.yml
@@ -1,0 +1,65 @@
+name: Dependency Advisory Monitor
+
+on:
+  schedule:
+    - cron: '23 5 * * *'
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - '.github/workflows/dependency-advisory-monitor.yml'
+      - '.github/dependency-audit-allowlist.json'
+      - 'scripts/check-dependency-audit.mjs'
+      - 'tests/unit/repository/dependency-audit-policy.test.ts'
+      - 'tests/unit/repository/security-tooling-policy.test.ts'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dependency-advisory-monitor-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  dependency-audit:
+    name: dependency-audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      # actions/checkout v6.0.3
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          persist-credentials: false
+
+      # pnpm/action-setup v6.0.8
+      - name: Setup pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093
+
+      # actions/setup-node v6.4.0
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version: '24'
+          package-manager-cache: false
+
+      - name: Verify frozen lockfile and supply-chain policy
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Evaluate dependency advisories
+        run: >-
+          pnpm security:audit --
+          --report-json reports/dependency-audit.json
+          --summary-file "$GITHUB_STEP_SUMMARY"
+
+      # actions/upload-artifact v7.0.1
+      - name: Upload machine-readable dependency audit report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: dependency-audit-report-${{ github.run_id }}
+          path: reports/dependency-audit.json
+          if-no-files-found: error
+          retention-days: 14

--- a/docs/development/security-tooling.md
+++ b/docs/development/security-tooling.md
@@ -125,3 +125,21 @@ The current `GHSA-frvp-7c67-39w9` exception is limited to
 `getRequestListener` from the package root, and easyeda-mcp-pro does not expose static file serving
 through Hono. Issue #334 owns upstream remediation; the exception must be reviewed by 2026-08-10
 and is automatically rejected after 2026-08-15.
+
+### Scheduled advisory monitoring
+
+The `Dependency Advisory Monitor` workflow runs every day at **05:23 UTC** and can also be started
+manually with `workflow_dispatch`. Pull requests that change the audit policy, dependency graph, or
+workflow run the same job for validation.
+
+The job first performs a frozen, script-disabled install so the committed pnpm lockfile and
+workspace supply-chain policy are evaluated before any advisory decision. It then runs
+`pnpm security:audit`, writes the human-readable result to the GitHub Job Summary, and uploads the
+machine-readable `dependency-audit-report` JSON artifact for 14 days. The report includes advisory
+IDs, affected packages, resolved dependency paths, installed versions, patched version ranges, and
+policy decisions.
+
+The workflow has read-only repository permission and never creates or updates issues. A repeated
+advisory therefore produces one failed workflow signal per run without duplicate public issue
+noise. Remediation remains tracked through the explicit issue referenced by a time-bounded audit
+exception.

--- a/scripts/check-dependency-audit.mjs
+++ b/scripts/check-dependency-audit.mjs
@@ -149,50 +149,81 @@ const getToday = () => {
 const getGeneratedAt = () => {
   const value = process.env.DEPENDENCY_AUDIT_GENERATED_AT ?? new Date().toISOString();
   if (Number.isNaN(Date.parse(value))) {
-    throw new Error('DEPENDENCY_AUDIT_GENERATED_AT must be a valid ISO-8601 timestamp');
+    throw new TypeError('DEPENDENCY_AUDIT_GENERATED_AT must be a valid ISO-8601 timestamp');
   }
   return value;
 };
 
-const flattenFindings = (audit) => {
-  if (
-    !audit ||
-    typeof audit !== 'object' ||
-    !audit.advisories ||
-    typeof audit.advisories !== 'object'
-  ) {
-    throw new Error('pnpm audit JSON is missing the advisories object');
+const getAuditAdvisories = (audit) => {
+  if (!audit || typeof audit !== 'object' || Array.isArray(audit)) {
+    throw new TypeError('pnpm audit JSON must be an object');
+  }
+  const { advisories } = audit;
+  if (!advisories || typeof advisories !== 'object' || Array.isArray(advisories)) {
+    throw new TypeError('pnpm audit JSON is missing the advisories object');
+  }
+  return advisories;
+};
+
+const optionalString = (value) => (typeof value === 'string' ? value : '');
+
+const getAdvisoryMetadata = (advisory) => {
+  if (!advisory || typeof advisory !== 'object' || Array.isArray(advisory)) {
+    throw new TypeError('pnpm audit JSON contains an invalid advisory record');
   }
 
-  const findings = [];
-  for (const advisory of Object.values(audit.advisories)) {
-    const advisoryId = advisory?.github_advisory_id;
-    const packageName = advisory?.module_name;
-    const severity = advisory?.severity;
-    if (!advisoryId || !packageName || !severity || !Array.isArray(advisory.findings)) {
-      throw new Error('pnpm audit JSON contains an incomplete advisory record');
-    }
-    for (const finding of advisory.findings) {
-      if (typeof finding?.version !== 'string' || finding.version === '') {
-        throw new Error(`pnpm audit finding ${advisoryId} is missing a resolved version`);
-      }
-      findings.push({
-        advisory: advisoryId,
-        title: typeof advisory.title === 'string' ? advisory.title : '',
-        url: typeof advisory.url === 'string' ? advisory.url : '',
-        package: packageName,
-        severity,
-        resolvedVersion: finding.version,
-        vulnerableVersions:
-          typeof advisory.vulnerable_versions === 'string' ? advisory.vulnerable_versions : '',
-        patchedVersions:
-          typeof advisory.patched_versions === 'string' ? advisory.patched_versions : '',
-        paths: Array.isArray(finding.paths) ? finding.paths : [],
-      });
-    }
+  const advisoryId = advisory.github_advisory_id;
+  const packageName = advisory.module_name;
+  const severity = advisory.severity;
+  if (
+    typeof advisoryId !== 'string' ||
+    typeof packageName !== 'string' ||
+    typeof severity !== 'string' ||
+    !Array.isArray(advisory.findings)
+  ) {
+    throw new TypeError('pnpm audit JSON contains an incomplete advisory record');
   }
-  return findings;
+
+  return {
+    advisoryId,
+    packageName,
+    severity,
+    title: optionalString(advisory.title),
+    url: optionalString(advisory.url),
+    vulnerableVersions: optionalString(advisory.vulnerable_versions),
+    patchedVersions: optionalString(advisory.patched_versions),
+    findings: advisory.findings,
+  };
 };
+
+const normalizeFinding = (metadata, finding) => {
+  if (!finding || typeof finding !== 'object' || typeof finding.version !== 'string') {
+    throw new TypeError(`pnpm audit finding ${metadata.advisoryId} is missing a resolved version`);
+  }
+  if (finding.version === '') {
+    throw new TypeError(`pnpm audit finding ${metadata.advisoryId} is missing a resolved version`);
+  }
+
+  return {
+    advisory: metadata.advisoryId,
+    title: metadata.title,
+    url: metadata.url,
+    package: metadata.packageName,
+    severity: metadata.severity,
+    resolvedVersion: finding.version,
+    vulnerableVersions: metadata.vulnerableVersions,
+    patchedVersions: metadata.patchedVersions,
+    paths: Array.isArray(finding.paths) ? finding.paths : [],
+  };
+};
+
+const normalizeAdvisory = (advisory) => {
+  const metadata = getAdvisoryMetadata(advisory);
+  return metadata.findings.map((finding) => normalizeFinding(metadata, finding));
+};
+
+const flattenFindings = (audit) =>
+  Object.values(getAuditAdvisories(audit)).flatMap(normalizeAdvisory);
 
 const getFindingPolicyError = (finding, exception, today) => {
   if (finding.severity === 'high' || finding.severity === 'critical') {
@@ -273,7 +304,7 @@ const createReport = (audit, evaluation, generatedAt) => ({
 
 const escapeTableCell = (value) =>
   String(value ?? '')
-    .replaceAll('|', '\\|')
+    .replaceAll('|', String.raw`\|`)
     .replace(/\r?\n/g, '<br>');
 
 const createMarkdownSummary = (report) => {

--- a/scripts/check-dependency-audit.mjs
+++ b/scripts/check-dependency-audit.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { appendFileSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
 
 const DEFAULT_ALLOWLIST = '.github/dependency-audit-allowlist.json';
@@ -17,26 +17,29 @@ const parseArguments = (argv) => {
   const options = {
     auditJsonPath: undefined,
     allowlistPath: DEFAULT_ALLOWLIST,
+    reportJsonPath: undefined,
+    summaryFilePath: undefined,
   };
+  const optionNames = new Map([
+    ['--audit-json', 'auditJsonPath'],
+    ['--allowlist', 'allowlistPath'],
+    ['--report-json', 'reportJsonPath'],
+    ['--summary-file', 'summaryFilePath'],
+  ]);
 
   for (let index = 0; index < argv.length; index += 1) {
     const argument = argv[index];
-    if (argument === '--audit-json') {
-      options.auditJsonPath = argv[index + 1];
-      index += 1;
-    } else if (argument === '--allowlist') {
-      options.allowlistPath = argv[index + 1];
-      index += 1;
-    } else {
+    if (argument === '--') continue;
+    const optionName = optionNames.get(argument);
+    if (!optionName) {
       throw new Error(`Unknown argument: ${argument}`);
     }
-  }
-
-  if (argv.includes('--audit-json') && !options.auditJsonPath) {
-    throw new Error('--audit-json requires a file path');
-  }
-  if (argv.includes('--allowlist') && !options.allowlistPath) {
-    throw new Error('--allowlist requires a file path');
+    const value = argv[index + 1];
+    if (!value || value.startsWith('--')) {
+      throw new Error(`${argument} requires a file path`);
+    }
+    options[optionName] = value;
+    index += 1;
   }
 
   return options;
@@ -143,6 +146,14 @@ const getToday = () => {
   return value;
 };
 
+const getGeneratedAt = () => {
+  const value = process.env.DEPENDENCY_AUDIT_GENERATED_AT ?? new Date().toISOString();
+  if (Number.isNaN(Date.parse(value))) {
+    throw new Error('DEPENDENCY_AUDIT_GENERATED_AT must be a valid ISO-8601 timestamp');
+  }
+  return value;
+};
+
 const flattenFindings = (audit) => {
   if (
     !audit ||
@@ -167,9 +178,15 @@ const flattenFindings = (audit) => {
       }
       findings.push({
         advisory: advisoryId,
+        title: typeof advisory.title === 'string' ? advisory.title : '',
+        url: typeof advisory.url === 'string' ? advisory.url : '',
         package: packageName,
         severity,
-        version: finding.version,
+        resolvedVersion: finding.version,
+        vulnerableVersions:
+          typeof advisory.vulnerable_versions === 'string' ? advisory.vulnerable_versions : '',
+        patchedVersions:
+          typeof advisory.patched_versions === 'string' ? advisory.patched_versions : '',
         paths: Array.isArray(finding.paths) ? finding.paths : [],
       });
     }
@@ -184,8 +201,8 @@ const getFindingPolicyError = (finding, exception, today) => {
   if (exception.severity !== finding.severity) {
     return `Severity ${finding.severity} is not allowlisted for ${finding.advisory}; expected ${exception.severity}`;
   }
-  if (!exception.versions.includes(finding.version)) {
-    return `Resolved version ${finding.version} is not allowlisted for ${finding.advisory} (${finding.package})`;
+  if (!exception.versions.includes(finding.resolvedVersion)) {
+    return `Resolved version ${finding.resolvedVersion} is not allowlisted for ${finding.advisory} (${finding.package})`;
   }
   if (today > exception.expiresOn) {
     return `Dependency audit exception expired for ${finding.advisory}: ${exception.expiresOn}`;
@@ -204,25 +221,22 @@ const evaluate = (audit, exceptions, today) => {
     exceptions.map((exception) => [exceptionKey(exception), exception]),
   );
   const usedExceptions = new Set();
-  const allowed = [];
+  const evaluatedFindings = [];
   const errors = [];
 
   for (const finding of findings) {
     const exception = exceptionsByKey.get(exceptionKey(finding));
     if (!exception) {
-      errors.push(
-        `Unexpected dependency advisory ${finding.advisory}: ${finding.package}@${finding.version} (${finding.severity})`,
-      );
+      const policyError = `Unexpected dependency advisory ${finding.advisory}: ${finding.package}@${finding.resolvedVersion} (${finding.severity})`;
+      errors.push(policyError);
+      evaluatedFindings.push({ finding, exception: undefined, policyError });
       continue;
     }
 
     usedExceptions.add(exception);
     const policyError = getFindingPolicyError(finding, exception, today);
-    if (policyError) {
-      errors.push(policyError);
-    } else {
-      allowed.push({ finding, exception });
-    }
+    if (policyError) errors.push(policyError);
+    evaluatedFindings.push({ finding, exception, policyError });
   }
 
   for (const exception of exceptions) {
@@ -233,7 +247,108 @@ const evaluate = (audit, exceptions, today) => {
     }
   }
 
-  return { allowed, errors };
+  return { evaluatedFindings, errors };
+};
+
+const createReport = (audit, evaluation, generatedAt) => ({
+  schemaVersion: 1,
+  generatedAt,
+  status: evaluation.errors.length === 0 ? 'passed' : 'failed',
+  vulnerabilityCounts: audit.metadata?.vulnerabilities ?? {},
+  findings: evaluation.evaluatedFindings.map(({ finding, exception, policyError }) => ({
+    ...finding,
+    policy: policyError ? 'blocked' : 'allowed',
+    ...(policyError ? { policyError } : {}),
+    ...(exception
+      ? {
+          trackingIssue: exception.trackingIssue,
+          owner: exception.owner,
+          reviewBy: exception.reviewBy,
+          expiresOn: exception.expiresOn,
+        }
+      : {}),
+  })),
+  errors: evaluation.errors,
+});
+
+const escapeTableCell = (value) =>
+  String(value ?? '')
+    .replaceAll('|', '\\|')
+    .replace(/\r?\n/g, '<br>');
+
+const createMarkdownSummary = (report) => {
+  const lines = [
+    '# Dependency advisory monitor',
+    '',
+    report.status === 'passed' ? '✅ Policy passed' : '❌ Policy failed',
+    '',
+    `Generated: ${report.generatedAt}`,
+    '',
+  ];
+
+  if (report.findings.length === 0) {
+    lines.push('No dependency advisories were reported.', '');
+  } else {
+    lines.push(
+      '| Advisory | Package | Severity | Resolved | Patched | Policy | Dependency paths |',
+      '| --- | --- | --- | --- | --- | --- | --- |',
+    );
+    for (const finding of report.findings) {
+      const policy =
+        finding.policy === 'allowed'
+          ? `allowed via #${finding.trackingIssue} until ${finding.expiresOn}`
+          : 'blocked';
+      const paths = finding.paths.length > 0 ? finding.paths.join('<br>') : '—';
+      lines.push(
+        `| ${escapeTableCell(finding.advisory)} | ${escapeTableCell(finding.package)} | ${escapeTableCell(finding.severity)} | ${escapeTableCell(finding.resolvedVersion)} | ${escapeTableCell(finding.patchedVersions || 'unknown')} | ${escapeTableCell(policy)} | ${escapeTableCell(paths)} |`,
+      );
+    }
+    lines.push('');
+  }
+
+  if (report.errors.length > 0) {
+    lines.push('## Policy errors', '');
+    for (const error of report.errors) lines.push(`- ${error}`);
+    lines.push('');
+  }
+
+  return `${lines.join('\n')}\n`;
+};
+
+const writeReports = (options, report) => {
+  if (options.reportJsonPath) {
+    const path = resolve(options.reportJsonPath);
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, `${JSON.stringify(report, null, 2)}\n`);
+  }
+  if (options.summaryFilePath) {
+    const path = resolve(options.summaryFilePath);
+    mkdirSync(dirname(path), { recursive: true });
+    appendFileSync(path, createMarkdownSummary(report));
+  }
+};
+
+const printEvaluation = (evaluation) => {
+  if (evaluation.errors.length > 0) {
+    for (const error of evaluation.errors) fail(error);
+    return;
+  }
+
+  const allowed = evaluation.evaluatedFindings.filter(({ policyError }) => !policyError);
+  if (allowed.length === 0) {
+    console.log('Dependency audit passed with no advisories.');
+    return;
+  }
+
+  console.log(
+    `Allowed ${allowed.length} documented advisory finding${allowed.length === 1 ? '' : 's'}:`,
+  );
+  for (const { finding, exception } of allowed) {
+    console.log(
+      `- ${finding.advisory}: ${finding.package}@${finding.resolvedVersion} (${finding.severity}, patched ${finding.patchedVersions || 'unknown'}, #${exception.trackingIssue}, review by ${exception.reviewBy}, expires ${exception.expiresOn})`,
+    );
+    for (const path of finding.paths) console.log(`  path: ${path}`);
+  }
 };
 
 try {
@@ -243,22 +358,10 @@ try {
   const audit = options.auditJsonPath
     ? parseJsonFile(options.auditJsonPath, 'pnpm audit JSON')
     : runPnpmAudit();
-  const { allowed, errors } = evaluate(audit, exceptions, getToday());
-
-  if (errors.length > 0) {
-    for (const error of errors) fail(error);
-  } else if (allowed.length > 0) {
-    console.log(
-      `Allowed ${allowed.length} documented advisory finding${allowed.length === 1 ? '' : 's'}:`,
-    );
-    for (const { finding, exception } of allowed) {
-      console.log(
-        `- ${finding.advisory}: ${finding.package}@${finding.version} (${finding.severity}, #${exception.trackingIssue}, review by ${exception.reviewBy}, expires ${exception.expiresOn})`,
-      );
-    }
-  } else {
-    console.log('Dependency audit passed with no advisories.');
-  }
+  const evaluation = evaluate(audit, exceptions, getToday());
+  const report = createReport(audit, evaluation, getGeneratedAt());
+  writeReports(options, report);
+  printEvaluation(evaluation);
 } catch (error) {
   fail(error instanceof Error ? error.message : String(error));
 }

--- a/tests/unit/repository/dependency-audit-policy.test.ts
+++ b/tests/unit/repository/dependency-audit-policy.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, resolve } from 'node:path';
 import { spawnSync } from 'node:child_process';
@@ -79,13 +79,18 @@ const makeAllowlist = (overrides: Record<string, unknown> = {}) => ({
   ],
 });
 
-const runPolicy = (audit: unknown, allowlist: unknown) => {
+const createPolicyFixture = (audit: unknown, allowlist: unknown) => {
   const directory = mkdtempSync(resolve(tmpdir(), 'dependency-audit-policy-'));
   temporaryDirectories.push(directory);
   const auditPath = resolve(directory, 'audit.json');
   const allowlistPath = resolve(directory, 'allowlist.json');
   writeFileSync(auditPath, `${JSON.stringify(audit, null, 2)}\n`);
   writeFileSync(allowlistPath, `${JSON.stringify(allowlist, null, 2)}\n`);
+  return { directory, auditPath, allowlistPath };
+};
+
+const runPolicy = (audit: unknown, allowlist: unknown) => {
+  const { auditPath, allowlistPath } = createPolicyFixture(audit, allowlist);
 
   return spawnSync(
     process.execPath,
@@ -99,6 +104,38 @@ const runPolicy = (audit: unknown, allowlist: unknown) => {
       },
     },
   );
+};
+
+const runPolicyWithReports = (audit: unknown, allowlist: unknown) => {
+  const { directory, auditPath, allowlistPath } = createPolicyFixture(audit, allowlist);
+  const reportPath = resolve(directory, 'dependency-audit-report.json');
+  const summaryPath = resolve(directory, 'dependency-audit-summary.md');
+  const result = spawnSync(
+    process.execPath,
+    [
+      scriptPath,
+      '--audit-json',
+      auditPath,
+      '--allowlist',
+      allowlistPath,
+      '--',
+      '--report-json',
+      reportPath,
+      '--summary-file',
+      summaryPath,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        DEPENDENCY_AUDIT_TODAY: '2026-07-22',
+        DEPENDENCY_AUDIT_GENERATED_AT: '2026-07-22T18:00:00.000Z',
+      },
+    },
+  );
+
+  return { result, reportPath, summaryPath };
 };
 
 afterEach(() => {
@@ -154,6 +191,64 @@ describe('dependency audit policy', () => {
 
     expect(result.status).toBe(1);
     expect(result.stderr).toContain('Dependency audit exception expired');
+  });
+
+  it('writes machine-readable and human-readable reports for allowed findings', () => {
+    const { result, reportPath, summaryPath } = runPolicyWithReports(makeAudit(), makeAllowlist());
+
+    expect(result.status).toBe(0);
+    const report = JSON.parse(readFileSync(reportPath, 'utf8')) as {
+      schemaVersion: number;
+      generatedAt: string;
+      status: string;
+      findings: Array<Record<string, unknown>>;
+      errors: string[];
+    };
+    expect(report).toMatchObject({
+      schemaVersion: 1,
+      generatedAt: '2026-07-22T18:00:00.000Z',
+      status: 'passed',
+      errors: [],
+    });
+    expect(report.findings).toEqual([
+      expect.objectContaining({
+        advisory: 'GHSA-frvp-7c67-39w9',
+        package: '@hono/node-server',
+        resolvedVersion: '1.19.14',
+        patchedVersions: '>=2.0.5',
+        paths: ['.>@modelcontextprotocol/sdk>@hono/node-server'],
+        policy: 'allowed',
+        trackingIssue: 334,
+      }),
+    ]);
+
+    const summary = readFileSync(summaryPath, 'utf8');
+    expect(summary).toContain('# Dependency advisory monitor');
+    expect(summary).toContain('✅ Policy passed');
+    expect(summary).toContain('GHSA-frvp-7c67-39w9');
+    expect(summary).toContain('@hono/node-server');
+    expect(summary).toContain('>=2.0.5');
+    expect(summary).toContain('.>@modelcontextprotocol/sdk>@hono/node-server');
+  });
+
+  it('writes failure evidence before rejecting an unexpected advisory', () => {
+    const { result, reportPath, summaryPath } = runPolicyWithReports(
+      makeAudit({ advisory: 'GHSA-aaaa-bbbb-cccc' }),
+      makeAllowlist(),
+    );
+
+    expect(result.status).toBe(1);
+    const report = JSON.parse(readFileSync(reportPath, 'utf8')) as {
+      status: string;
+      findings: Array<Record<string, unknown>>;
+      errors: string[];
+    };
+    expect(report.status).toBe('failed');
+    expect(report.findings).toEqual([expect.objectContaining({ policy: 'blocked' })]);
+    expect(report.errors.join('\n')).toContain('Unexpected dependency advisory');
+    const summary = readFileSync(summaryPath, 'utf8');
+    expect(summary).toContain('❌ Policy failed');
+    expect(summary).toContain('Unexpected dependency advisory');
   });
 
   it('rejects stale exceptions after the advisory disappears', () => {

--- a/tests/unit/repository/security-tooling-policy.test.ts
+++ b/tests/unit/repository/security-tooling-policy.test.ts
@@ -115,6 +115,7 @@ describe('repository security tooling policy', () => {
       readText('.github/workflows/ci.yml') +
       readText('.github/workflows/agent-runtime-config.yml') +
       readText('.github/workflows/dependency-review.yml') +
+      readText('.github/workflows/dependency-advisory-monitor.yml') +
       readText('.github/workflows/deploy-docs.yml') +
       readText('.github/workflows/golden-benchmark.yml') +
       readText('.github/workflows/release-please.yml') +
@@ -157,6 +158,41 @@ describe('repository security tooling policy', () => {
       reviewBy: '2026-08-10',
       expiresOn: '2026-08-15',
     });
+  });
+
+  it('runs a least-privilege scheduled dependency advisory monitor', () => {
+    const workflow = readText('.github/workflows/dependency-advisory-monitor.yml');
+
+    expect(workflow).toContain('name: Dependency Advisory Monitor');
+    expect(workflow).toContain('schedule:');
+    expect(workflow).toContain("cron: '23 5 * * *'");
+    expect(workflow).toContain('workflow_dispatch:');
+    expect(workflow).toContain('pull_request:');
+    expect(workflow).toContain('permissions:');
+    expect(workflow).toContain('contents: read');
+    expect(workflow).not.toContain('issues: write');
+    expect(workflow).not.toContain('pull-requests: write');
+    expect(workflow).not.toContain('pull_request_target');
+    expect(workflow).toContain('actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0');
+    expect(workflow).toContain('pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093');
+    expect(workflow).toContain('actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e');
+    expect(workflow).toContain('actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a');
+    expect(workflow).toContain('persist-credentials: false');
+    expect(workflow).toContain("node-version: '24'");
+    expect(workflow).toContain('package-manager-cache: false');
+    expect(workflow).toContain('pnpm install --frozen-lockfile --ignore-scripts');
+    expect(workflow).toContain('pnpm security:audit --');
+    expect(workflow).toContain('--report-json reports/dependency-audit.json');
+    expect(workflow).toContain('--summary-file "$GITHUB_STEP_SUMMARY"');
+    expect(workflow).toContain('if: ${{ always() }}');
+    expect(workflow).toContain('reports/dependency-audit.json');
+    expect(workflow).toContain('if-no-files-found: error');
+    expect(workflow).not.toContain('gh issue create');
+
+    const guide = readText('docs/development/security-tooling.md');
+    expect(guide).toContain('05:23 UTC');
+    expect(guide).toContain('workflow_dispatch');
+    expect(guide).toContain('dependency-audit-report');
   });
 
   it('hardens release and benchmark dependency installation', () => {


### PR DESCRIPTION
## Summary

- add a daily dependency advisory monitor at 05:23 UTC
- support manual `workflow_dispatch` runs and pull-request validation
- evaluate the frozen lockfile and committed pnpm supply-chain policy before advisory analysis
- publish a concise GitHub Job Summary and a 14-day machine-readable JSON artifact
- keep repository permissions read-only and avoid automatic issue creation

## Audit evidence

The audit report includes:

- GitHub advisory ID
- affected package and installed version
- resolved dependency paths
- vulnerable and patched version ranges
- allowlist policy decision and tracking metadata
- policy errors when the run fails

The evaluator writes evidence before exiting on an unexpected, changed, escalated, expired, or stale finding. High and critical advisories remain non-allowlistable.

## Notification behavior

The workflow does not create or update GitHub issues. Repeated findings therefore remain visible as workflow failures and summaries without producing duplicate public issues or comments. Remediation ownership stays with the explicit issue referenced by a time-bounded exception.

## Security

- `permissions: contents: read`
- no `issues: write` or `pull-requests: write`
- no `pull_request_target`
- all third-party actions pinned by full commit SHA
- install scripts disabled during the monitor's frozen-lockfile check
- workflow passes actionlint and zizmor at medium severity or higher

## Verification

Executed on Node.js `v24.18.0` with pnpm `11.5.1`:

- `pnpm install --frozen-lockfile --ignore-scripts`
- live `pnpm security:audit -- --report-json ... --summary-file ...`
- dependency/security policy tests: 18 passed
- `pnpm verify`
  - server: 146 files / 1,705 tests passed
  - extension: 8 files / 123 tests passed
  - formatting, type checking, linting, builds, metadata checks, extension packaging, and docs build passed
- `actionlint .github/workflows/dependency-advisory-monitor.yml`
- `zizmor --min-severity=medium .github/workflows/dependency-advisory-monitor.yml`
- `git diff --check`

## GitHub Actions evidence

- Dependency Advisory Monitor validation: https://github.com/oaslananka/easyeda-mcp-pro/actions/runs/29949596196
- Result: success
- Artifact: `dependency-audit-report-29949596196` (JSON, retained for 14 days)

Closes #335
