### PR TITLE
test(extension): enforce measured coverage thresholds

### DIFF
--- a/docs/coverage-ratchet.md
+++ b/docs/coverage-ratchet.md
@@ -32,3 +32,26 @@ The current suite includes targeted coverage for:
 - vendor API error handling for DigiKey, Mouser, LCSC, JLCPCB, and shared HTTP client paths.
 
 Future changes should raise thresholds gradually and only after adding tests for real error/guard branches. Do not lower coverage thresholds to ship a feature; add focused tests or split the change.
+
+## 2026-07-23 extension baseline
+
+Measured on Node.js 24 with the same command used by the Ubuntu quality job:
+
+```bash
+pnpm test:extension:ci
+```
+
+Result and enforceable floor:
+
+| Metric     | Measured baseline | Blocking threshold | Next target |
+| ---------- | ----------------- | ------------------ | ----------- |
+| Statements | 51.49%            | 51%                | 65%         |
+| Branches   | 46.41%            | 46%                | 50%         |
+| Functions  | 61.35%            | 61%                | 70%         |
+| Lines      | 52.15%            | 52%                | 65%         |
+
+The thresholds deliberately round down the measured result instead of claiming coverage that the current harness cannot attribute. The extension build tests execute the bundled loader, but V8 does not map that generated bundle execution back to `src/index.ts`; therefore the loader currently remains visible as uncovered source.
+
+Do not exclude `src/index.ts`, `src/dispatcher-entry.ts`, or other executable trust-boundary code to inflate the percentage. The only exclusion is non-executable TypeScript declaration files. The JSON summary, LCOV report, and JUnit results remain separate from the server suite and are uploaded under the extension Codecov flags.
+
+Issue #337 owns direct lifecycle, approval, timeout, reconnect, and shutdown tests for the loader. Those behavior tests should raise this ratchet toward the 65% statements/lines, 70% functions, and 50% branches target. Thresholds may increase when supported by measured coverage; lowering them requires a public regression rationale and must not be used to ship an uncovered feature.

--- a/easyeda-bridge-extension/vitest.config.ts
+++ b/easyeda-bridge-extension/vitest.config.ts
@@ -7,10 +7,18 @@ export default defineConfig({
     include: ['tests/**/*.test.ts'],
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'lcov'],
+      reporter: ['text', 'json-summary', 'lcov'],
       reportsDirectory: 'coverage',
       include: ['src/**/*.ts'],
+      // Keep every executable runtime source in the denominator, including
+      // index.ts and dispatcher-entry.ts. Only declaration files are excluded.
       exclude: ['src/**/*.d.ts'],
+      thresholds: {
+        lines: 52,
+        statements: 51,
+        functions: 61,
+        branches: 46,
+      },
     },
   },
 });

--- a/tests/unit/repository/codecov-policy.test.ts
+++ b/tests/unit/repository/codecov-policy.test.ts
@@ -34,13 +34,24 @@ describe('Codecov analytics policy', () => {
       '--outputFile.junit=../reports/extension.junit.xml',
     );
     expect(vitestConfig).toContain("reporter: ['text', 'json', 'html', 'lcov']");
-    expect(extensionVitestConfig).toContain("reporter: ['text', 'lcov']");
+    expect(extensionVitestConfig).toContain("reporter: ['text', 'json-summary', 'lcov']");
     expect(extensionVitestConfig).toContain("include: ['src/**/*.ts']");
+    expect(extensionVitestConfig).toContain('thresholds: {');
+    expect(extensionVitestConfig).toContain('lines: 52');
+    expect(extensionVitestConfig).toContain('statements: 51');
+    expect(extensionVitestConfig).toContain('functions: 61');
+    expect(extensionVitestConfig).toContain('branches: 46');
+    expect(extensionVitestConfig).not.toContain("'src/index.ts'");
+    expect(extensionVitestConfig).not.toContain("'src/dispatcher-entry.ts'");
     expect(packageJson.scripts?.['validate:codecov']).toContain('codecov.io/validate');
     expect(packageJson.devDependencies?.['@codecov/bundle-analyzer']).toBe('2.0.1');
     expect(packageJson.scripts?.['analyze:extension-bundle:ci']).toContain(
       'bundle-analyzer easyeda-bridge-extension/dist',
     );
+    const ratchet = readText('docs/coverage-ratchet.md');
+    expect(ratchet).toContain('2026-07-23 extension baseline');
+    expect(ratchet).toContain('#337');
+    expect(ratchet).toContain('Do not exclude `src/index.ts`');
   });
 
   it('uploads coverage and both test reports with pinned Codecov tooling', () => {


### PR DESCRIPTION
## Summary

Establish a blocking, evidence-based coverage floor for the EasyEDA bridge extension without hiding executable runtime code from the denominator.

Closes #336.

## Baseline and thresholds

Measured on Node.js 24 with the same command used by the Ubuntu quality job:

```bash
pnpm test:extension:ci
```

| Metric | Measured | Blocking threshold | Ratchet target |
| --- | ---: | ---: | ---: |
| Statements | 51.49% | 51% | 65% |
| Branches | 46.41% | 46% | 50% |
| Functions | 61.35% | 61% | 70% |
| Lines | 52.15% | 52% | 65% |

The initial floor rounds down the measured result so CI blocks regressions immediately without claiming unmeasured coverage.

## Changes

- Add global extension thresholds to `easyeda-bridge-extension/vitest.config.ts`.
- Emit a separate `coverage-summary.json` alongside LCOV and the existing JUnit report.
- Keep all executable extension sources in scope, including `src/index.ts` and `src/dispatcher-entry.ts`; only TypeScript declaration files remain excluded.
- Add repository policy assertions for the threshold values, report formats, and non-exclusion contract.
- Document the measured baseline and the ratchet plan owned by #337.

## Fail-closed proof

A deliberate local probe raised only the line threshold from 52% to 53%:

```bash
pnpm --filter @easyeda-mcp-pro/bridge-extension exec vitest run \
  --coverage --coverage.thresholds.lines=53
```

The suite still passed 126 tests, but Vitest exited 1 with:

```text
ERROR: Coverage for lines (52.15%) does not meet global threshold (53%)
```

## Verification

- Coverage policy test: 4/4 passed.
- Extension CI suite: 8 files / 126 tests passed with threshold enforcement, JSON summary, LCOV, and JUnit output.
- Full `pnpm verify` passed:
  - formatting
  - root and extension typecheck
  - ESLint with zero warnings
  - 115 tool metadata/profile checks
  - 146 server files / 1,708 tests
  - 8 extension files / 126 tests
  - server and extension builds
  - extension package/checksum generation
  - metadata alignment
  - documentation build

## Follow-up

#337 will add direct loader lifecycle, reconnect, approval, timeout, and shutdown tests and raise this ratchet toward 65% statements/lines, 70% functions, and 50% branches. Thresholds must not be lowered merely to ship a feature.