### PR TITLE
docs(repo): preserve CDP guidance and roadmap lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,6 +712,8 @@ required by EasyEDA Pro.
 
 Installation: Open EasyEDA Pro → **Settings** → **Extensions** → **Extension Manager...** → **Import Extension**, then select the `.eext` file. Make sure **Allow External Interaction** is enabled for the extension.
 
+For local bridge development, an experimental loopback-only CDP transport is documented in the [CDP Bridge guide](docs/guide/cdp-bridge.md). The extension remains the recommended transport for normal use. Public delivery targets and milestone lifecycle rules are maintained in the [roadmap](docs/ROADMAP.md).
+
 ---
 
 ## Agent plugin and skills

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
     logo: '/logo.png',
     nav: [
       { text: 'Guide', link: '/guide/getting-started' },
+      { text: 'Roadmap', link: '/ROADMAP' },
       { text: 'Tools Reference', link: '/reference/tools' },
       { text: 'Resources & Prompts', link: '/reference/resources-prompts' },
       { text: 'EasyEDA Compatibility', link: '/reference/easyeda-compatibility' },
@@ -56,6 +57,8 @@ export default defineConfig({
         items: [
           { text: 'Getting Started', link: '/guide/getting-started' },
           { text: 'Configuration', link: '/guide/configuration' },
+          { text: 'CDP Bridge (Experimental)', link: '/guide/cdp-bridge' },
+          { text: 'Roadmap', link: '/ROADMAP' },
           { text: 'Troubleshooting', link: '/guide/troubleshooting' },
           { text: 'Best Practices Badge', link: '/BEST_PRACTICES_BADGE' },
         ],

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,27 @@
 
 This roadmap describes the intended direction for `easyeda-mcp-pro` for the next 12 months. It is not a promise of delivery; it is a planning document for users, contributors, and OpenSSF Best Practices evidence.
 
+## Active delivery milestones
+
+| Milestone                                                                  | Target date       | Public tracker                                                        | Outcome                                                                                                        |
+| -------------------------------------------------------------------------- | ----------------- | --------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| **v0.37.0 — Maintainability and operational consistency**                  | 26 August 2026    | [Epic #349](https://github.com/oaslananka/easyeda-mcp-pro/issues/349) | Deterministic automation, accurate repository state, and an incremental dispatcher decomposition.              |
+| **v1.0 readiness — Governance, release quality, and ecosystem confidence** | 16 September 2026 | [Epic #350](https://github.com/oaslananka/easyeda-mcp-pro/issues/350) | Public governance, release, quality, security, and compatibility evidence suitable for a stable v1.0 decision. |
+
+Target dates are planning goals, not release guarantees.
+
+## Milestone and branch lifecycle
+
+Version-bound milestones use the title pattern `v<target> — <outcome>`. Readiness programs that span several prereleases use a clear outcome title such as `v1.0 readiness — <outcome>`.
+
+A milestone stays open only while it represents future work. Maintainers close a milestone after its release has shipped and it has no open issues; issue assignments, descriptions, and historical discussion remain intact. Completed work is not moved merely to make progress percentages look cleaner.
+
+Each active milestone has one public epic whose checklist links the deliverable issues. The epic and its child issues share the same milestone so the roadmap can be read from either view.
+
+Remote branches are retained only while they contain active, unmerged work or support an open pull request. Before deleting a stale branch, maintainers verify patch equivalence and preserve any unique, still-valid code or documentation on `main`.
+
+The release automation branch `release-please--branches--main--components--easyeda-mcp-pro` is exempt from stale-branch cleanup while it backs an active release pull request. It may be removed after that pull request is merged or closed.
+
 ## Project scope
 
 `easyeda-mcp-pro` is a production-oriented MCP server for EasyEDA Pro. Its scope is controlled hardware-design assistance: schematic inspection, BOM workflows, safe manufacturing exports, supplier lookup, diagnostics, and security-conscious AI-assisted review.
@@ -50,15 +71,6 @@ The latest npm and GitHub release is the actively maintained release. Older vers
 - Replacing human engineering review for manufacturability or safety-critical design decisions.
 - Enabling remote HTTP exposure without explicit authentication and allowed-origin controls.
 
-## v0.18.0 — Remote MCP Gateway & self-hosted tunnels
+## Shipped roadmap history
 
-Planned milestone for hosted and self-hosted remote MCP usage:
-
-- hosted Remote MCP Gateway endpoint design;
-- extension Remote Relay Mode;
-- pairing and session routing;
-- remote auth, scopes, approval policy, audit, and observability;
-- self-hosted remote setup using user-owned domains, tunnels, reverse proxies, or VPS deployments;
-- Claude Web connector and ChatGPT Apps SDK integration guidance.
-
-See [Remote MCP modes](./REMOTE_MCP_MODES.md), [remote security model](./REMOTE_SECURITY_MODEL.md), and [extension relay protocol](./EXTENSION_RELAY_PROTOCOL.md).
+Versioned work that has already shipped is represented by closed GitHub milestones, the [changelog](https://github.com/oaslananka/easyeda-mcp-pro/blob/main/CHANGELOG.md), and GitHub Releases. Remote MCP Gateway and self-hosted tunnel work originally planned for v0.18.0 is documented in [Remote MCP modes](./REMOTE_MCP_MODES.md), the [remote security model](./REMOTE_SECURITY_MODEL.md), and the [extension relay protocol](./EXTENSION_RELAY_PROTOCOL.md).

--- a/docs/guide/cdp-bridge.md
+++ b/docs/guide/cdp-bridge.md
@@ -1,0 +1,83 @@
+# CDP Bridge (Experimental)
+
+The Chrome DevTools Protocol (CDP) bridge is an experimental, local diagnostic transport for attaching the MCP server to an already-open EasyEDA Pro renderer. The EasyEDA bridge extension remains the recommended transport for normal use because it has the broadest live-validation evidence and the most predictable lifecycle.
+
+Use CDP when developing or debugging bridge mappings, not as a replacement for the extension in production workflows.
+
+## Security boundary
+
+CDP can evaluate code inside the EasyEDA renderer. Keep the debugging endpoint on loopback and never expose it on `0.0.0.0`, a LAN interface, a tunnel, or a public reverse proxy. Close EasyEDA Pro when the debugging session is finished.
+
+Use a disposable project for every write-path experiment. MCP confirmation, profile, and scope controls still apply, and CDP adds its own write gates described below.
+
+## Start EasyEDA Pro with local debugging
+
+Launch EasyEDA Pro with a loopback-only debugging endpoint:
+
+```bash
+easyeda-pro \
+  --remote-debugging-address=127.0.0.1 \
+  --remote-debugging-port=9222
+```
+
+Package-specific launchers may require their normal platform arguments in addition to the two remote-debugging flags. Do not add `--no-sandbox` unless your existing EasyEDA package already requires it and you understand the reduced isolation.
+
+After opening a project, confirm that the target list is available only from the local machine:
+
+```bash
+curl --fail http://127.0.0.1:9222/json/list
+```
+
+## Start the MCP server in CDP mode
+
+From a source checkout:
+
+```bash
+EASYEDA_BRIDGE=cdp \
+EASYEDA_CDP_URL=http://127.0.0.1:9222 \
+TOOL_PROFILE=dev \
+pnpm dev
+```
+
+The default URL is `http://127.0.0.1:9222`. Set `EASYEDA_CDP_TARGET_ID` only when multiple matching renderer targets are present and automatic target selection is ambiguous.
+
+## Verify the connection
+
+Start with read-only diagnostics:
+
+1. Call `easyeda_health_check`.
+2. Call `easyeda_bridge_status` and confirm that the selected bridge is `cdp`.
+3. Call `easyeda_get_capabilities`.
+4. In the `dev` profile, use `easyeda_bridge_probe_methods` before relying on a method mapping.
+
+A successful CDP connection proves target discovery and renderer communication; it does not prove that every extension method is mapped through CDP. Unmapped calls fail with `CDP_METHOD_NOT_MAPPED` rather than guessing an EasyEDA runtime API.
+
+## Write gates
+
+Mapped mutating methods are disabled unless the process explicitly enables them:
+
+```bash
+EASYEDA_CDP_ALLOW_WRITES=true
+```
+
+Use this only with a disposable EasyEDA project. The MCP tool must still pass its normal confirmation and authorization checks.
+
+Unmapped methods that look mutating are blocked by a separate, stronger gate:
+
+```bash
+EASYEDA_CDP_ALLOW_UNMAPPED_WRITES=true
+```
+
+This flag exists for controlled bridge-development probes. It is not a general automation mode and must never be enabled against a valuable project. Prefer adding and testing a typed mapping instead of leaving this flag enabled.
+
+Raw `api.execute` access is also subject to the repository's raw-execution quarantine and tool-profile policy. CDP does not bypass those controls.
+
+## Known limitations
+
+- The extension bridge is the supported default and has stronger live compatibility evidence.
+- CDP support is method-by-method; extension parity must not be assumed.
+- Renderer internals can change between EasyEDA Pro releases.
+- The endpoint is local-only and is not part of the hosted or self-hosted Remote MCP transport model.
+- Live support claims belong in the [EasyEDA compatibility matrix](../reference/easyeda-compatibility.md), not in ad hoc debug notes.
+
+A historical local probe confirmed EasyEDA editor target discovery on EasyEDA Pro `3.2.149.88089769`. That observation is useful development evidence, not a blanket compatibility guarantee.

--- a/tests/unit/repository/roadmap-docs-policy.test.ts
+++ b/tests/unit/repository/roadmap-docs-policy.test.ts
@@ -1,0 +1,50 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repoRoot = resolve(import.meta.dirname, '../../..');
+const read = (path: string): string =>
+  readFileSync(resolve(repoRoot, path), 'utf8').replace(/\r\n/g, '\n');
+
+describe('repository roadmap and CDP documentation policy', () => {
+  it('publishes a current, safety-scoped CDP bridge guide', () => {
+    const path = 'docs/guide/cdp-bridge.md';
+    expect(existsSync(resolve(repoRoot, path))).toBe(true);
+    const guide = read(path);
+
+    expect(guide).toContain('EASYEDA_BRIDGE=cdp');
+    expect(guide).toContain('EASYEDA_CDP_URL=http://127.0.0.1:9222');
+    expect(guide).toContain('EASYEDA_CDP_ALLOW_WRITES=true');
+    expect(guide).toContain('EASYEDA_CDP_ALLOW_UNMAPPED_WRITES=true');
+    expect(guide).toMatch(/loopback/i);
+    expect(guide).toMatch(/bridge extension.*recommended/i);
+    expect(guide).toMatch(/disposable/i);
+    expect(guide).not.toContain('First-pass mapped calls');
+    expect(guide).not.toContain('Deliberately blocked until mapped');
+  });
+
+  it('documents active milestone and branch lifecycle conventions', () => {
+    const path = 'docs/ROADMAP.md';
+    expect(existsSync(resolve(repoRoot, path))).toBe(true);
+    const roadmap = read(path);
+
+    expect(roadmap).toContain('v0.37.0 — Maintainability and operational consistency');
+    expect(roadmap).toContain(
+      'v1.0 readiness — Governance, release quality, and ecosystem confidence',
+    );
+    expect(roadmap).toContain('`v<target> — <outcome>`');
+    expect(roadmap).toMatch(/close.*milestone.*shipped/i);
+    expect(roadmap).toContain('release-please--branches--main--components--easyeda-mcp-pro');
+    expect(roadmap).toMatch(/active release pull request/i);
+  });
+
+  it('links both guides from public navigation and the README', () => {
+    const vitepress = read('docs/.vitepress/config.ts');
+    const readme = read('README.md');
+
+    expect(vitepress).toContain("link: '/guide/cdp-bridge'");
+    expect(vitepress).toContain("link: '/ROADMAP'");
+    expect(readme).toContain('docs/guide/cdp-bridge.md');
+    expect(readme).toContain('docs/ROADMAP.md');
+  });
+});


### PR DESCRIPTION
## Summary

Preserve the still-valid documentation from the stale CDP debug branch and define the public repository lifecycle needed before retiring obsolete branches and milestones.

Refs #341.

## Branch audit evidence

### `feat/remote-relay-resilience`

- current `main` is 102 commits ahead;
- the branch has two commits;
- `git cherry main origin/feat/remote-relay-resilience` marks both commits as patch-equivalent (`-`);
- no unique code needs preservation.

### `cdp-bridge-debug-mode-v2`

- current `main` is 110 commits ahead;
- the branch has one unique documentation commit: `308f1a6`;
- the only unique file is the historical `CDP_BRIDGE_NOTES.md`;
- valid material is preserved here as a current, safety-scoped guide instead of copying stale method-status claims.

Remote branches will be deleted only after this PR is merged, so no unique documentation can be lost.

## Documentation changes

- add an experimental CDP bridge guide covering:
  - loopback-only renderer debugging;
  - target discovery and connection verification;
  - mapped and unmapped write gates;
  - raw execution quarantine;
  - explicit compatibility limitations;
  - the extension bridge as the recommended default;
- publish active delivery milestones for v0.37.0 and v1.0 readiness;
- document milestone naming, closure, epic/child assignment, and branch-retention rules;
- replace the shipped v0.18.0 work item that still looked active with a historical reference;
- link CDP and roadmap guidance from the README and VitePress navigation.

## Post-merge repository operations

After merge, #341 will complete these public-state changes:

1. create and assign the active v0.37.0 and v1.0-readiness milestones;
2. close shipped v0.22.0, v0.23.0, v0.24.0, and v0.34.0 milestones without changing issue history;
3. remove the two audited stale branches;
4. update epic #349 and close #341 with evidence;
5. verify that `main` and release automation remain unaffected.

## Verification

- repository roadmap/CDP policy: 3 tests passed;
- full `pnpm verify` passed:
  - runtime preflight;
  - formatting, root and extension typecheck, ESLint;
  - 115 tool metadata/profile checks;
  - 150 server files / 1,740 tests;
  - 9 extension files / 143 tests;
  - server and extension builds;
  - extension package and checksum generation;
  - metadata and generated compatibility validation;
  - VitePress documentation build with no dead links.
