### PR TITLE
test(extension): cover lifecycle and relay session safety

### DIFF
--- a/docs/coverage-ratchet.md
+++ b/docs/coverage-ratchet.md
@@ -68,12 +68,12 @@ pnpm test:extension:ci
 
 | Metric     | Previous measured | New measured | Previous threshold | New threshold |
 | ---------- | ----------------- | ------------ | ------------------ | ------------- |
-| Statements | 51.49%            | 66.98%       | 51%                | 65%           |
-| Branches   | 46.41%            | 54.91%       | 46%                | 50%           |
-| Functions  | 61.35%            | 81.25%       | 61%                | 70%           |
-| Lines      | 52.15%            | 68.67%       | 52%                | 65%           |
+| Statements | 51.49%            | 67.22%       | 51%                | 65%           |
+| Branches   | 46.41%            | 55.20%       | 46%                | 50%           |
+| Functions  | 61.35%            | 81.51%       | 61%                | 70%           |
+| Lines      | 52.15%            | 68.93%       | 52%                | 65%           |
 
-The direct loader harness raises `src/index.ts` itself to 63.47% statements, 45.64% branches, 72.54% functions, and 64.67% lines. `src/remote-client.ts` reaches 77.90% statements, 62.60% branches, 89.65% functions, and 80.79% lines.
+The direct loader harness raises `src/index.ts` itself to 63.47% statements, 45.64% branches, 72.54% functions, and 64.67% lines. `src/remote-client.ts` reaches 81.97% statements, 68.69% branches, 93.10% functions, and 85.43% lines.
 
 The tests also exposed and fixed two lifecycle/security defects:
 

--- a/docs/coverage-ratchet.md
+++ b/docs/coverage-ratchet.md
@@ -55,3 +55,29 @@ The thresholds deliberately round down the measured result instead of claiming c
 Do not exclude `src/index.ts`, `src/dispatcher-entry.ts`, or other executable trust-boundary code to inflate the percentage. The only exclusion is non-executable TypeScript declaration files. The JSON summary, LCOV report, and JUnit results remain separate from the server suite and are uploaded under the extension Codecov flags.
 
 Issue #337 owns direct lifecycle, approval, timeout, reconnect, and shutdown tests for the loader. Those behavior tests should raise this ratchet toward the 65% statements/lines, 70% functions, and 50% branches target. Thresholds may increase when supported by measured coverage; lowering them requires a public regression rationale and must not be used to ship an uncovered feature.
+
+## 2026-07-23 extension lifecycle ratchet
+
+Issue #337 added direct source-level tests for the extension loader and Remote Relay lifecycle instead of relying only on generated-bundle VM execution. The suite now exercises auto-connect state transitions, complete port exhaustion and recovery, silent `SYS_WebSocket.register` fallback, duplicate connect suppression, heartbeat-stale cleanup, protocol/contract mismatch diagnostics, approval timeout and rejection, reconnect session binding, and unload cleanup.
+
+Measured on Node.js 24 with:
+
+```bash
+pnpm test:extension:ci
+```
+
+| Metric     | Previous measured | New measured | Previous threshold | New threshold |
+| ---------- | ----------------- | ------------ | ------------------ | ------------- |
+| Statements | 51.49%            | 66.98%       | 51%                | 65%           |
+| Branches   | 46.41%            | 54.91%       | 46%                | 50%           |
+| Functions  | 61.35%            | 81.25%       | 61%                | 70%           |
+| Lines      | 52.15%            | 68.67%       | 52%                | 65%           |
+
+The direct loader harness raises `src/index.ts` itself to 63.47% statements, 45.64% branches, 72.54% functions, and 64.67% lines. `src/remote-client.ts` reaches 77.90% statements, 62.60% branches, 89.65% functions, and 80.79% lines.
+
+The tests also exposed and fixed two lifecycle/security defects:
+
+- extension deactivation closed the local bridge but left the Remote Relay socket and timers alive;
+- an approval or tool request started on an old relay socket could complete after reconnect and send its result on the replacement session.
+
+Remote approval and tool responses are now bound to the socket that received the request and are dropped if that socket is no longer active. Deactivation closes both local and remote transports and clears their timers. Executable loader sources remain in the coverage denominator; no source exclusion was added to obtain the increase.

--- a/easyeda-bridge-extension/src/index.ts
+++ b/easyeda-bridge-extension/src/index.ts
@@ -1505,6 +1505,8 @@ async function activateInternal(_status?: 'onStartupFinished', _arg?: string): P
 function deactivateInternal(): void {
   activationStarted = false;
   disconnectInternal(false);
+  remoteRelayClient?.disconnect('disconnected');
+  remoteRelayClient = null;
   const globalScope = globalThis as any;
   const existing = globalScope[PERSISTENT_RUNTIME_KEY] as PersistentRuntime | undefined;
   if (existing?.deactivate === deactivateInternal) {

--- a/easyeda-bridge-extension/src/remote-client.ts
+++ b/easyeda-bridge-extension/src/remote-client.ts
@@ -230,15 +230,15 @@ export class RemoteRelayClient {
       return;
     }
     if (message.type === 'approval_request') {
-      void this.handleApprovalRequest(message);
+      void this.handleApprovalRequest(socket, message);
       return;
     }
     if (message.type === 'tool_request') {
-      void this.handleToolRequest(message);
+      void this.handleToolRequest(socket, message);
     }
   }
 
-  private async handleApprovalRequest(message: RemoteEnvelope): Promise<void> {
+  private async handleApprovalRequest(socket: WebSocket, message: RemoteEnvelope): Promise<void> {
     const approvalId = typeof message.approvalId === 'string' ? message.approvalId : '';
     const toolName = typeof message.toolName === 'string' ? message.toolName : '';
     const actionSummary =
@@ -274,18 +274,18 @@ export class RemoteRelayClient {
       this.pendingApprovalIds.delete(approvalId);
     }
 
-    this.send({
+    this.sendForSocket(socket, {
       type: 'approval_result',
       approvalId,
       result,
     });
   }
 
-  private async handleToolRequest(message: RemoteEnvelope): Promise<void> {
+  private async handleToolRequest(socket: WebSocket, message: RemoteEnvelope): Promise<void> {
     const startedAt = Date.now();
     const toolName = typeof message.toolName === 'string' ? message.toolName : '';
     if (!toolName) {
-      this.send({
+      this.sendForSocket(socket, {
         type: 'tool_response',
         requestMessageId: message.messageId,
         ok: false,
@@ -299,7 +299,7 @@ export class RemoteRelayClient {
       return;
     }
     if (!this.options.executeToolRequest) {
-      this.send({
+      this.sendForSocket(socket, {
         type: 'tool_response',
         requestMessageId: message.messageId,
         ok: false,
@@ -315,7 +315,7 @@ export class RemoteRelayClient {
 
     try {
       const result = await this.options.executeToolRequest(toolName, message.input);
-      this.send({
+      this.sendForSocket(socket, {
         type: 'tool_response',
         requestMessageId: message.messageId,
         ok: true,
@@ -323,7 +323,7 @@ export class RemoteRelayClient {
         durationMs: Date.now() - startedAt,
       });
     } catch (error) {
-      this.send({
+      this.sendForSocket(socket, {
         type: 'tool_response',
         requestMessageId: message.messageId,
         ok: false,
@@ -414,6 +414,11 @@ export class RemoteRelayClient {
   private send(payload: Record<string, unknown>): void {
     if (!this.socket) return;
     this.sendOnSocket(this.socket, payload);
+  }
+
+  private sendForSocket(socket: WebSocket, payload: Record<string, unknown>): void {
+    if (socket !== this.socket) return;
+    this.sendOnSocket(socket, payload);
   }
 
   private sendOnSocket(socket: WebSocket, payload: Record<string, unknown>): void {

--- a/easyeda-bridge-extension/tests/index-lifecycle.test.ts
+++ b/easyeda-bridge-extension/tests/index-lifecycle.test.ts
@@ -1,0 +1,385 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  BRIDGE_PORT,
+  HEARTBEAT_TIMEOUT_MS,
+  PORT_SCAN_COUNT,
+  RECONNECT_BASE_MS,
+  REGISTER_OPEN_CALLBACK_TIMEOUT_MS,
+} from '../src/connection-policy.js';
+
+const GLOBAL_KEYS = [
+  '__easyedaMcpProBridgeRuntime_v8__',
+  'connect',
+  'disconnect',
+  'showStatus',
+  'connectRemoteRelay',
+  'disconnectRemoteRelay',
+  'showRemoteRelayStatus',
+  'enableAutoConnect',
+  'disableAutoConnect',
+  'toggleAutoConnect',
+  'activate',
+  'deactivate',
+  'sys_Message',
+  'sys_Storage',
+  'sys_WebSocket',
+  'sys_Dialog',
+  'eda',
+  'WebSocket',
+] as const;
+
+type ExtensionModule = typeof import('../src/index.js');
+type LocalBehavior = 'pending' | 'error' | 'success';
+
+class HarnessSocket {
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+  static instances: HarnessSocket[] = [];
+  static localBehavior: LocalBehavior = 'pending';
+  static localHello: Record<string, unknown> = {
+    type: 'hello',
+    contractVersion: 1,
+    supportedProtocolVersions: ['1.0.0'],
+  };
+
+  readonly sent: Array<Record<string, unknown>> = [];
+  readyState = 0;
+  closeCalls = 0;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: ((error: unknown) => void) | null = null;
+  onclose: (() => void) | null = null;
+
+  constructor(readonly url: string) {
+    HarnessSocket.instances.push(this);
+    if (!url.startsWith('ws://127.0.0.1:')) return;
+    queueMicrotask(() => {
+      if (HarnessSocket.localBehavior === 'error') {
+        this.onerror?.(new Error('connection refused'));
+      } else if (HarnessSocket.localBehavior === 'success') {
+        this.open();
+      }
+    });
+  }
+
+  open(): void {
+    if (this.readyState === HarnessSocket.OPEN) return;
+    this.readyState = HarnessSocket.OPEN;
+    this.onopen?.();
+  }
+
+  receive(payload: Record<string, unknown>): void {
+    this.onmessage?.({ data: JSON.stringify(payload) });
+  }
+
+  send(payload: string): void {
+    const parsed = JSON.parse(payload) as Record<string, unknown>;
+    this.sent.push(parsed);
+    if (this.url.startsWith('ws://127.0.0.1:') && parsed.type === 'handshake') {
+      queueMicrotask(() => this.receive(HarnessSocket.localHello));
+    }
+  }
+
+  close(): void {
+    this.closeCalls += 1;
+    if (this.readyState === HarnessSocket.CLOSED) return;
+    this.readyState = HarnessSocket.CLOSED;
+    this.onclose?.();
+  }
+}
+
+let loaded: ExtensionModule | undefined;
+
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+async function loadExtension(
+  options: {
+    autoConnect?: boolean;
+    withWebSocket?: boolean;
+    webSocketApi?: Record<string, unknown>;
+    dialog?: {
+      showConfirmationMessage: (
+        content: string,
+        title?: string,
+        approveTitle?: string,
+        rejectTitle?: string,
+        callback?: (approved: boolean) => void,
+      ) => void;
+    };
+  } = {},
+): Promise<{
+  extension: ExtensionModule;
+  toasts: string[];
+  storage: { autoConnect: boolean };
+}> {
+  const toasts: string[] = [];
+  const storage = { autoConnect: options.autoConnect ?? false };
+  vi.stubGlobal('sys_Message', {
+    showToastMessage: (message: string) => toasts.push(message),
+  });
+  vi.stubGlobal('sys_Storage', {
+    getExtensionUserConfig: () => storage.autoConnect,
+    setExtensionUserConfig: async (_key: string, value: boolean) => {
+      storage.autoConnect = value;
+      return true;
+    },
+  });
+  if (options.withWebSocket) vi.stubGlobal('WebSocket', HarnessSocket);
+  if (options.webSocketApi) vi.stubGlobal('sys_WebSocket', options.webSocketApi);
+  if (options.dialog) vi.stubGlobal('sys_Dialog', options.dialog);
+  vi.resetModules();
+  loaded = await import('../src/index.js');
+  await flushMicrotasks();
+  return { extension: loaded, toasts, storage };
+}
+
+function latestRemoteSocket(): HarnessSocket {
+  const socket = HarnessSocket.instances.findLast((item) => item.url.startsWith('wss://'));
+  if (!socket) throw new Error('remote socket was not created');
+  return socket;
+}
+
+function approvalRequest(extra: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    protocolVersion: '2026-07-remote-relay-v1',
+    messageId: 'msg_approval',
+    timestamp: new Date().toISOString(),
+    type: 'approval_request',
+    approvalId: 'approval_1',
+    toolName: 'schematic.addText',
+    riskLevel: 'write',
+    actionSummary: 'Add a schematic note',
+    inputHash: '1234567890abcdef',
+    expiresAt: new Date(Date.now() + 1_000).toISOString(),
+    ...extra,
+  };
+}
+
+describe('extension loader lifecycle source', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    HarnessSocket.instances = [];
+    HarnessSocket.localBehavior = 'pending';
+    HarnessSocket.localHello = {
+      type: 'hello',
+      contractVersion: 1,
+      supportedProtocolVersions: ['1.0.0'],
+    };
+    for (const key of GLOBAL_KEYS) Reflect.deleteProperty(globalThis, key);
+  });
+
+  afterEach(() => {
+    loaded?.deactivate();
+    loaded = undefined;
+    for (const key of GLOBAL_KEYS) Reflect.deleteProperty(globalThis, key);
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('honors disabled auto-connect activation without allocating timers', async () => {
+    const { extension, toasts } = await loadExtension({ autoConnect: false });
+
+    await extension.activate('onStartupFinished');
+
+    expect(toasts).toContain('MCP Bridge: Auto-Connect OFF — click Connect to connect');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('persists auto-connect transitions and cancels scheduled recovery when disabled', async () => {
+    const { extension, toasts, storage } = await loadExtension({ autoConnect: false });
+
+    await extension.enableAutoConnect();
+
+    expect(storage.autoConnect).toBe(true);
+    expect(toasts.at(-1)).toBe('Auto-Connect: ON — will reconnect automatically');
+    expect(vi.getTimerCount()).toBe(1);
+
+    await extension.disableAutoConnect();
+
+    expect(storage.autoConnect).toBe(false);
+    expect(toasts.at(-1)).toBe('Auto-Connect: OFF — use Connect button to connect');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('falls back from a silent register handle to the EasyEDA create API', async () => {
+    HarnessSocket.localBehavior = 'success';
+    const registeredIds: string[] = [];
+    const closedIds: string[] = [];
+    let createCalls = 0;
+    const { extension, toasts } = await loadExtension({
+      webSocketApi: {
+        register: (id: string) => registeredIds.push(id),
+        send: () => undefined,
+        close: (id: string) => closedIds.push(id),
+        create: (url: string) => {
+          createCalls += 1;
+          return new HarnessSocket(url);
+        },
+      },
+    });
+
+    const connecting = extension.connect();
+    await vi.advanceTimersByTimeAsync(REGISTER_OPEN_CALLBACK_TIMEOUT_MS);
+    await flushMicrotasks();
+    await connecting;
+
+    expect(registeredIds).toHaveLength(1);
+    expect(closedIds).toEqual(registeredIds);
+    expect(createCalls).toBe(1);
+    expect(toasts).toContain('MCP Bridge connected to local server');
+  });
+
+  it('scans every local port once, then recovers on the scheduled retry', async () => {
+    HarnessSocket.localBehavior = 'error';
+    const { extension, toasts } = await loadExtension({ withWebSocket: true });
+
+    await extension.connect();
+
+    const firstScan = HarnessSocket.instances.filter((item) => item.url.startsWith('ws://'));
+    expect(firstScan).toHaveLength(PORT_SCAN_COUNT);
+    expect(firstScan.map((item) => item.url)).toEqual(
+      Array.from(
+        { length: PORT_SCAN_COUNT },
+        (_, offset) => `ws://127.0.0.1:${BRIDGE_PORT + offset}`,
+      ),
+    );
+    expect(toasts.at(-1)).toContain('MCP Bridge offline: no local server found');
+
+    HarnessSocket.localBehavior = 'success';
+    await vi.advanceTimersByTimeAsync(RECONNECT_BASE_MS);
+    await flushMicrotasks();
+
+    extension.showStatus();
+    expect(toasts.at(-1)).toContain('MCP Bridge connected to local server');
+    expect(HarnessSocket.instances).toHaveLength(PORT_SCAN_COUNT + 1);
+  });
+
+  it('suppresses duplicate auto-connect calls while one handshake is pending', async () => {
+    HarnessSocket.localBehavior = 'pending';
+    const { extension } = await loadExtension({ withWebSocket: true });
+
+    const first = extension.connect('auto');
+    const second = extension.connect('auto');
+
+    expect(HarnessSocket.instances).toHaveLength(1);
+    HarnessSocket.instances[0].open();
+    await flushMicrotasks();
+    await Promise.all([first, second]);
+
+    expect(HarnessSocket.instances).toHaveLength(1);
+    expect(HarnessSocket.instances[0].sent).toContainEqual(
+      expect.objectContaining({ type: 'handshake' }),
+    );
+  });
+
+  it('closes a heartbeat-stale socket and releases all reconnect resources on deactivate', async () => {
+    HarnessSocket.localBehavior = 'success';
+    const { extension } = await loadExtension({ autoConnect: true, withWebSocket: true });
+
+    await extension.connect();
+    const socket = HarnessSocket.instances[0];
+    expect(socket.readyState).toBe(HarnessSocket.OPEN);
+
+    await vi.advanceTimersByTimeAsync(HEARTBEAT_TIMEOUT_MS + 15_000);
+
+    expect(socket.closeCalls).toBeGreaterThan(0);
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    extension.deactivate();
+
+    expect(vi.getTimerCount()).toBe(0);
+    expect(Reflect.has(globalThis, '__easyedaMcpProBridgeRuntime_v8__')).toBe(false);
+    loaded = undefined;
+  });
+
+  it('logs protocol and contract mismatch diagnostics without losing the connection', async () => {
+    HarnessSocket.localBehavior = 'success';
+    HarnessSocket.localHello = {
+      type: 'hello',
+      contractVersion: 99,
+      supportedProtocolVersions: ['9.9.9'],
+    };
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    const { extension, toasts } = await loadExtension({ withWebSocket: true });
+
+    await extension.connect();
+
+    const logText = logSpy.mock.calls.flat().map(String).join('\n');
+    expect(logText).toContain('Bridge hello contract version mismatch');
+    expect(logText).toContain('\"expected\":1,\"actual\":99');
+    expect(logText).toContain('Bridge hello does not include this extension protocol version');
+    expect(logText).toContain('\"protocolVersion\":\"1.0.0\"');
+    expect(toasts).toContain('MCP Bridge connected to local server');
+  });
+
+  it('returns approval timeout when the EasyEDA dialog remains unanswered', async () => {
+    const { extension } = await loadExtension({
+      withWebSocket: true,
+      dialog: { showConfirmationMessage: () => undefined },
+    });
+    extension.connectRemoteRelay('self_hosted', 'wss://relay.example/session', '123456');
+    const socket = latestRemoteSocket();
+    socket.open();
+    socket.receive(approvalRequest());
+
+    await vi.advanceTimersByTimeAsync(1_001);
+    await flushMicrotasks();
+
+    expect(socket.sent).toContainEqual(
+      expect.objectContaining({
+        type: 'approval_result',
+        approvalId: 'approval_1',
+        result: 'timeout',
+      }),
+    );
+  });
+
+  it('returns explicit rejection and never treats it as approval', async () => {
+    const { extension } = await loadExtension({
+      withWebSocket: true,
+      dialog: {
+        showConfirmationMessage: (_content, _title, _approve, _reject, callback) =>
+          callback?.(false),
+      },
+    });
+    extension.connectRemoteRelay('hosted', 'wss://relay.example/session');
+    const socket = latestRemoteSocket();
+    socket.open();
+    socket.receive(approvalRequest());
+    await flushMicrotasks();
+
+    expect(socket.sent).toContainEqual(
+      expect.objectContaining({
+        type: 'approval_result',
+        approvalId: 'approval_1',
+        result: 'rejected',
+      }),
+    );
+    expect(socket.sent).not.toContainEqual(expect.objectContaining({ result: 'approved' }));
+  });
+
+  it('deactivate closes both local and Remote Relay sockets and clears every timer', async () => {
+    HarnessSocket.localBehavior = 'success';
+    const { extension } = await loadExtension({ autoConnect: true, withWebSocket: true });
+    await extension.connect();
+    const localSocket = HarnessSocket.instances[0];
+
+    extension.connectRemoteRelay('self_hosted', 'wss://relay.example/session', '123456');
+    const remoteSocket = latestRemoteSocket();
+    remoteSocket.open();
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    extension.deactivate();
+
+    expect(localSocket.closeCalls).toBeGreaterThan(0);
+    expect(remoteSocket.closeCalls).toBeGreaterThan(0);
+    expect(vi.getTimerCount()).toBe(0);
+    loaded = undefined;
+  });
+});

--- a/easyeda-bridge-extension/tests/remote-client.test.ts
+++ b/easyeda-bridge-extension/tests/remote-client.test.ts
@@ -46,9 +46,11 @@ class FakeWebSocket {
   }
 }
 
+type ExecuteToolRequest = (toolName: string, input: unknown) => Promise<unknown>;
+
 function makeClient(
   requestApproval = vi.fn(async () => 'approved' as const),
-  executeToolRequest = vi.fn(async () => ({ ok: true })),
+  executeToolRequest: ExecuteToolRequest | null = vi.fn(async () => ({ ok: true })),
 ) {
   const log = vi.fn();
   const showToast = vi.fn();
@@ -57,7 +59,7 @@ function makeClient(
     log,
     showToast,
     readActiveProject: () => ({ projectName: 'Fixture', documentType: 'schematic' }),
-    executeToolRequest,
+    executeToolRequest: executeToolRequest ?? undefined,
     requestApproval,
     timers: createRuntimeTimers(() => undefined, globalThis as any, 'remote-test'),
     createWebSocket: (url) => new FakeWebSocket(url) as unknown as WebSocket,
@@ -320,6 +322,79 @@ describe('RemoteRelayClient approval session binding', () => {
       .map((data) => JSON.parse(data) as Record<string, unknown>)
       .filter((message) => message.type === 'approval_result');
     expect(approvalResults).toHaveLength(0);
+  });
+
+  it('returns a structured error when a tool request omits its name', async () => {
+    const { client } = makeClient();
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+
+    socket.receive(relayMessage('tool_request', { input: {} }));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const response = socket.sent
+      .map((data) => JSON.parse(data) as Record<string, unknown>)
+      .find((message) => message.type === 'tool_response');
+    expect(response).toMatchObject({
+      type: 'tool_response',
+      ok: false,
+      error: { code: 'REMOTE_TOOL_NAME_MISSING' },
+    });
+  });
+
+  it('returns a structured error when Remote Relay execution is disabled', async () => {
+    const { client } = makeClient(undefined, null);
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+
+    socket.receive(
+      relayMessage('tool_request', {
+        toolName: 'schematic.listComponents',
+        input: {},
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const response = socket.sent
+      .map((data) => JSON.parse(data) as Record<string, unknown>)
+      .find((message) => message.type === 'tool_response');
+    expect(response).toMatchObject({
+      type: 'tool_response',
+      ok: false,
+      error: { code: 'REMOTE_EXECUTION_NOT_ENABLED' },
+    });
+  });
+
+  it('serializes execution failures on the originating active socket', async () => {
+    const executeToolRequest = vi.fn(async () => {
+      throw Object.assign(new Error('fixture execution failed'), { code: 'FIXTURE_FAILURE' });
+    });
+    const { client } = makeClient(undefined, executeToolRequest);
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+
+    socket.receive(
+      relayMessage('tool_request', {
+        toolName: 'schematic.listComponents',
+        input: {},
+      }),
+    );
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const response = socket.sent
+      .map((data) => JSON.parse(data) as Record<string, unknown>)
+      .find((message) => message.type === 'tool_response');
+    expect(response).toMatchObject({
+      type: 'tool_response',
+      ok: false,
+      error: { code: 'FIXTURE_FAILURE', message: 'fixture execution failed' },
+    });
   });
 
   it('does not deliver a pending tool response on a replacement socket', async () => {

--- a/easyeda-bridge-extension/tests/remote-client.test.ts
+++ b/easyeda-bridge-extension/tests/remote-client.test.ts
@@ -46,10 +46,12 @@ class FakeWebSocket {
   }
 }
 
-function makeClient(requestApproval = vi.fn(async () => 'approved' as const)) {
+function makeClient(
+  requestApproval = vi.fn(async () => 'approved' as const),
+  executeToolRequest = vi.fn(async () => ({ ok: true })),
+) {
   const log = vi.fn();
   const showToast = vi.fn();
-  const executeToolRequest = vi.fn(async () => ({ ok: true }));
   const client = new RemoteRelayClient({
     extensionVersion: '0.24.2',
     log,
@@ -243,5 +245,138 @@ describe('RemoteRelayClient resilience', () => {
       .filter((message) => message.type === 'approval_result');
     expect(decisions).toHaveLength(1);
     expect(decisions[0]).toMatchObject({ approvalId: 'appr_duplicate', result: 'rejected' });
+  });
+});
+
+describe('RemoteRelayClient approval session binding', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    FakeWebSocket.instances = [];
+    vi.stubGlobal('WebSocket', FakeWebSocket);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it('ignores malformed approval requests without prompting or replying', async () => {
+    const { client, requestApproval } = makeClient();
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+
+    socket.receive(
+      relayMessage('approval_request', {
+        approvalId: '',
+        toolName: '',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+    await Promise.resolve();
+
+    expect(requestApproval).not.toHaveBeenCalled();
+    expect(
+      socket.sent
+        .map((data) => JSON.parse(data))
+        .filter((message) => message.type === 'approval_result'),
+    ).toHaveLength(0);
+  });
+
+  it('does not deliver a pending approval result on a replacement socket', async () => {
+    let resolveDecision: ((decision: 'approved') => void) | undefined;
+    const requestApproval = vi.fn(
+      async () =>
+        await new Promise<'approved'>((resolve) => {
+          resolveDecision = resolve;
+        }),
+    );
+    const { client } = makeClient(requestApproval);
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    const originalSocket = FakeWebSocket.instances[0];
+    originalSocket.open();
+    originalSocket.receive(
+      relayMessage('approval_request', {
+        approvalId: 'appr_stale',
+        toolName: 'schematic.addText',
+        riskLevel: 'write',
+        actionSummary: 'Add a schematic note',
+        inputHash: 'hash',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+    expect(requestApproval).toHaveBeenCalledTimes(1);
+
+    originalSocket.close();
+    await vi.advanceTimersByTimeAsync(1_000);
+    const replacementSocket = FakeWebSocket.instances[1];
+    replacementSocket.open();
+
+    resolveDecision?.('approved');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const approvalResults = [...originalSocket.sent, ...replacementSocket.sent]
+      .map((data) => JSON.parse(data) as Record<string, unknown>)
+      .filter((message) => message.type === 'approval_result');
+    expect(approvalResults).toHaveLength(0);
+  });
+
+  it('does not deliver a pending tool response on a replacement socket', async () => {
+    let resolveResult: ((result: { ok: true }) => void) | undefined;
+    const executeToolRequest = vi.fn(
+      async () =>
+        await new Promise<{ ok: true }>((resolve) => {
+          resolveResult = resolve;
+        }),
+    );
+    const { client } = makeClient(
+      vi.fn(async () => 'approved' as const),
+      executeToolRequest,
+    );
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    const originalSocket = FakeWebSocket.instances[0];
+    originalSocket.open();
+    originalSocket.receive(
+      relayMessage('tool_request', {
+        toolName: 'schematic.listComponents',
+        input: {},
+      }),
+    );
+    await Promise.resolve();
+    expect(executeToolRequest).toHaveBeenCalledTimes(1);
+
+    originalSocket.close();
+    await vi.advanceTimersByTimeAsync(1_000);
+    const replacementSocket = FakeWebSocket.instances[1];
+    replacementSocket.open();
+
+    resolveResult?.({ ok: true });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const responses = [...originalSocket.sent, ...replacementSocket.sent]
+      .map((data) => JSON.parse(data) as Record<string, unknown>)
+      .filter((message) => message.type === 'tool_response');
+    expect(responses).toHaveLength(0);
+  });
+
+  it('ignores approval messages received from a disconnected socket', async () => {
+    const { client, requestApproval } = makeClient();
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+    client.disconnect('user_disabled');
+
+    socket.receive(
+      relayMessage('approval_request', {
+        approvalId: 'appr_disconnected',
+        toolName: 'schematic.addText',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+      }),
+    );
+    await Promise.resolve();
+
+    expect(requestApproval).not.toHaveBeenCalled();
   });
 });

--- a/easyeda-bridge-extension/vitest.config.ts
+++ b/easyeda-bridge-extension/vitest.config.ts
@@ -14,10 +14,10 @@ export default defineConfig({
       // index.ts and dispatcher-entry.ts. Only declaration files are excluded.
       exclude: ['src/**/*.d.ts'],
       thresholds: {
-        lines: 52,
-        statements: 51,
-        functions: 61,
-        branches: 46,
+        lines: 65,
+        statements: 65,
+        functions: 70,
+        branches: 50,
       },
     },
   },

--- a/tests/unit/repository/codecov-policy.test.ts
+++ b/tests/unit/repository/codecov-policy.test.ts
@@ -37,10 +37,10 @@ describe('Codecov analytics policy', () => {
     expect(extensionVitestConfig).toContain("reporter: ['text', 'json-summary', 'lcov']");
     expect(extensionVitestConfig).toContain("include: ['src/**/*.ts']");
     expect(extensionVitestConfig).toContain('thresholds: {');
-    expect(extensionVitestConfig).toContain('lines: 52');
-    expect(extensionVitestConfig).toContain('statements: 51');
-    expect(extensionVitestConfig).toContain('functions: 61');
-    expect(extensionVitestConfig).toContain('branches: 46');
+    expect(extensionVitestConfig).toContain('lines: 65');
+    expect(extensionVitestConfig).toContain('statements: 65');
+    expect(extensionVitestConfig).toContain('functions: 70');
+    expect(extensionVitestConfig).toContain('branches: 50');
     expect(extensionVitestConfig).not.toContain("'src/index.ts'");
     expect(extensionVitestConfig).not.toContain("'src/dispatcher-entry.ts'");
     expect(packageJson.scripts?.['validate:codecov']).toContain('codecov.io/validate');
@@ -50,7 +50,7 @@ describe('Codecov analytics policy', () => {
     );
     const ratchet = readText('docs/coverage-ratchet.md');
     expect(ratchet).toContain('2026-07-23 extension baseline');
-    expect(ratchet).toContain('#337');
+    expect(ratchet).toContain('2026-07-23 extension lifecycle ratchet');
     expect(ratchet).toContain('Do not exclude `src/index.ts`');
   });
 


### PR DESCRIPTION
## Summary

Add deterministic source-level coverage for the EasyEDA extension loader, reconnect lifecycle, Remote Relay approvals, session replacement, and shutdown cleanup.

The new tests also exposed and fix two real lifecycle/security defects:

1. extension deactivation closed the local bridge but left the Remote Relay socket and timers alive;
2. an approval or tool request received on an old relay socket could finish after reconnect and send its result on the replacement session.

Closes #337.

## Loader lifecycle coverage

The new direct `src/index.ts` harness covers:

- auto-connect disabled activation;
- persisted enable/disable transitions;
- complete local port exhaustion and scheduled recovery;
- silent `SYS_WebSocket.register` fallback to the EasyEDA create API;
- duplicate auto-connect suppression during a pending handshake;
- heartbeat-stale socket cleanup and reconnect scheduling;
- protocol and contract mismatch diagnostics without dropping a valid connection;
- approval timeout and explicit rejection through the EasyEDA dialog;
- local and Remote Relay resource cleanup during deactivation.

Existing bridge-manager tests continue to cover method-registry hash mismatch diagnostics.

## Remote Relay session safety

Async approval and tool responses are now bound to the socket that received the request. If that socket is no longer the active session, the result is dropped instead of crossing a reconnect boundary.

Added coverage verifies:

- malformed approval requests are ignored;
- disconnected sockets cannot prompt for approval;
- a pending approval cannot deliver `approved` on a replacement socket;
- a pending tool response cannot be delivered on a replacement socket;
- timeout and rejection remain distinct from approval;
- missing tool names return `REMOTE_TOOL_NAME_MISSING`;
- disabled execution returns `REMOTE_EXECUTION_NOT_ENABLED`;
- execution exceptions are serialized on the originating active socket.

## Coverage ratchet

Measured with `pnpm test:extension:ci` on Node.js 24:

| Metric | Previous | New | Previous threshold | New threshold |
| --- | ---: | ---: | ---: | ---: |
| Statements | 51.49% | 67.22% | 51% | 65% |
| Branches | 46.41% | 55.20% | 46% | 50% |
| Functions | 61.35% | 81.51% | 61% | 70% |
| Lines | 52.15% | 68.93% | 52% | 65% |

`src/index.ts` now reaches 63.47% statements, 45.64% branches, 72.54% functions, and 64.67% lines. No executable source was excluded from the denominator.

## Fail-closed proof

A deliberate probe raised only the line threshold to 69%. All 143 extension tests passed, but Vitest still exited 1 because measured line coverage was 68.93%:

```text
ERROR: Coverage for lines (68.93%) does not meet global threshold (69%)
```

## Verification

- focused lifecycle/relay tests: 24 passed;
- extension CI: 9 files / 143 tests passed with the raised thresholds;
- full `pnpm verify` passed:
  - formatting;
  - root and extension typecheck;
  - ESLint with zero warnings;
  - 115 tool metadata/profile checks;
  - 147 server files / 1,714 tests;
  - 9 extension files / 143 tests;
  - server and extension builds;
  - extension package/checksum generation;
  - metadata alignment;
  - documentation build.
