### PR TITLE
test(remote): harden relay session isolation

### DIFF
--- a/docs/coverage-ratchet.md
+++ b/docs/coverage-ratchet.md
@@ -81,3 +81,29 @@ The tests also exposed and fixed two lifecycle/security defects:
 - an approval or tool request started on an old relay socket could complete after reconnect and send its result on the replacement session.
 
 Remote approval and tool responses are now bound to the socket that received the request and are dropped if that socket is no longer active. Deactivation closes both local and remote transports and clears their timers. Executable loader sources remain in the coverage denominator; no source exclusion was added to obtain the increase.
+
+## 2026-07-23 remote gateway ratchet
+
+Issue #338 added a real WebSocket relay harness plus multi-session concurrency tests for `src/remote/gateway.ts`. The suite now verifies malformed JSON/schema rejection, registration requirements, same-socket session replacement, user/session isolation, parallel execution across independent sessions, per-session serialization, approval metadata binding, cross-session response rejection, duplicate response rejection, timeout quarantine, and immediate in-flight cleanup when a session or socket closes.
+
+Measured with the server CI command on Node.js 24:
+
+```bash
+pnpm test:coverage:ci
+```
+
+| Metric     | Previous measured | New measured | Blocking module threshold |
+| ---------- | ----------------- | ------------ | ------------------------- |
+| Statements | 63.14%            | 81.58%       | —                         |
+| Branches   | 57.72%            | 70.47%       | 70%                       |
+| Functions  | 83.05%            | 91.52%       | —                         |
+| Lines      | 64.78%            | 84.59%       | 80%                       |
+
+Vitest now enforces the line and branch floors directly for `src/remote/gateway.ts`, in addition to the repository-wide thresholds. The tests exposed and fixed these relay boundary defects:
+
+- registering a second session on the same socket left the previous session connected;
+- approval and tool responses were accepted even when their `sessionId` did not match the socket's active session;
+- duplicate or unknown tool responses were silently ignored;
+- `session_closed` and socket close rejected in-flight requests with a generic extension error or only after their deadline.
+
+Re-registration now disconnects and rejects the old session before replacement. Relay responses must match the active session, unknown request IDs return `REQUEST_NOT_FOUND`, and socket/session teardown rejects pending requests immediately as `SESSION_DISCONNECTED` with HTTP-equivalent status 424. Different sessions remain concurrently dispatchable while requests targeting the same session remain serialized.

--- a/docs/coverage-ratchet.md
+++ b/docs/coverage-ratchet.md
@@ -94,10 +94,10 @@ pnpm test:coverage:ci
 
 | Metric     | Previous measured | New measured | Blocking module threshold |
 | ---------- | ----------------- | ------------ | ------------------------- |
-| Statements | 63.14%            | 81.58%       | —                         |
-| Branches   | 57.72%            | 70.47%       | 70%                       |
-| Functions  | 83.05%            | 91.52%       | —                         |
-| Lines      | 64.78%            | 84.59%       | 80%                       |
+| Statements | 63.14%            | 83.18%       | —                         |
+| Branches   | 57.72%            | 72.22%       | 70%                       |
+| Functions  | 83.05%            | 92.85%       | —                         |
+| Lines      | 64.78%            | 86.12%       | 80%                       |
 
 Vitest now enforces the line and branch floors directly for `src/remote/gateway.ts`, in addition to the repository-wide thresholds. The tests exposed and fixed these relay boundary defects:
 

--- a/src/remote/gateway.ts
+++ b/src/remote/gateway.ts
@@ -158,7 +158,7 @@ class RemoteDispatchTimeoutError extends Error {
 
 class RemoteSessionUnavailableError extends Error {
   constructor(readonly sessionId: string) {
-    super(`Remote extension session ${sessionId} disconnected before dispatch.`);
+    super(`Remote extension session ${sessionId} became unavailable during dispatch.`);
     this.name = 'RemoteSessionUnavailableError';
   }
 }
@@ -914,14 +914,40 @@ export class RemoteGateway {
       );
     };
 
+    const rejectPending = (error: Error): void => {
+      for (const handler of pending.values()) handler.reject(error);
+      pending.clear();
+    };
+
+    const disconnectCurrentSession = (): void => {
+      const currentSessionId = sessionId;
+      if (!currentSessionId) return;
+      this.disconnect(currentSessionId);
+      rejectPending(new RemoteSessionUnavailableError(currentSessionId));
+      sessionId = undefined;
+    };
+
+    const messageMatchesCurrentSession = (messageSessionId: string | undefined): boolean => {
+      if (messageSessionId === sessionId) return true;
+      send({
+        type: 'error',
+        code: 'SESSION_MISMATCH',
+        message: 'Relay message sessionId does not match the active socket session.',
+      });
+      return false;
+    };
+
     const dispatch: RemoteToolDispatcher = async (request) => {
-      if (ws.readyState !== ws.OPEN) throw new Error('Remote relay socket is closed.');
+      if (ws.readyState !== ws.OPEN) {
+        throw new RemoteSessionUnavailableError(request.sessionId);
+      }
       ws.send(JSON.stringify(request));
       return await new Promise<ToolResponseMessage>((resolve, reject) => {
+        const timeoutMs = request.deadlineMs ?? 30_000;
         const timeout = setTimeout(() => {
           pending.delete(request.messageId);
-          reject(new Error('Remote extension did not respond before the deadline.'));
-        }, request.deadlineMs ?? 30_000);
+          reject(new RemoteDispatchTimeoutError(timeoutMs));
+        }, timeoutMs);
         pending.set(request.messageId, {
           resolve: (response) => {
             clearTimeout(timeout);
@@ -957,6 +983,7 @@ export class RemoteGateway {
       }
 
       if (message.data.type === 'register_session') {
+        disconnectCurrentSession();
         const session = this.registerExtension({
           connectionId,
           mode: message.data.mode,
@@ -997,6 +1024,7 @@ export class RemoteGateway {
       }
 
       if (message.data.type === 'approval_result') {
+        if (!messageMatchesCurrentSession(message.data.sessionId)) return;
         const resolved = this.resolveApprovalFromExtension({
           sessionId,
           approvalId: message.data.approvalId,
@@ -1013,25 +1041,29 @@ export class RemoteGateway {
       }
 
       if (message.data.type === 'tool_response') {
+        if (!messageMatchesCurrentSession(message.data.sessionId)) return;
         const handler = pending.get(message.data.requestMessageId);
-        if (handler) {
-          pending.delete(message.data.requestMessageId);
-          handler.resolve(message.data);
+        if (!handler) {
+          send({
+            type: 'error',
+            code: 'REQUEST_NOT_FOUND',
+            message: 'Tool response did not match an active relay request.',
+          });
+          return;
         }
+        pending.delete(message.data.requestMessageId);
+        handler.resolve(message.data);
         return;
       }
 
       if (message.data.type === 'session_closed') {
-        this.disconnect(sessionId);
-        sessionId = undefined;
+        if (!messageMatchesCurrentSession(message.data.sessionId)) return;
+        disconnectCurrentSession();
       }
     });
 
     ws.on('close', () => {
-      if (sessionId) this.disconnect(sessionId);
-      for (const handler of pending.values())
-        handler.reject(new Error('Remote relay socket closed.'));
-      pending.clear();
+      disconnectCurrentSession();
     });
   }
 }

--- a/src/remote/gateway.ts
+++ b/src/remote/gateway.ts
@@ -943,21 +943,7 @@ export class RemoteGateway {
       }
       ws.send(JSON.stringify(request));
       return await new Promise<ToolResponseMessage>((resolve, reject) => {
-        const timeoutMs = request.deadlineMs ?? 30_000;
-        const timeout = setTimeout(() => {
-          pending.delete(request.messageId);
-          reject(new RemoteDispatchTimeoutError(timeoutMs));
-        }, timeoutMs);
-        pending.set(request.messageId, {
-          resolve: (response) => {
-            clearTimeout(timeout);
-            resolve(response);
-          },
-          reject: (error) => {
-            clearTimeout(timeout);
-            reject(error);
-          },
-        });
+        pending.set(request.messageId, { resolve, reject });
       });
     };
 

--- a/tests/unit/remote/gateway-concurrency.test.ts
+++ b/tests/unit/remote/gateway-concurrency.test.ts
@@ -162,9 +162,130 @@ describe('RemoteGateway session dispatch concurrency', () => {
     });
     expect(started).toEqual(['schematic.listComponents']);
     expect(closeConnectionCount).toBe(1);
+    expect(gateway.audit.recent(20)).toContainEqual(
+      expect.objectContaining({
+        event: 'remote.tool.failed',
+        sessionId: session.sessionId,
+        errorCode: 'REMOTE_EXTENSION_TIMEOUT',
+      }),
+    );
 
     releaseLateResponse?.();
     await new Promise((resolve) => setTimeout(resolve, 10));
     expect(started).toEqual(['schematic.listComponents']);
   });
+});
+
+it('allows different extension sessions to execute concurrently without crossing results', async () => {
+  const gateway = new RemoteGateway();
+  const identity = { userId: 'parallel-user', scopes: ['easyeda.read'] as const };
+  const releases = new Map<string, () => void>();
+  let activeDispatches = 0;
+  let maxActiveDispatches = 0;
+
+  const register = (name: string) =>
+    gateway.registerExtension({
+      connectionId: `conn-${name}`,
+      mode: 'hosted',
+      extensionVersion: '0.35.1',
+      activeProject: { projectName: name, documentType: 'schematic' },
+      dispatch: async (request: ToolRequestMessage): Promise<ToolResponseMessage> => {
+        activeDispatches += 1;
+        maxActiveDispatches = Math.max(maxActiveDispatches, activeDispatches);
+        await new Promise<void>((resolve) => releases.set(name, resolve));
+        activeDispatches -= 1;
+        return {
+          protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+          type: 'tool_response',
+          messageId: `response-${request.messageId}`,
+          sessionId: request.sessionId,
+          requestMessageId: request.messageId,
+          timestamp: new Date().toISOString(),
+          ok: true,
+          result: { projectName: name, sessionId: request.sessionId },
+          durationMs: 1,
+        };
+      },
+    });
+
+  const sessionA = register('Project A');
+  const sessionB = register('Project B');
+  for (const session of [sessionA, sessionB]) {
+    const code = gateway.createPairingCode({ identity, sessionId: session.sessionId });
+    expect(gateway.completePairing({ identity, code, sessionId: session.sessionId })).toBe(true);
+  }
+
+  const requestA = gateway.routeToolRequest({
+    identity,
+    sessionId: sessionA.sessionId,
+    toolName: 'schematic.listComponents',
+    riskLevel: 'read',
+    input: { expected: 'Project A' },
+  });
+  const requestB = gateway.routeToolRequest({
+    identity,
+    sessionId: sessionB.sessionId,
+    toolName: 'schematic.listComponents',
+    riskLevel: 'read',
+    input: { expected: 'Project B' },
+  });
+  await waitFor(() => releases.size === 2);
+
+  expect(activeDispatches).toBe(2);
+  expect(maxActiveDispatches).toBe(2);
+  releases.get('Project B')?.();
+  releases.get('Project A')?.();
+
+  await expect(requestA).resolves.toMatchObject({
+    ok: true,
+    sessionId: sessionA.sessionId,
+    result: { projectName: 'Project A', sessionId: sessionA.sessionId },
+  });
+  await expect(requestB).resolves.toMatchObject({
+    ok: true,
+    sessionId: sessionB.sessionId,
+    result: { projectName: 'Project B', sessionId: sessionB.sessionId },
+  });
+  expect(activeDispatches).toBe(0);
+});
+
+it('never routes an explicit session across paired user boundaries', async () => {
+  const gateway = new RemoteGateway();
+  const owner = { userId: 'session-owner', scopes: ['easyeda.read'] as const };
+  const attacker = { userId: 'different-user', scopes: ['easyeda.read'] as const };
+  let dispatchCount = 0;
+  const session = gateway.registerExtension({
+    connectionId: 'conn-owner-only',
+    mode: 'hosted',
+    extensionVersion: '0.35.1',
+    activeProject: { projectName: 'Owner Project', documentType: 'schematic' },
+    dispatch: async (request: ToolRequestMessage): Promise<ToolResponseMessage> => {
+      dispatchCount += 1;
+      return {
+        protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+        type: 'tool_response',
+        messageId: `response-${request.messageId}`,
+        sessionId: request.sessionId,
+        requestMessageId: request.messageId,
+        timestamp: new Date().toISOString(),
+        ok: true,
+        result: {},
+        durationMs: 1,
+      };
+    },
+  });
+  const code = gateway.createPairingCode({ identity: owner, sessionId: session.sessionId });
+  expect(gateway.completePairing({ identity: owner, code, sessionId: session.sessionId })).toBe(
+    true,
+  );
+
+  await expect(
+    gateway.routeToolRequest({
+      identity: attacker,
+      sessionId: session.sessionId,
+      toolName: 'schematic.listComponents',
+      riskLevel: 'read',
+    }),
+  ).resolves.toMatchObject({ ok: false, code: 'SESSION_UNPAIRED' });
+  expect(dispatchCount).toBe(0);
 });

--- a/tests/unit/remote/gateway-websocket.test.ts
+++ b/tests/unit/remote/gateway-websocket.test.ts
@@ -1,0 +1,346 @@
+import { createServer, type Server } from 'node:http';
+import { afterEach, describe, expect, it } from 'vitest';
+import { WebSocket } from 'ws';
+import { RemoteGateway } from '../../../src/remote/gateway.js';
+import { REMOTE_RELAY_PROTOCOL_VERSION } from '../../../src/remote/protocol.js';
+import type { RemoteIdentity } from '../../../src/remote/scope.js';
+
+type RelayRecord = Record<string, unknown>;
+
+const readIdentity: RemoteIdentity = {
+  userId: 'relay-user',
+  scopes: ['easyeda.read'],
+};
+
+const writeIdentity: RemoteIdentity = {
+  userId: 'relay-user',
+  scopes: ['easyeda.write'],
+};
+
+class RelayClient {
+  readonly messages: RelayRecord[] = [];
+  private readonly waiters: Array<{
+    predicate: (message: RelayRecord) => boolean;
+    resolve: (message: RelayRecord) => void;
+    reject: (error: Error) => void;
+    timeout: NodeJS.Timeout;
+  }> = [];
+
+  constructor(readonly socket: WebSocket) {
+    socket.on('message', (raw) => {
+      const message = JSON.parse(raw.toString()) as RelayRecord;
+      this.messages.push(message);
+      const index = this.waiters.findIndex((waiter) => waiter.predicate(message));
+      if (index < 0) return;
+      const [waiter] = this.waiters.splice(index, 1);
+      clearTimeout(waiter.timeout);
+      waiter.resolve(message);
+    });
+  }
+
+  send(payload: RelayRecord): void {
+    this.socket.send(JSON.stringify(payload));
+  }
+
+  sendRaw(payload: string): void {
+    this.socket.send(payload);
+  }
+
+  waitFor(predicate: (message: RelayRecord) => boolean, timeoutMs = 1_000): Promise<RelayRecord> {
+    const existing = this.messages.find(predicate);
+    if (existing) return Promise.resolve(existing);
+    return new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        const index = this.waiters.findIndex((waiter) => waiter.resolve === resolve);
+        if (index >= 0) this.waiters.splice(index, 1);
+        reject(new Error('Timed out waiting for relay message.'));
+      }, timeoutMs);
+      this.waiters.push({ predicate, resolve, reject, timeout });
+    });
+  }
+
+  async close(): Promise<void> {
+    if (this.socket.readyState === WebSocket.CLOSED) return;
+    await new Promise<void>((resolve) => {
+      this.socket.once('close', () => resolve());
+      this.socket.close();
+    });
+  }
+}
+
+interface GatewayHarness {
+  gateway: RemoteGateway;
+  server: Server;
+  client: RelayClient;
+}
+
+const harnesses: GatewayHarness[] = [];
+
+async function createHarness(): Promise<GatewayHarness> {
+  let counter = 0;
+  const gateway = new RemoteGateway({ makeId: () => `id-${++counter}` });
+  const server = createServer();
+  gateway.attachWebSocketServer(server);
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Gateway test server has no port.');
+  const socket = new WebSocket(`ws://127.0.0.1:${address.port}/remote/relay`);
+  await new Promise<void>((resolve, reject) => {
+    socket.once('open', () => resolve());
+    socket.once('error', reject);
+  });
+  const harness = { gateway, server, client: new RelayClient(socket) };
+  harnesses.push(harness);
+  return harness;
+}
+
+function envelope(type: string, extra: RelayRecord = {}): RelayRecord {
+  return {
+    protocolVersion: REMOTE_RELAY_PROTOCOL_VERSION,
+    type,
+    messageId: `client-${Math.random()}`,
+    timestamp: new Date().toISOString(),
+    ...extra,
+  };
+}
+
+async function registerSession(
+  harness: GatewayHarness,
+  identity: RemoteIdentity = readIdentity,
+): Promise<string> {
+  const pairingCode = harness.gateway.createPairingCode({ identity });
+  const previousMessages = new Set(harness.client.messages);
+  harness.client.send(
+    envelope('register_session', {
+      extensionVersion: '0.35.1',
+      mode: 'hosted',
+      capabilities: [],
+      activeProject: { projectName: 'Relay Fixture', documentType: 'schematic' },
+      pairingCode,
+    }),
+  );
+  const registered = await harness.client.waitFor(
+    (message) => message.type === 'session_registered' && !previousMessages.has(message),
+  );
+  expect(registered.paired).toBe(true);
+  return String(registered.sessionId);
+}
+
+function toolResponse(input: {
+  sessionId: string;
+  requestMessageId: string;
+  result?: unknown;
+}): RelayRecord {
+  return envelope('tool_response', {
+    sessionId: input.sessionId,
+    requestMessageId: input.requestMessageId,
+    ok: true,
+    result: input.result ?? { ok: true },
+    durationMs: 1,
+  });
+}
+
+afterEach(async () => {
+  while (harnesses.length > 0) {
+    const harness = harnesses.pop();
+    if (!harness) continue;
+    await harness.client.close().catch(() => undefined);
+    await new Promise<void>((resolve) => harness.server.close(() => resolve()));
+  }
+});
+
+describe('RemoteGateway WebSocket relay', () => {
+  it('fails closed with stable errors for malformed and pre-registration frames', async () => {
+    const harness = await createHarness();
+
+    harness.client.sendRaw('{not-json');
+    await expect(
+      harness.client.waitFor((message) => message.code === 'BAD_JSON'),
+    ).resolves.toMatchObject({ type: 'error', code: 'BAD_JSON' });
+
+    harness.client.send(envelope('heartbeat', { timestamp: 'not-a-date' }));
+    await expect(
+      harness.client.waitFor((message) => message.code === 'BAD_MESSAGE'),
+    ).resolves.toMatchObject({ type: 'error', code: 'BAD_MESSAGE' });
+
+    harness.client.send(envelope('heartbeat'));
+    await expect(
+      harness.client.waitFor((message) => message.code === 'SESSION_NOT_REGISTERED'),
+    ).resolves.toMatchObject({ type: 'error', code: 'SESSION_NOT_REGISTERED' });
+  });
+
+  it('re-registering one socket replaces and disconnects its previous session', async () => {
+    const harness = await createHarness();
+    const firstSessionId = await registerSession(harness);
+    const secondSessionId = await registerSession(harness);
+
+    expect(secondSessionId).not.toBe(firstSessionId);
+    await expect(
+      harness.gateway.routeToolRequest({
+        identity: readIdentity,
+        sessionId: firstSessionId,
+        toolName: 'schematic.listComponents',
+        riskLevel: 'read',
+      }),
+    ).resolves.toMatchObject({ ok: false, code: 'SESSION_DISCONNECTED' });
+  });
+
+  it('rejects cross-session and duplicate tool responses without settling the wrong request', async () => {
+    const harness = await createHarness();
+    const sessionId = await registerSession(harness);
+    let settled = false;
+    const routed = harness.gateway
+      .routeToolRequest({
+        identity: readIdentity,
+        sessionId,
+        toolName: 'schematic.listComponents',
+        riskLevel: 'read',
+        deadlineMs: 1_000,
+      })
+      .then((result) => {
+        settled = true;
+        return result;
+      });
+    const request = await harness.client.waitFor((message) => message.type === 'tool_request');
+
+    harness.client.send(
+      toolResponse({
+        sessionId: 'sess_wrong',
+        requestMessageId: String(request.messageId),
+      }),
+    );
+    await expect(
+      harness.client.waitFor((message) => message.code === 'SESSION_MISMATCH'),
+    ).resolves.toMatchObject({ type: 'error', code: 'SESSION_MISMATCH' });
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(settled).toBe(false);
+
+    const validResponse = toolResponse({
+      sessionId,
+      requestMessageId: String(request.messageId),
+      result: { sessionId },
+    });
+    harness.client.send(validResponse);
+    await expect(routed).resolves.toMatchObject({ ok: true, result: { sessionId } });
+
+    harness.client.send(validResponse);
+    await expect(
+      harness.client.waitFor((message) => message.code === 'REQUEST_NOT_FOUND'),
+    ).resolves.toMatchObject({ type: 'error', code: 'REQUEST_NOT_FOUND' });
+  });
+
+  it('rejects approval results whose metadata does not match the active relay session', async () => {
+    const harness = await createHarness();
+    const sessionId = await registerSession(harness, writeIdentity);
+    const first = await harness.gateway.routeToolRequest({
+      identity: writeIdentity,
+      sessionId,
+      toolName: 'schematic.addText',
+      riskLevel: 'write',
+      input: { content: 'relay fixture' },
+    });
+    expect(first).toMatchObject({ ok: false, code: 'APPROVAL_REQUIRED' });
+    if (first.ok || !first.approvalId) throw new Error('Expected approval id.');
+    const approvalRequest = await harness.client.waitFor(
+      (message) => message.type === 'approval_request',
+    );
+    expect(approvalRequest).toMatchObject({
+      sessionId,
+      approvalId: first.approvalId,
+      toolName: 'schematic.addText',
+      riskLevel: 'write',
+      inputHash: expect.any(String),
+      expiresAt: expect.any(String),
+    });
+
+    harness.client.send(
+      envelope('approval_result', {
+        sessionId: 'sess_wrong',
+        approvalId: first.approvalId,
+        result: 'approved',
+      }),
+    );
+    await expect(
+      harness.client.waitFor((message) => message.code === 'SESSION_MISMATCH'),
+    ).resolves.toMatchObject({ type: 'error', code: 'SESSION_MISMATCH' });
+
+    await expect(
+      harness.gateway.routeToolRequest({
+        identity: writeIdentity,
+        sessionId,
+        toolName: 'schematic.addText',
+        riskLevel: 'write',
+        input: { content: 'relay fixture' },
+        approvalId: first.approvalId,
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      code: 'APPROVAL_NOT_APPROVED',
+      message: 'Remote approval is still pending user action.',
+    });
+  });
+
+  it('rejects in-flight requests immediately when the extension closes its session', async () => {
+    const harness = await createHarness();
+    const sessionId = await registerSession(harness);
+    const routed = harness.gateway.routeToolRequest({
+      identity: readIdentity,
+      sessionId,
+      toolName: 'schematic.listComponents',
+      riskLevel: 'read',
+      deadlineMs: 2_000,
+    });
+    await harness.client.waitFor((message) => message.type === 'tool_request');
+
+    harness.client.send(
+      envelope('session_closed', {
+        sessionId,
+        reason: 'disconnected',
+      }),
+    );
+
+    await expect(routed).resolves.toMatchObject({
+      ok: false,
+      status: 424,
+      code: 'SESSION_DISCONNECTED',
+    });
+    expect(harness.gateway.audit.recent(20)).toContainEqual(
+      expect.objectContaining({
+        event: 'remote.tool.failed',
+        sessionId,
+        errorCode: 'SESSION_DISCONNECTED',
+      }),
+    );
+  });
+
+  it('rejects in-flight requests immediately when the relay socket closes', async () => {
+    const harness = await createHarness();
+    const sessionId = await registerSession(harness);
+    const routed = harness.gateway.routeToolRequest({
+      identity: readIdentity,
+      sessionId,
+      toolName: 'schematic.listComponents',
+      riskLevel: 'read',
+      deadlineMs: 2_000,
+    });
+    await harness.client.waitFor((message) => message.type === 'tool_request');
+
+    await harness.client.close();
+
+    await expect(routed).resolves.toMatchObject({
+      ok: false,
+      status: 424,
+      code: 'SESSION_DISCONNECTED',
+    });
+    expect(harness.gateway.audit.recent(20)).toContainEqual(
+      expect.objectContaining({
+        event: 'remote.tool.failed',
+        sessionId,
+        errorCode: 'SESSION_DISCONNECTED',
+      }),
+    );
+  });
+});

--- a/tests/unit/remote/gateway-websocket.test.ts
+++ b/tests/unit/remote/gateway-websocket.test.ts
@@ -1,3 +1,4 @@
+import { EventEmitter } from 'node:events';
 import { createServer, type Server } from 'node:http';
 import { afterEach, describe, expect, it } from 'vitest';
 import { WebSocket } from 'ws';
@@ -281,19 +282,64 @@ describe('RemoteGateway WebSocket relay', () => {
       code: 'APPROVAL_NOT_APPROVED',
       message: 'Remote approval is still pending user action.',
     });
+
+    harness.client.send(
+      envelope('approval_result', {
+        sessionId,
+        approvalId: first.approvalId,
+        result: 'approved',
+      }),
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const routed = harness.gateway.routeToolRequest({
+      identity: writeIdentity,
+      sessionId,
+      toolName: 'schematic.addText',
+      riskLevel: 'write',
+      input: { content: 'relay fixture' },
+      approvalId: first.approvalId,
+    });
+    const request = await harness.client.waitFor((message) => message.type === 'tool_request');
+    harness.client.send(
+      toolResponse({
+        sessionId,
+        requestMessageId: String(request.messageId),
+        result: { approved: true },
+      }),
+    );
+    await expect(routed).resolves.toMatchObject({ ok: true, result: { approved: true } });
   });
 
   it('rejects in-flight requests immediately when the extension closes its session', async () => {
     const harness = await createHarness();
     const sessionId = await registerSession(harness);
-    const routed = harness.gateway.routeToolRequest({
-      identity: readIdentity,
-      sessionId,
-      toolName: 'schematic.listComponents',
-      riskLevel: 'read',
-      deadlineMs: 2_000,
-    });
+    let settled = false;
+    const routed = harness.gateway
+      .routeToolRequest({
+        identity: readIdentity,
+        sessionId,
+        toolName: 'schematic.listComponents',
+        riskLevel: 'read',
+        deadlineMs: 2_000,
+      })
+      .then((result) => {
+        settled = true;
+        return result;
+      });
     await harness.client.waitFor((message) => message.type === 'tool_request');
+
+    harness.client.send(
+      envelope('session_closed', {
+        sessionId: 'sess_wrong',
+        reason: 'disconnected',
+      }),
+    );
+    await expect(
+      harness.client.waitFor((message) => message.code === 'SESSION_MISMATCH'),
+    ).resolves.toMatchObject({ type: 'error', code: 'SESSION_MISMATCH' });
+    await new Promise((resolve) => setTimeout(resolve, 15));
+    expect(settled).toBe(false);
 
     harness.client.send(
       envelope('session_closed', {
@@ -314,6 +360,68 @@ describe('RemoteGateway WebSocket relay', () => {
         errorCode: 'SESSION_DISCONNECTED',
       }),
     );
+  });
+
+  it('normalizes a dispatch attempted after the relay transport is already closed', async () => {
+    class FakeRelaySocket extends EventEmitter {
+      readonly OPEN = WebSocket.OPEN;
+      readyState = WebSocket.OPEN;
+      readonly sent: RelayRecord[] = [];
+
+      send(payload: string): void {
+        this.sent.push(JSON.parse(payload) as RelayRecord);
+      }
+
+      close(): void {
+        this.readyState = WebSocket.CLOSED;
+        this.emit('close');
+      }
+    }
+
+    const gateway = new RemoteGateway({
+      makeId: (() => {
+        let counter = 0;
+        return () => `closed-${++counter}`;
+      })(),
+    });
+    const socket = new FakeRelaySocket();
+    const pairingCode = gateway.createPairingCode({ identity: readIdentity });
+    const gatewayInternals = gateway as unknown as {
+      handleRelaySocket(ws: WebSocket): void;
+    };
+    gatewayInternals.handleRelaySocket(socket as unknown as WebSocket);
+    socket.emit(
+      'message',
+      Buffer.from(
+        JSON.stringify(
+          envelope('register_session', {
+            extensionVersion: '0.35.1',
+            mode: 'hosted',
+            capabilities: [],
+            activeProject: { projectName: 'Closed Relay', documentType: 'schematic' },
+            pairingCode,
+          }),
+        ),
+      ),
+    );
+    const registered = socket.sent.find((message) => message.type === 'session_registered');
+    const sessionId = String(registered?.sessionId ?? '');
+    expect(sessionId).toMatch(/^sess_/);
+
+    socket.readyState = WebSocket.CLOSED;
+    await expect(
+      gateway.routeToolRequest({
+        identity: readIdentity,
+        sessionId,
+        toolName: 'schematic.listComponents',
+        riskLevel: 'read',
+      }),
+    ).resolves.toMatchObject({
+      ok: false,
+      status: 424,
+      code: 'SESSION_DISCONNECTED',
+    });
+    gateway.disconnect(sessionId);
   });
 
   it('rejects in-flight requests immediately when the relay socket closes', async () => {

--- a/tests/unit/repository/codecov-policy.test.ts
+++ b/tests/unit/repository/codecov-policy.test.ts
@@ -34,6 +34,9 @@ describe('Codecov analytics policy', () => {
       '--outputFile.junit=../reports/extension.junit.xml',
     );
     expect(vitestConfig).toContain("reporter: ['text', 'json', 'html', 'lcov']");
+    expect(vitestConfig).toContain("'src/remote/gateway.ts': {");
+    expect(vitestConfig).toContain('lines: 80');
+    expect(vitestConfig).toContain('branches: 70');
     expect(extensionVitestConfig).toContain("reporter: ['text', 'json-summary', 'lcov']");
     expect(extensionVitestConfig).toContain("include: ['src/**/*.ts']");
     expect(extensionVitestConfig).toContain('thresholds: {');
@@ -51,6 +54,7 @@ describe('Codecov analytics policy', () => {
     const ratchet = readText('docs/coverage-ratchet.md');
     expect(ratchet).toContain('2026-07-23 extension baseline');
     expect(ratchet).toContain('2026-07-23 extension lifecycle ratchet');
+    expect(ratchet).toContain('2026-07-23 remote gateway ratchet');
     expect(ratchet).toContain('Do not exclude `src/index.ts`');
   });
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
         functions: 80,
         branches: 75,
         statements: 80,
+        'src/remote/gateway.ts': {
+          lines: 80,
+          branches: 70,
+        },
       },
     },
   },


### PR DESCRIPTION
## Summary

Strengthen the Remote Relay gateway trust boundary with real WebSocket acceptance tests, multi-session concurrency tests, deterministic teardown checks, and enforceable per-file coverage thresholds.

The tests exposed and fix four session-isolation and cleanup defects:

1. registering a replacement session on the same socket left the previous session connected;
2. approval and tool responses were accepted when their `sessionId` did not match the socket's active session;
3. duplicate or unknown tool responses were silently ignored;
4. `session_closed` and socket close did not immediately reject in-flight requests with the stable disconnected-session error contract.

Closes #338.

## Relay boundary behavior

- re-registration disconnects and rejects the previous socket session before replacement;
- approval results, tool responses, and session-close messages must match the active socket session;
- cross-session frames fail closed with `SESSION_MISMATCH`;
- duplicate or unknown response identifiers fail closed with `REQUEST_NOT_FOUND`;
- socket/session teardown immediately rejects pending operations as `SESSION_DISCONNECTED` with status 424;
- timeout quarantine still closes the connection before queued work can dispatch;
- requests targeting separate extension sessions execute concurrently;
- requests targeting one session remain serialized;
- explicit session IDs cannot cross paired user boundaries;
- audit events retain stable timeout and disconnect error codes.

## Tests

Added a real HTTP/WebSocket relay harness covering:

- malformed JSON and invalid relay schemas;
- pre-registration traffic;
- same-socket session replacement;
- mismatched and valid approval results;
- cross-session and duplicate tool responses;
- extension-declared session close, including mismatched metadata;
- physical relay socket close;
- dispatch attempts after the transport is already closed;
- pending request cleanup and audit classification.

Expanded concurrency coverage for independent-session parallelism and user/session isolation.

## Coverage ratchet

Measured with `pnpm test:coverage:ci` on Node.js 24:

| Metric | Previous | New | Blocking module threshold |
| --- | ---: | ---: | ---: |
| Statements | 63.14% | 83.18% | — |
| Branches | 57.72% | 72.22% | 70% |
| Functions | 83.05% | 92.85% | — |
| Lines | 64.78% | 86.12% | 80% |

Vitest now enforces the line and branch floors directly for `src/remote/gateway.ts` in addition to the repository-wide thresholds.

### Fail-closed proof

A deliberate probe raised only the gateway line threshold to 87%. All 1,717 server tests passed, but Vitest still exited 1 because measured gateway line coverage was 86.12%:

```text
ERROR: Coverage for lines (86.12%) does not meet "src/remote/gateway.ts" threshold (87%)
```

## Bot review follow-up

The first PR head received a Codecov warning for two uncovered and four partially covered changed gateway lines. The follow-up commit:

- removed a redundant inner deadline timer whose error branch could not win against the existing outer dispatcher deadline;
- added matching approval-result execution coverage;
- covered both matching and mismatched `session_closed` metadata;
- covered dispatch normalization after the relay transport is already closed.

Local LCOV now records hits for every changed gateway line and both sides of the changed session guards.

## Verification

- focused remote gateway suites: 4 files / 30 tests passed;
- `pnpm test:coverage:ci` passed:
  - 147 server files / 1,717 tests;
  - repository coverage 90.55% lines / 76.78% branches;
  - gateway coverage 86.12% lines / 72.22% branches;
- full `pnpm verify` passed:
  - Prettier;
  - root and extension typecheck;
  - ESLint with zero warnings;
  - 115 tool metadata/profile checks;
  - 147 server files / 1,717 tests;
  - 9 extension files / 143 tests;
  - server and extension builds;
  - extension package/checksum generation;
  - metadata alignment;
  - documentation build.

No EasyEDA Pro installation is required for these deterministic relay tests. Existing fake-extension and HTTP/MCP integration suites remain green.