### PR TITLE
refactor(extension): extract API introspection policy

### DIFF
--- a/docs/superpowers/plans/2026-07-23-dispatcher-api-introspection-extraction.md
+++ b/docs/superpowers/plans/2026-07-23-dispatcher-api-introspection-extraction.md
@@ -1,0 +1,438 @@
+# Dispatcher API Introspection Extraction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [x]`) syntax for tracking.
+
+**Goal:** Extract the EasyEDA API path allowlist and runtime result normalization from the 5,041-line extension dispatcher into one stateless, independently tested module without changing any public bridge method or response.
+
+**Architecture:** Create `api-introspection.ts` as a stateless browser-safe module that depends only on `utils.ts`. The dispatcher continues to own toolkit selection, API invocation, inventory assembly, and method routing, but imports typed policy and normalization helpers from the new module. Existing dispatcher integration tests remain the end-to-end parity gate while focused unit tests lock the extracted safety behavior.
+
+**Tech Stack:** TypeScript 6, Vitest 4, esbuild browser IIFE bundle, pnpm 11.5.1, Node.js 24.18.0.
+
+## Global Constraints
+
+- Preserve all 67 extension method names and their sorted order.
+- Preserve request/response shapes, error codes, suggestions, and EasyEDA class-name fallback behavior.
+- Do not add new EasyEDA features or dependencies.
+- Keep `api.execute` quarantine and `api.call` authorization behavior unchanged.
+- Keep repeated object references as valid data while representing only active recursion cycles as `[Circular]`.
+- Keep the packaged `.eext` under the existing repository size budget.
+- Run the exact Node.js 24.18.0 and pnpm 11.5.1 runtime preflight before repository verification.
+
+---
+
+### Task 1: Lock the extracted API safety contract
+
+**Files:**
+
+- Create: `easyeda-bridge-extension/tests/api-introspection.test.ts`
+- Test: `easyeda-bridge-extension/tests/dispatcher.test.ts`
+
+**Interfaces:**
+
+- Consumes: existing dispatcher behavior for `api.call` authorization and normalization.
+- Produces: executable expectations for `withClassNameVariants`, `normalizeApiClassName`, `isAllowedApiClassName`, `isAllowedApiPath`, `readMember`, `normalizeValue`, `normalizeStandalone`, `readStateValue`, and `compactPrimitiveSummary`.
+
+- [x] **Step 1: Write the failing focused test**
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import {
+  compactPrimitiveSummary,
+  isAllowedApiClassName,
+  isAllowedApiPath,
+  normalizeApiClassName,
+  normalizeStandalone,
+  normalizeValue,
+  readMember,
+  readStateValue,
+  withClassNameVariants,
+} from '../src/api-introspection.js';
+
+describe('API introspection policy', () => {
+  it('normalizes EasyEDA class prefixes and generates stable variants', () => {
+    expect(normalizeApiClassName('sch_PrimitiveWire')).toBe('SCH_PrimitiveWire');
+    expect(withClassNameVariants(['sch_PrimitiveWire.getAll', 'SCH_PrimitiveWire.getAll'])).toEqual(
+      ['sch_PrimitiveWire.getAll', 'SCH_PrimitiveWire.getAll'],
+    );
+  });
+
+  it('allows only documented EasyEDA class prefixes and safe method names', () => {
+    expect(isAllowedApiClassName('SCH_PrimitiveWire')).toBe(true);
+    expect(isAllowedApiPath('sch_PrimitiveWire.getAll')).toBe(true);
+    expect(isAllowedApiPath('SYS_Shell.exec')).toBe(false);
+    expect(isAllowedApiPath('SCH_PrimitiveWire.constructor')).toBe(false);
+    expect(isAllowedApiPath('SCH_PrimitiveWire.__proto__')).toBe(false);
+  });
+
+  it('preserves state, methods, repeated references, cycles, and depth bounds', () => {
+    const shared = { value: 7 };
+    const wrapper = {
+      first: shared,
+      second: shared,
+      getState_PrimitiveId: () => 'wire-1',
+      helper() {},
+    };
+    const cycle: Record<string, unknown> = {};
+    cycle.self = cycle;
+
+    expect(normalizeValue(wrapper, 5)).toMatchObject({
+      first: { value: 7 },
+      second: { value: 7 },
+      state: { PrimitiveId: 'wire-1' },
+      __methods: expect.arrayContaining(['getState_PrimitiveId', 'helper']),
+    });
+    expect(normalizeStandalone(cycle, 4)).toEqual({ self: '[Circular]' });
+    expect(normalizeStandalone({ nested: { value: 1 } }, 1)).toEqual({ nested: '[MaxDepth]' });
+  });
+
+  it('handles throwing members and state getters without escaping the bridge', () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const source = Object.create(null, {
+      dangerous: {
+        get: () => {
+          throw new Error('blocked');
+        },
+      },
+      getState_Name: {
+        value: () => {
+          throw new Error('state blocked');
+        },
+      },
+    });
+
+    expect(readMember(source, 'dangerous')).toBeUndefined();
+    expect(readStateValue(source, 'Name')).toBe('ERROR: Error: state blocked');
+    expect(compactPrimitiveSummary(source, ['Name'])).toEqual({
+      Name: 'ERROR: Error: state blocked',
+    });
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+});
+```
+
+- [x] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+pnpm --filter @easyeda-mcp-pro/bridge-extension exec vitest run tests/api-introspection.test.ts
+```
+
+Expected: FAIL because `../src/api-introspection.js` does not exist.
+
+- [x] **Step 3: Confirm existing integration behavior remains green before extraction**
+
+Run:
+
+```bash
+pnpm --filter @easyeda-mcp-pro/bridge-extension exec vitest run tests/dispatcher.test.ts
+```
+
+Expected: 88 dispatcher tests pass.
+
+### Task 2: Extract the stateless policy and normalization module
+
+**Files:**
+
+- Create: `easyeda-bridge-extension/src/api-introspection.ts`
+- Modify: `easyeda-bridge-extension/src/dispatcher.ts:9-42,638-802,1176-1240`
+- Test: `easyeda-bridge-extension/tests/api-introspection.test.ts`
+- Test: `easyeda-bridge-extension/tests/dispatcher.test.ts`
+
+**Interfaces:**
+
+- Consumes: `isRecord`, `logRecoverableError`, and `JsonValue` from `easyeda-bridge-extension/src/utils.ts`.
+- Produces:
+  - `withClassNameVariants(paths: readonly string[]): string[]`
+  - `normalizeApiClassName(className: string): string`
+  - `isAllowedApiClassName(className: string): boolean`
+  - `isAllowedApiPath(path: string): boolean`
+  - `getFunctionNames(value: unknown): string[]`
+  - `readMember(source: unknown, key: string): unknown`
+  - `normalizeValue(value: unknown, depth?: number, seen?: WeakSet<object>): JsonValue`
+  - `normalizeStandalone(value: unknown, depth?: number): JsonValue`
+  - `readStateValue(source: unknown, stateName: string, depth?: number): JsonValue | undefined`
+  - `compactPrimitiveSummary(value: unknown, stateNames: readonly string[]): Record<string, JsonValue | undefined>`
+
+- [x] **Step 1: Implement the stateless module**
+
+```ts
+import { isRecord, logRecoverableError, type JsonValue } from './utils.js';
+
+const API_CLASS_PREFIXES = ['DMT_', 'SCH_', 'PCB_', 'LIB_'] as const;
+const DENIED_API_METHODS = new Set([
+  'constructor',
+  'prototype',
+  '__defineGetter__',
+  '__defineSetter__',
+]);
+
+export function withClassNameVariants(paths: readonly string[]): string[] {
+  const variants: string[] = [];
+  for (const path of paths) {
+    variants.push(path);
+    const parts = path.split('.');
+    const className = parts[0];
+    if (!className) continue;
+    const suffix = parts.length > 1 ? `.${parts.slice(1).join('.')}` : '';
+    const lower = /^([a-z]+)_(.+)$/.exec(className);
+    const upper = /^([A-Z]+)_(.+)$/.exec(className);
+    if (lower?.[1] && lower[2]) variants.push(`${lower[1].toUpperCase()}_${lower[2]}${suffix}`);
+    if (upper?.[1] && upper[2]) variants.push(`${upper[1].toLowerCase()}_${upper[2]}${suffix}`);
+  }
+  return [...new Set(variants)];
+}
+
+export function normalizeApiClassName(className: string): string {
+  const match = /^([a-z]+)_(.+)$/.exec(className);
+  return match?.[1] && match[2] ? `${match[1].toUpperCase()}_${match[2]}` : className;
+}
+
+export function isAllowedApiClassName(className: string): boolean {
+  const normalized = normalizeApiClassName(className);
+  return API_CLASS_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+export function isAllowedApiPath(path: string): boolean {
+  const parts = path.split('.');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return false;
+  const [className, methodName] = parts;
+  if (DENIED_API_METHODS.has(methodName) || methodName.startsWith('__')) return false;
+  if (!/^[A-Za-z]+_[A-Za-z0-9]+$/.test(className)) return false;
+  if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(methodName)) return false;
+  return isAllowedApiClassName(className);
+}
+
+function getAllPropertyNames(value: unknown): string[] {
+  const names: string[] = [];
+  let cursor = value;
+  let depth = 0;
+  while (isRecord(cursor) && cursor !== Object.prototype && depth < 8) {
+    try {
+      names.push(...Object.getOwnPropertyNames(cursor));
+    } catch (error) {
+      logRecoverableError('failed to read API property names', error);
+      break;
+    }
+    try {
+      cursor = Object.getPrototypeOf(cursor);
+    } catch (error) {
+      logRecoverableError('failed to read API property prototype', error);
+      break;
+    }
+    depth += 1;
+  }
+  return [...new Set(names)].filter(
+    (name) => !['length', 'name', 'prototype', 'constructor'].includes(name),
+  );
+}
+
+export function readMember(source: unknown, key: string): unknown {
+  if (!isRecord(source) || !(key in source)) return undefined;
+  try {
+    return source[key];
+  } catch (error) {
+    logRecoverableError(`failed to read API member ${key}`, error);
+    return undefined;
+  }
+}
+
+export function getFunctionNames(value: unknown): string[] {
+  return getAllPropertyNames(value).filter((name) => typeof readMember(value, name) === 'function');
+}
+
+export function normalizeValue(value: unknown, depth = 3, seen = new WeakSet<object>()): JsonValue {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  )
+    return value;
+  if (value === undefined) return null;
+  if (typeof value === 'function') return `[Function ${value.name ?? 'anonymous'}]`;
+  if (typeof value !== 'object') return String(value);
+  if (seen.has(value)) return '[Circular]';
+  if (depth <= 0) return '[MaxDepth]';
+
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) return value.map((item) => normalizeValue(item, depth - 1, seen));
+    const output: Record<string, JsonValue | undefined> = {};
+    const ctorName = (value as { constructor?: { name?: string } }).constructor?.name;
+    if (ctorName && ctorName !== 'Object') output.__class = ctorName;
+    const getterNames = getFunctionNames(value).filter((name) => name.startsWith('getState_'));
+    if (getterNames.length) {
+      const state: Record<string, JsonValue | undefined> = {};
+      for (const getterName of getterNames) {
+        const getter = readMember(value, getterName);
+        if (typeof getter !== 'function') continue;
+        try {
+          state[getterName.replace(/^getState_/, '')] = normalizeValue(
+            getter.call(value),
+            depth - 1,
+            seen,
+          );
+        } catch (error) {
+          state[getterName.replace(/^getState_/, '')] = `ERROR: ${String(error)}`;
+        }
+      }
+      output.state = state;
+    }
+    const methodNames = getFunctionNames(value);
+    if (methodNames.length) output.__methods = methodNames;
+    for (const key of Object.keys(value)) {
+      output[key] = normalizeValue((value as Record<string, unknown>)[key], depth - 1, seen);
+    }
+    return output;
+  } finally {
+    seen.delete(value);
+  }
+}
+
+export function normalizeStandalone(value: unknown, depth = 4): JsonValue {
+  return normalizeValue(value, depth, new WeakSet<object>());
+}
+
+export function readStateValue(
+  source: unknown,
+  stateName: string,
+  depth = 4,
+): JsonValue | undefined {
+  const getter = readMember(source, `getState_${stateName}`);
+  if (typeof getter !== 'function') return undefined;
+  try {
+    return normalizeStandalone(getter.call(source), depth);
+  } catch (error) {
+    return `ERROR: ${String(error)}`;
+  }
+}
+
+export function compactPrimitiveSummary(
+  value: unknown,
+  stateNames: readonly string[],
+): Record<string, JsonValue | undefined> {
+  const state: Record<string, JsonValue | undefined> = {};
+  for (const stateName of stateNames) state[stateName] = readStateValue(value, stateName, 5);
+  return state;
+}
+```
+
+- [x] **Step 2: Replace dispatcher-local helpers with imports**
+
+Add this import to `dispatcher.ts`:
+
+```ts
+import {
+  compactPrimitiveSummary,
+  getFunctionNames,
+  isAllowedApiClassName,
+  isAllowedApiPath,
+  normalizeApiClassName,
+  normalizeStandalone,
+  normalizeValue,
+  readMember,
+  readStateValue,
+  withClassNameVariants,
+} from './api-introspection.js';
+```
+
+Delete the dispatcher-local API prefix constants and helper implementations. In `inspectApiInventory`, replace the direct prefix-array predicate with:
+
+```ts
+if (!isAllowedApiClassName(className)) continue;
+```
+
+- [x] **Step 3: Run focused tests and typecheck**
+
+Run:
+
+```bash
+pnpm --filter @easyeda-mcp-pro/bridge-extension exec vitest run \
+  tests/api-introspection.test.ts tests/dispatcher.test.ts
+pnpm --filter @easyeda-mcp-pro/bridge-extension typecheck
+```
+
+Expected: focused module tests and all 88 dispatcher integration tests pass; TypeScript reports zero errors.
+
+- [x] **Step 4: Commit the extraction**
+
+```bash
+git add easyeda-bridge-extension/src/api-introspection.ts \
+  easyeda-bridge-extension/src/dispatcher.ts \
+  easyeda-bridge-extension/tests/api-introspection.test.ts
+git commit -m "refactor(extension): extract API introspection policy"
+```
+
+### Task 3: Prove behavior and package parity
+
+**Files:**
+
+- Modify: `docs/superpowers/plans/2026-07-23-dispatcher-api-introspection-extraction.md`
+- Verify: `easyeda-bridge-extension/dist/dispatcher.meta.json`
+- Verify: `easyeda-bridge-extension/easyeda-bridge-extension.eext`
+- Verify: `tests/unit/extension/method-list-parity.test.ts`
+- Verify: `tests/unit/repository/extension-size-budget.test.ts`
+
+**Interfaces:**
+
+- Consumes: the extraction implemented in Task 2.
+- Produces: PR-ready evidence that the refactor preserves public methods, dispatcher behavior, and package limits.
+
+- [x] **Step 1: Run extension coverage and package checks**
+
+Run:
+
+```bash
+pnpm test:extension:ci
+pnpm build:extension
+pnpm check:extension-size
+pnpm vitest run tests/unit/extension/method-list-parity.test.ts \
+  tests/unit/repository/extension-size-budget.test.ts
+```
+
+Expected: all extension tests and coverage pass; the package is generated; method-list parity and size-budget tests pass.
+
+- [x] **Step 2: Run complete repository verification**
+
+Run:
+
+```bash
+pnpm verify
+```
+
+Expected: runtime preflight, format, root and extension typecheck, lint, metadata/profile checks, server tests, extension tests, builds, package checks, generated compatibility validation, and docs build all pass.
+
+- [x] **Step 3: Record objective parity evidence for the PR**
+
+Run:
+
+```bash
+wc -l easyeda-bridge-extension/src/dispatcher.ts
+node -e "const m=require('./easyeda-bridge-extension/dist/dispatcher.meta.json'); console.log(JSON.stringify({buildId:m.buildId,byteLength:m.byteLength}))"
+git diff --check
+git status --short --branch
+```
+
+Expected: dispatcher line count decreases; the bundle remains under the repository budget; only planned source, test, and plan files are changed.
+
+- [x] **Step 4: Commit the implementation plan and evidence updates**
+
+```bash
+git add docs/superpowers/plans/2026-07-23-dispatcher-api-introspection-extraction.md
+git commit -m "docs(plan): record dispatcher extraction strategy"
+```
+
+## Execution evidence
+
+- TDD RED: the focused test failed because `src/api-introspection.ts` did not exist; the existing dispatcher integration baseline remained 88/88 green.
+- Focused parity: 9 API-introspection tests and all 88 dispatcher integration tests pass.
+- Extracted-module coverage: 100% statements, branches, functions, and lines in the full extension coverage run.
+- Public method contract: the extension still reports the same 67 sorted bridge methods; the repository method-list parity test passes.
+- Dispatcher source size: 5,041 lines on `main` → 4,878 lines after extraction (163-line reduction).
+- Built dispatcher bundle: 151,308 bytes on `main` → 151,445 bytes (+137 bytes, approximately +0.09%).
+- Packaged extension: 160,515 bytes on `main` → 160,489 bytes (-26 bytes); the repository size budget passes.
+- Full extension suite: 10 files / 152 tests pass.
+- Full server suite: 150 files / 1,740 tests pass.
+- Full `pnpm verify` passes runtime preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, server and extension tests, both builds, extension packaging/checksums, metadata alignment, generated compatibility validation, and VitePress documentation.

--- a/docs/superpowers/plans/2026-07-23-dispatcher-api-introspection-extraction.md
+++ b/docs/superpowers/plans/2026-07-23-dispatcher-api-introspection-extraction.md
@@ -431,8 +431,9 @@ git commit -m "docs(plan): record dispatcher extraction strategy"
 - Extracted-module coverage: 100% statements, branches, functions, and lines in the full extension coverage run.
 - Public method contract: the extension still reports the same 67 sorted bridge methods; the repository method-list parity test passes.
 - Dispatcher source size: 5,041 lines on `main` → 4,878 lines after extraction (163-line reduction).
-- Built dispatcher bundle: 151,308 bytes on `main` → 151,445 bytes (+137 bytes, approximately +0.09%).
-- Packaged extension: 160,515 bytes on `main` → 160,489 bytes (-26 bytes); the repository size budget passes.
+- Built dispatcher bundle: 151,308 bytes on `main` → 151,841 bytes (+533 bytes, approximately +0.35%).
+- Packaged extension: 160,515 bytes on `main` → 160,594 bytes (+79 bytes, approximately +0.05%); the repository size budget passes.
 - Full extension suite: 10 files / 152 tests pass.
+- Sonar follow-up: the initial PR scan reported three new issues (regex style, cognitive complexity, and ambiguous scalar stringification); the normalization flow was split into bounded helpers and bigint/symbol conversion was made explicit before the final verification run.
 - Full server suite: 150 files / 1,740 tests pass.
 - Full `pnpm verify` passes runtime preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, server and extension tests, both builds, extension packaging/checksums, metadata alignment, generated compatibility validation, and VitePress documentation.

--- a/docs/superpowers/plans/2026-07-23-dispatcher-api-introspection-extraction.md
+++ b/docs/superpowers/plans/2026-07-23-dispatcher-api-introspection-extraction.md
@@ -427,13 +427,14 @@ git commit -m "docs(plan): record dispatcher extraction strategy"
 ## Execution evidence
 
 - TDD RED: the focused test failed because `src/api-introspection.ts` did not exist; the existing dispatcher integration baseline remained 88/88 green.
-- Focused parity: 9 API-introspection tests and all 88 dispatcher integration tests pass.
+- Focused parity: 9 API-introspection tests and all 89 dispatcher integration tests pass.
 - Extracted-module coverage: 100% statements, branches, functions, and lines in the full extension coverage run.
 - Public method contract: the extension still reports the same 67 sorted bridge methods; the repository method-list parity test passes.
 - Dispatcher source size: 5,041 lines on `main` → 4,878 lines after extraction (163-line reduction).
 - Built dispatcher bundle: 151,308 bytes on `main` → 151,841 bytes (+533 bytes, approximately +0.35%).
 - Packaged extension: 160,515 bytes on `main` → 160,594 bytes (+79 bytes, approximately +0.05%); the repository size budget passes.
-- Full extension suite: 10 files / 152 tests pass.
+- Full extension suite: 10 files / 153 tests pass.
 - Sonar follow-up: the initial PR scan reported three new issues (regex style, cognitive complexity, and ambiguous scalar stringification); the normalization flow was split into bounded helpers and bigint/symbol conversion was made explicit before the final verification run.
+- Codecov follow-up: the initial patch report identified the delegated `system.apiInventory` allowlist line as uncovered; a dispatcher contract test now proves both allowed-class inclusion and `SYS_*` exclusion (`DA:1030=160`, branches `159/1`).
 - Full server suite: 150 files / 1,740 tests pass.
 - Full `pnpm verify` passes runtime preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, server and extension tests, both builds, extension packaging/checksums, metadata alignment, generated compatibility validation, and VitePress documentation.

--- a/easyeda-bridge-extension/src/api-introspection.ts
+++ b/easyeda-bridge-extension/src/api-introspection.ts
@@ -50,7 +50,7 @@ export function isAllowedApiPath(path: string): boolean {
   const [className, methodName] = parts;
   if (DENIED_API_METHODS.has(methodName) || methodName.startsWith('__')) return false;
   if (!/^[A-Za-z]+_[A-Za-z0-9]+$/.test(className)) return false;
-  if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(methodName)) return false;
+  if (!/^[A-Za-z]\w*$/.test(methodName)) return false;
   return isAllowedApiClassName(className);
 }
 
@@ -95,18 +95,49 @@ export function getFunctionNames(value: unknown): string[] {
   });
 }
 
-export function normalizeValue(value: unknown, depth = 3, seen = new WeakSet<object>()): JsonValue {
-  if (
-    value === null ||
-    typeof value === 'string' ||
-    typeof value === 'number' ||
-    typeof value === 'boolean'
-  ) {
-    return value;
+function normalizeStateGetters(
+  value: object,
+  depth: number,
+  seen: WeakSet<object>,
+): Record<string, JsonValue | undefined> | undefined {
+  const getterNames = getFunctionNames(value).filter((name) => name.startsWith('getState_'));
+  if (getterNames.length === 0) return undefined;
+
+  const state: Record<string, JsonValue | undefined> = {};
+  for (const getterName of getterNames) {
+    const getter = readMember(value, getterName);
+    if (typeof getter !== 'function') continue;
+    try {
+      state[getterName.replace(/^getState_/, '')] = normalizeValue(
+        getter.call(value),
+        depth - 1,
+        seen,
+      );
+    } catch (error) {
+      state[getterName.replace(/^getState_/, '')] = `ERROR: ${String(error)}`;
+    }
   }
-  if (value === undefined) return null;
-  if (typeof value === 'function') return `[Function ${value.name ?? 'anonymous'}]`;
-  if (typeof value !== 'object') return String(value);
+  return state;
+}
+
+function normalizeRecordValue(value: object, depth: number, seen: WeakSet<object>): JsonValue {
+  const output: Record<string, JsonValue | undefined> = {};
+  const ctorName = (value as { constructor?: { name?: string } }).constructor?.name;
+  if (ctorName && ctorName !== 'Object') output.__class = ctorName;
+
+  const state = normalizeStateGetters(value, depth, seen);
+  if (state) output.state = state;
+
+  const methodNames = getFunctionNames(value);
+  if (methodNames.length > 0) output.__methods = methodNames;
+
+  for (const key of Object.keys(value)) {
+    output[key] = normalizeValue((value as Record<string, unknown>)[key], depth - 1, seen);
+  }
+  return output;
+}
+
+function normalizeObjectValue(value: object, depth: number, seen: WeakSet<object>): JsonValue {
   if (seen.has(value)) return '[Circular]';
   if (depth <= 0) return '[MaxDepth]';
 
@@ -115,43 +146,24 @@ export function normalizeValue(value: unknown, depth = 3, seen = new WeakSet<obj
     if (Array.isArray(value)) {
       return value.map((item) => normalizeValue(item, depth - 1, seen));
     }
-
-    const output: Record<string, JsonValue | undefined> = {};
-    const ctorName = (value as { constructor?: { name?: string } }).constructor?.name;
-    if (ctorName && ctorName !== 'Object') output.__class = ctorName;
-
-    const getterNames = getFunctionNames(value).filter((name) => name.startsWith('getState_'));
-    if (getterNames.length > 0) {
-      const state: Record<string, JsonValue | undefined> = {};
-      for (const getterName of getterNames) {
-        const getter = readMember(value, getterName);
-        if (typeof getter !== 'function') continue;
-        try {
-          state[getterName.replace(/^getState_/, '')] = normalizeValue(
-            getter.call(value),
-            depth - 1,
-            seen,
-          );
-        } catch (error) {
-          state[getterName.replace(/^getState_/, '')] = `ERROR: ${String(error)}`;
-        }
-      }
-      output.state = state;
-    }
-
-    const methodNames = getFunctionNames(value);
-    if (methodNames.length > 0) output.__methods = methodNames;
-
-    for (const key of Object.keys(value)) {
-      output[key] = normalizeValue((value as Record<string, unknown>)[key], depth - 1, seen);
-    }
-
-    return output;
+    return normalizeRecordValue(value, depth, seen);
   } finally {
     // Track only the active recursion path. Repeated references are valid data;
     // only a reference back into the current path is a true cycle.
     seen.delete(value);
   }
+}
+
+export function normalizeValue(value: unknown, depth = 3, seen = new WeakSet<object>()): JsonValue {
+  if (value === null) return null;
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number') return value;
+  if (typeof value === 'boolean') return value;
+  if (value === undefined) return null;
+  if (typeof value === 'function') return `[Function ${value.name ?? 'anonymous'}]`;
+  if (typeof value === 'bigint') return value.toString();
+  if (typeof value === 'symbol') return value.toString();
+  return normalizeObjectValue(value, depth, seen);
 }
 
 export function normalizeStandalone(value: unknown, depth = 4): JsonValue {

--- a/easyeda-bridge-extension/src/api-introspection.ts
+++ b/easyeda-bridge-extension/src/api-introspection.ts
@@ -1,0 +1,184 @@
+import { isRecord, logRecoverableError, type JsonValue } from './utils.js';
+
+const API_CLASS_PREFIXES = ['DMT_', 'SCH_', 'PCB_', 'LIB_'] as const;
+const DENIED_API_METHODS = new Set([
+  'constructor',
+  'prototype',
+  '__defineGetter__',
+  '__defineSetter__',
+]);
+
+export function withClassNameVariants(paths: readonly string[]): string[] {
+  const variants: string[] = [];
+  for (const path of paths) {
+    variants.push(path);
+    const parts = path.split('.');
+    const className = parts[0];
+    if (!className) continue;
+
+    const rest = parts.slice(1).join('.');
+    const suffix = rest ? `.${rest}` : '';
+    const lowerPrefixMatch = /^([a-z]+)_(.+)$/.exec(className);
+    const upperPrefixMatch = /^([A-Z]+)_(.+)$/.exec(className);
+
+    if (lowerPrefixMatch?.[1] && lowerPrefixMatch[2]) {
+      variants.push(`${lowerPrefixMatch[1].toUpperCase()}_${lowerPrefixMatch[2]}${suffix}`);
+    }
+
+    if (upperPrefixMatch?.[1] && upperPrefixMatch[2]) {
+      variants.push(`${upperPrefixMatch[1].toLowerCase()}_${upperPrefixMatch[2]}${suffix}`);
+    }
+  }
+
+  return [...new Set(variants)];
+}
+
+export function normalizeApiClassName(className: string): string {
+  const match = /^([a-z]+)_(.+)$/.exec(className);
+  if (!match?.[1] || !match[2]) return className;
+  return `${match[1].toUpperCase()}_${match[2]}`;
+}
+
+export function isAllowedApiClassName(className: string): boolean {
+  const normalizedClassName = normalizeApiClassName(className);
+  return API_CLASS_PREFIXES.some((prefix) => normalizedClassName.startsWith(prefix));
+}
+
+export function isAllowedApiPath(path: string): boolean {
+  const parts = path.split('.');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) return false;
+  const [className, methodName] = parts;
+  if (DENIED_API_METHODS.has(methodName) || methodName.startsWith('__')) return false;
+  if (!/^[A-Za-z]+_[A-Za-z0-9]+$/.test(className)) return false;
+  if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(methodName)) return false;
+  return isAllowedApiClassName(className);
+}
+
+function getAllPropertyNames(value: unknown): string[] {
+  const names: string[] = [];
+  let cursor = value;
+  let depth = 0;
+  while (isRecord(cursor) && cursor !== Object.prototype && depth < 8) {
+    try {
+      names.push(...Object.getOwnPropertyNames(cursor));
+    } catch (error) {
+      logRecoverableError('failed to read API property names', error);
+      break;
+    }
+    try {
+      cursor = Object.getPrototypeOf(cursor);
+    } catch (error) {
+      logRecoverableError('failed to read API property prototype', error);
+      break;
+    }
+    depth += 1;
+  }
+  return Array.from(new Set(names)).filter(
+    (name) => !['length', 'name', 'prototype', 'constructor'].includes(name),
+  );
+}
+
+export function readMember(source: unknown, key: string): unknown {
+  if (!isRecord(source) || !(key in source)) return undefined;
+  try {
+    return source[key];
+  } catch (error) {
+    logRecoverableError(`failed to read API member ${key}`, error);
+    return undefined;
+  }
+}
+
+export function getFunctionNames(value: unknown): string[] {
+  return getAllPropertyNames(value).filter((name) => {
+    const member = readMember(value, name);
+    return typeof member === 'function';
+  });
+}
+
+export function normalizeValue(value: unknown, depth = 3, seen = new WeakSet<object>()): JsonValue {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+  if (value === undefined) return null;
+  if (typeof value === 'function') return `[Function ${value.name ?? 'anonymous'}]`;
+  if (typeof value !== 'object') return String(value);
+  if (seen.has(value)) return '[Circular]';
+  if (depth <= 0) return '[MaxDepth]';
+
+  seen.add(value);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item) => normalizeValue(item, depth - 1, seen));
+    }
+
+    const output: Record<string, JsonValue | undefined> = {};
+    const ctorName = (value as { constructor?: { name?: string } }).constructor?.name;
+    if (ctorName && ctorName !== 'Object') output.__class = ctorName;
+
+    const getterNames = getFunctionNames(value).filter((name) => name.startsWith('getState_'));
+    if (getterNames.length > 0) {
+      const state: Record<string, JsonValue | undefined> = {};
+      for (const getterName of getterNames) {
+        const getter = readMember(value, getterName);
+        if (typeof getter !== 'function') continue;
+        try {
+          state[getterName.replace(/^getState_/, '')] = normalizeValue(
+            getter.call(value),
+            depth - 1,
+            seen,
+          );
+        } catch (error) {
+          state[getterName.replace(/^getState_/, '')] = `ERROR: ${String(error)}`;
+        }
+      }
+      output.state = state;
+    }
+
+    const methodNames = getFunctionNames(value);
+    if (methodNames.length > 0) output.__methods = methodNames;
+
+    for (const key of Object.keys(value)) {
+      output[key] = normalizeValue((value as Record<string, unknown>)[key], depth - 1, seen);
+    }
+
+    return output;
+  } finally {
+    // Track only the active recursion path. Repeated references are valid data;
+    // only a reference back into the current path is a true cycle.
+    seen.delete(value);
+  }
+}
+
+export function normalizeStandalone(value: unknown, depth = 4): JsonValue {
+  return normalizeValue(value, depth, new WeakSet<object>());
+}
+
+export function readStateValue(
+  source: unknown,
+  stateName: string,
+  depth = 4,
+): JsonValue | undefined {
+  const getter = readMember(source, `getState_${stateName}`);
+  if (typeof getter !== 'function') return undefined;
+  try {
+    return normalizeStandalone(getter.call(source), depth);
+  } catch (error) {
+    return `ERROR: ${String(error)}`;
+  }
+}
+
+export function compactPrimitiveSummary(
+  value: unknown,
+  stateNames: readonly string[],
+): Record<string, JsonValue | undefined> {
+  const state: Record<string, JsonValue | undefined> = {};
+  for (const stateName of stateNames) {
+    state[stateName] = readStateValue(value, stateName, 5);
+  }
+  return state;
+}

--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -6,6 +6,18 @@
 // injected DispatcherToolkit (see toolkit.ts) so the identical code works both
 // baked into the extension script scope and eval'd via AsyncFunction.
 
+import {
+  compactPrimitiveSummary,
+  getFunctionNames,
+  isAllowedApiClassName,
+  isAllowedApiPath,
+  normalizeApiClassName,
+  normalizeStandalone,
+  normalizeValue,
+  readMember,
+  readStateValue,
+  withClassNameVariants,
+} from './api-introspection.js';
 import { normalizeBinaryResult, type BinaryResultPayload } from './binary-result.js';
 import type { Dispatcher, DispatcherToolkit } from './toolkit.js';
 import {
@@ -30,14 +42,6 @@ const BUILD_ID =
 // bytes) plus JSON envelope overhead. Exceeding the server's actual limit closes
 // the whole WS connection, not just the offending call — so we self-limit first.
 const PAYLOAD_SAFETY_MARGIN = 0.6;
-const API_CLASS_PREFIXES = ['DMT_', 'SCH_', 'PCB_', 'LIB_'] as const;
-const DENIED_API_METHODS = new Set([
-  'constructor',
-  'prototype',
-  '__defineGetter__',
-  '__defineSetter__',
-]);
-
 /** Every bridge method handled by dispatch() below. Keep in lockstep with the
  *  switch cases AND the server's EasyedaApiMethodSchema (src/bridge/types.ts). */
 const METHOD_LIST: readonly string[] = [
@@ -635,173 +639,6 @@ async function waitForCanvasPaint(): Promise<void> {
   await new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
-function withClassNameVariants(paths: string[]): string[] {
-  const variants: string[] = [];
-  for (const path of paths) {
-    variants.push(path);
-    const parts = path.split('.');
-    const className = parts[0];
-    if (!className) continue;
-
-    const rest = parts.slice(1).join('.');
-    const suffix = rest ? `.${rest}` : '';
-    const lowerPrefixMatch = className.match(/^([a-z]+)_(.+)$/);
-    const upperPrefixMatch = className.match(/^([A-Z]+)_(.+)$/);
-
-    if (lowerPrefixMatch?.[1] && lowerPrefixMatch[2]) {
-      variants.push(`${lowerPrefixMatch[1].toUpperCase()}_${lowerPrefixMatch[2]}${suffix}`);
-    }
-
-    if (upperPrefixMatch?.[1] && upperPrefixMatch[2]) {
-      variants.push(`${upperPrefixMatch[1].toLowerCase()}_${upperPrefixMatch[2]}${suffix}`);
-    }
-  }
-
-  return [...new Set(variants)];
-}
-
-function normalizeApiClassName(className: string): string {
-  const match = className.match(/^([a-z]+)_(.+)$/);
-  if (!match?.[1] || !match[2]) return className;
-  return `${match[1].toUpperCase()}_${match[2]}`;
-}
-
-function isAllowedApiPath(path: string): boolean {
-  const parts = path.split('.');
-  if (parts.length !== 2 || !parts[0] || !parts[1]) return false;
-  const [className, methodName] = parts;
-  if (DENIED_API_METHODS.has(methodName) || methodName.startsWith('__')) return false;
-  if (!/^[A-Za-z]+_[A-Za-z0-9]+$/.test(className)) return false;
-  if (!/^[A-Za-z][A-Za-z0-9_]*$/.test(methodName)) return false;
-  return API_CLASS_PREFIXES.some((prefix) => normalizeApiClassName(className).startsWith(prefix));
-}
-
-function getAllPropertyNames(value: unknown): string[] {
-  const names: string[] = [];
-  let cursor = value;
-  let depth = 0;
-  while (isRecord(cursor) && cursor !== Object.prototype && depth < 8) {
-    try {
-      names.push(...Object.getOwnPropertyNames(cursor));
-    } catch (error) {
-      logRecoverableError('failed to read API property names', error);
-      break;
-    }
-    try {
-      cursor = Object.getPrototypeOf(cursor);
-    } catch (error) {
-      logRecoverableError('failed to read API property prototype', error);
-      break;
-    }
-    depth += 1;
-  }
-  return Array.from(new Set(names)).filter(
-    (name) => !['length', 'name', 'prototype', 'constructor'].includes(name),
-  );
-}
-
-function getFunctionNames(value: unknown): string[] {
-  return getAllPropertyNames(value).filter((name) => {
-    const member = readMember(value, name);
-    return typeof member === 'function';
-  });
-}
-
-function readMember(source: unknown, key: string): unknown {
-  if (!isRecord(source) || !(key in source)) return undefined;
-  try {
-    return source[key];
-  } catch (error) {
-    logRecoverableError(`failed to read API member ${key}`, error);
-    return undefined;
-  }
-}
-
-function normalizeValue(value: unknown, depth = 3, seen = new WeakSet<object>()): JsonValue {
-  if (
-    value === null ||
-    typeof value === 'string' ||
-    typeof value === 'number' ||
-    typeof value === 'boolean'
-  ) {
-    return value;
-  }
-  if (value === undefined) return null;
-  if (typeof value === 'function')
-    return `[Function ${(value as { name?: string }).name ?? 'anonymous'}]`;
-  if (typeof value !== 'object') return String(value);
-  if (seen.has(value)) return '[Circular]';
-  if (depth <= 0) return '[MaxDepth]';
-
-  seen.add(value);
-  try {
-    if (Array.isArray(value)) {
-      return value.map((item) => normalizeValue(item, depth - 1, seen));
-    }
-
-    const output: Record<string, JsonValue | undefined> = {};
-    const ctorName = (value as { constructor?: { name?: string } }).constructor?.name;
-    if (ctorName && ctorName !== 'Object') output.__class = ctorName;
-
-    const getterNames = getFunctionNames(value).filter((name) => name.startsWith('getState_'));
-    if (getterNames.length > 0) {
-      const state: Record<string, JsonValue | undefined> = {};
-      for (const getterName of getterNames) {
-        const getter = readMember(value, getterName);
-        if (typeof getter !== 'function') continue;
-        try {
-          state[getterName.replace(/^getState_/, '')] = normalizeValue(
-            getter.call(value),
-            depth - 1,
-            seen,
-          );
-        } catch (error) {
-          state[getterName.replace(/^getState_/, '')] = `ERROR: ${String(error)}`;
-        }
-      }
-      output.state = state;
-    }
-
-    const methodNames = getFunctionNames(value);
-    if (methodNames.length > 0) output.__methods = methodNames;
-
-    for (const key of Object.keys(value)) {
-      output[key] = normalizeValue((value as Record<string, unknown>)[key], depth - 1, seen);
-    }
-
-    return output;
-  } finally {
-    // Track only the active recursion path. Repeated references are valid data;
-    // only a reference back into the current path is a true cycle.
-    seen.delete(value);
-  }
-}
-
-function normalizeStandalone(value: unknown, depth = 4): JsonValue {
-  return normalizeValue(value, depth, new WeakSet<object>());
-}
-
-function readStateValue(source: unknown, stateName: string, depth = 4): JsonValue | undefined {
-  const getter = readMember(source, `getState_${stateName}`);
-  if (typeof getter !== 'function') return undefined;
-  try {
-    return normalizeStandalone(getter.call(source), depth);
-  } catch (error) {
-    return `ERROR: ${String(error)}`;
-  }
-}
-
-function compactPrimitiveSummary(
-  value: unknown,
-  stateNames: string[],
-): Record<string, JsonValue | undefined> {
-  const state: Record<string, JsonValue | undefined> = {};
-  for (const stateName of stateNames) {
-    state[stateName] = readStateValue(value, stateName, 5);
-  }
-  return state;
-}
-
 function summarizeWirePrimitive(wire: unknown): Record<string, JsonValue | undefined> {
   const normalized = normalizeStandalone(wire, 4);
   const output: Record<string, JsonValue | undefined> = isRecord(normalized)
@@ -1190,7 +1027,7 @@ function inspectApiInventory(filter?: string): JsonValue {
 
     for (const key of Object.getOwnPropertyNames(root)) {
       const className = normalizeApiClassName(key);
-      if (!API_CLASS_PREFIXES.some((prefix) => className.startsWith(prefix))) continue;
+      if (!isAllowedApiClassName(className)) continue;
       if (normalizedFilter && !className.toLowerCase().includes(normalizedFilter)) continue;
 
       const value = readMember(root, key);

--- a/easyeda-bridge-extension/tests/api-introspection.test.ts
+++ b/easyeda-bridge-extension/tests/api-introspection.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  compactPrimitiveSummary,
+  getFunctionNames,
+  isAllowedApiClassName,
+  isAllowedApiPath,
+  normalizeApiClassName,
+  normalizeStandalone,
+  normalizeValue,
+  readMember,
+  readStateValue,
+  withClassNameVariants,
+} from '../src/api-introspection.js';
+
+describe('API introspection policy', () => {
+  it('normalizes EasyEDA class prefixes and generates stable variants', () => {
+    expect(normalizeApiClassName('sch_PrimitiveWire')).toBe('SCH_PrimitiveWire');
+    expect(withClassNameVariants(['sch_PrimitiveWire.getAll', 'SCH_PrimitiveWire.getAll'])).toEqual(
+      ['sch_PrimitiveWire.getAll', 'SCH_PrimitiveWire.getAll'],
+    );
+  });
+
+  it('allows only documented EasyEDA class prefixes and safe method names', () => {
+    for (const className of [
+      'DMT_SelectControl',
+      'SCH_PrimitiveWire',
+      'PCB_PrimitiveVia',
+      'LIB_Device',
+    ]) {
+      expect(isAllowedApiClassName(className)).toBe(true);
+    }
+    expect(isAllowedApiClassName('SYS_Shell')).toBe(false);
+
+    expect(isAllowedApiPath('sch_PrimitiveWire.getAll')).toBe(true);
+    for (const path of [
+      'SYS_Shell.exec',
+      'SCH_PrimitiveWire',
+      'SCH_PrimitiveWire.getAll.extra',
+      '.getAll',
+      'SCH_PrimitiveWire.',
+      'SCH-PrimitiveWire.getAll',
+      'SCH_.getAll',
+      'SCH_PrimitiveWire._private',
+      'SCH_PrimitiveWire.get-all',
+      'SCH_PrimitiveWire.constructor',
+      'SCH_PrimitiveWire.prototype',
+      'SCH_PrimitiveWire.__defineGetter__',
+      'SCH_PrimitiveWire.__defineSetter__',
+      'SCH_PrimitiveWire.__proto__',
+    ]) {
+      expect(isAllowedApiPath(path)).toBe(false);
+    }
+  });
+
+  it('keeps unmatched and class-only paths stable', () => {
+    expect(withClassNameVariants([])).toEqual([]);
+    expect(withClassNameVariants([''])).toEqual(['']);
+    expect(withClassNameVariants(['NoPrefix.method'])).toEqual(['NoPrefix.method']);
+    expect(withClassNameVariants(['sch_PrimitiveWire'])).toEqual([
+      'sch_PrimitiveWire',
+      'SCH_PrimitiveWire',
+    ]);
+    expect(normalizeApiClassName('SCH_PrimitiveWire')).toBe('SCH_PrimitiveWire');
+  });
+
+  it('normalizes primitives, functions, arrays, and runtime class metadata', () => {
+    function namedFunction() {}
+    const anonymousFunction = Object.defineProperty(() => undefined, 'name', { value: '' });
+    const missingNameFunction = Object.defineProperty(() => undefined, 'name', {
+      value: undefined,
+    });
+    class RuntimeThing {
+      value = 4;
+      method() {}
+    }
+
+    expect(normalizeStandalone(null)).toBeNull();
+    expect(normalizeStandalone(undefined)).toBeNull();
+    expect(normalizeStandalone('text')).toBe('text');
+    expect(normalizeStandalone(2)).toBe(2);
+    expect(normalizeStandalone(true)).toBe(true);
+    expect(normalizeStandalone(2n)).toBe('2');
+    expect(normalizeStandalone(Symbol.for('value'))).toBe('Symbol(value)');
+    expect(normalizeStandalone(namedFunction)).toBe('[Function namedFunction]');
+    expect(normalizeStandalone(anonymousFunction)).toBe('[Function ]');
+    expect(normalizeStandalone(missingNameFunction)).toBe('[Function anonymous]');
+    expect(normalizeStandalone([1, { nested: true }])).toEqual([1, { nested: true }]);
+    expect(normalizeStandalone(new RuntimeThing())).toMatchObject({
+      __class: 'RuntimeThing',
+      __methods: expect.arrayContaining(['method']),
+      value: 4,
+    });
+  });
+
+  it('preserves state, methods, repeated references, cycles, and depth bounds', () => {
+    const shared = { value: 7 };
+    const wrapper = {
+      first: shared,
+      second: shared,
+      getState_PrimitiveId: () => 'wire-1',
+      helper() {},
+    };
+    const cycle: Record<string, unknown> = {};
+    cycle.self = cycle;
+
+    expect(normalizeValue(wrapper, 5)).toMatchObject({
+      first: { value: 7 },
+      second: { value: 7 },
+      state: { PrimitiveId: 'wire-1' },
+      __methods: expect.arrayContaining(['getState_PrimitiveId', 'helper']),
+    });
+    expect(normalizeStandalone(cycle, 4)).toEqual({ self: '[Circular]' });
+    expect(normalizeStandalone({ nested: { value: 1 } }, 1)).toEqual({
+      nested: '[MaxDepth]',
+    });
+  });
+
+  it('skips a state getter that disappears between discovery and invocation', () => {
+    let reads = 0;
+    const source = new Proxy(
+      {
+        getState_Name: () => 'visible-on-first-read',
+      },
+      {
+        get(target, key, receiver) {
+          if (key === 'getState_Name') {
+            reads += 1;
+            return reads === 1 ? Reflect.get(target, key, receiver) : undefined;
+          }
+          return Reflect.get(target, key, receiver);
+        },
+      },
+    );
+
+    expect(normalizeStandalone(source, 4)).toEqual({
+      state: {},
+      getState_Name: null,
+    });
+  });
+
+  it('returns undefined for absent members and state getters', () => {
+    expect(readMember(null, 'missing')).toBeUndefined();
+    expect(readMember({}, 'missing')).toBeUndefined();
+    expect(readStateValue({}, 'Missing')).toBeUndefined();
+    expect(getFunctionNames({ value: 1 })).toEqual([]);
+  });
+
+  it('bounds reflective failures without escaping the bridge', () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const ownKeysFailure = new Proxy(
+      {},
+      {
+        ownKeys: () => {
+          throw new Error('own keys blocked');
+        },
+      },
+    );
+    const prototypeFailure = new Proxy(
+      {},
+      {
+        getPrototypeOf: () => {
+          throw new Error('prototype blocked');
+        },
+      },
+    );
+
+    expect(getFunctionNames(ownKeysFailure)).toEqual([]);
+    expect(getFunctionNames(prototypeFailure)).toEqual([]);
+    expect(warning).toHaveBeenCalledTimes(2);
+    warning.mockRestore();
+  });
+
+  it('handles throwing members and state getters without escaping the bridge', () => {
+    const warning = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const normalized = normalizeStandalone({
+      getState_Name: () => {
+        throw new Error('normalized state blocked');
+      },
+    });
+    expect(normalized).toMatchObject({
+      state: { Name: 'ERROR: Error: normalized state blocked' },
+      __methods: ['getState_Name'],
+    });
+    const source = Object.create(null, {
+      dangerous: {
+        get: () => {
+          throw new Error('blocked');
+        },
+      },
+      getState_Name: {
+        value: () => {
+          throw new Error('state blocked');
+        },
+      },
+    });
+
+    expect(readMember(source, 'dangerous')).toBeUndefined();
+    expect(readStateValue(source, 'Name')).toBe('ERROR: Error: state blocked');
+    expect(compactPrimitiveSummary(source, ['Name'])).toEqual({
+      Name: 'ERROR: Error: state blocked',
+    });
+    expect(warning).toHaveBeenCalledOnce();
+    warning.mockRestore();
+  });
+});

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -741,6 +741,30 @@ describe('createDispatcher', () => {
     expect(importChanges).not.toHaveBeenCalled();
   });
 
+  it('system.apiInventory excludes runtime classes outside the API allowlist', async () => {
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        SCH_PrimitiveWire: { getAll: async () => [] },
+        SYS_Shell: { exec: async () => true },
+      }),
+    );
+
+    const result = (await dispatcher.dispatch('system.apiInventory', {
+      filter: 'primitivewire',
+    })) as { classes: Array<{ className: string; methods: string[] }>; total: number };
+
+    expect(result).toEqual({
+      classes: [
+        {
+          className: 'SCH_PrimitiveWire',
+          runtimePaths: ['eda.SCH_PrimitiveWire'],
+          methods: ['getAll'],
+        },
+      ],
+      total: 1,
+    });
+  });
+
   it('rejects api.call paths outside the allowed class prefixes', async () => {
     const dispatcher = createDispatcher(makeToolkit({}));
     await expect(


### PR DESCRIPTION
## Summary

Extract the EasyEDA API path allowlist, reflective member inspection, state getter handling, and JSON-safe result normalization from the extension's monolithic dispatcher into a stateless `api-introspection.ts` module.

This is the first bounded, behavior-preserving slice of #339. It does not close the parent issue and does not add or remove any public bridge capability.

## Behavior and security parity

- Keeps all 67 sorted extension bridge methods unchanged.
- Preserves the existing `DMT_`, `SCH_`, `PCB_`, and `LIB_` API class allowlist.
- Preserves lowercase/uppercase EasyEDA class-name fallback behavior.
- Keeps prototype and internal method names denied for `api.call`.
- Preserves response normalization for primitives, arrays, runtime class metadata, `getState_*` values, methods, repeated references, cycles, and maximum-depth bounds.
- Keeps reflective property failures and throwing state getters contained instead of escaping the bridge.
- Leaves toolkit selection, API invocation, inventory assembly, routing, error codes, and response shapes in `dispatcher.ts`.

## Objective decomposition evidence

- `dispatcher.ts`: 5,041 lines on `main` → 4,878 lines (-163).
- Built dispatcher bundle: 151,308 bytes → 151,841 bytes (+533 bytes, approximately +0.35%).
- Packaged extension: 160,515 bytes → 160,594 bytes (+79 bytes, approximately +0.05%).
- Existing extension size-budget and method-list parity checks pass.

## Tests

- Added 9 focused API introspection policy/normalization tests.
- Added an integration contract for `system.apiInventory` that proves allowed-class inclusion and `SYS_*` exclusion.
- Extracted module coverage: 100% statements, branches, functions, and lines.
- Delegated dispatcher allowlist line: `DA:1030=160`, branches `159/1` in the final local LCOV report.
- Extension suite: 10 files / 153 tests passed.
- Server suite: 150 files / 1,740 tests passed.
- Full `pnpm verify` passed runtime preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, tests, builds, extension packaging/checksums, metadata alignment, compatibility generation, and VitePress documentation.

## Automated review follow-up

- The initial Sonar scan reported three new issues: concise regex syntax, cognitive complexity in `normalizeValue`, and ambiguous non-object stringification. Commit `9d8b655` addresses all three by splitting object/state normalization into bounded helpers and explicitly handling bigint/symbol values. The latest Sonar report is 0 new issues / 0 hotspots.
- The initial Codecov report identified one uncovered dispatcher line at the delegated inventory allowlist. Commit `493d80c` adds the contract test that executes both allow and deny directions.

## Follow-up

Further dispatcher domains will be extracted in separately reviewable, parity-tested PRs under #339.
