### PR TITLE
refactor(extension): extract EasyEDA API runtime

### DIFF
--- a/docs/superpowers/plans/2026-07-23-dispatcher-api-runtime-extraction.md
+++ b/docs/superpowers/plans/2026-07-23-dispatcher-api-runtime-extraction.md
@@ -1,0 +1,52 @@
+# Dispatcher API Runtime Extraction Implementation Plan
+
+**Goal:** Move EasyEDA runtime-root discovery, class/method resolution, API inventory assembly, and authorized `api.call` execution from `dispatcher.ts` into one typed factory without changing any public method, error, or response contract.
+
+**Architecture:** Add `api-runtime.ts` as a browser-safe factory depending on the existing `api-introspection.ts`, `toolkit.ts`, and `utils.ts` contracts. The factory receives the narrow runtime-root subset of `DispatcherToolkit` and the dispatcher's existing bridge-error factory. `dispatcher.ts` retains method routing and all domain operations, but binds the factory's four functions during `createDispatcher()`.
+
+## Constraints
+
+- Preserve root precedence: `eda` → `EDA` → `api` → `globalThis`.
+- Re-read toolkit roots on every call so late runtime availability remains supported.
+- Preserve lowercase/uppercase EasyEDA class variants and method receiver binding.
+- Preserve `METHOD_NOT_FOUND` and `UNAUTHORIZED` error metadata and messages.
+- Preserve inventory normalization, filtering, sorting, deduplication, and response shape.
+- Preserve all 67 public methods and the package size budget.
+- Do not introduce a new EasyEDA capability.
+
+## Task 1 — Lock the runtime contract
+
+- [x] Add focused tests for root precedence, dynamic roots, receiver binding, class variants, first-value reads, inventory deduplication/filtering, authorized calls, normalization, and bounded errors.
+- [x] Run the focused test before implementation and record the expected module-not-found RED.
+- [x] Confirm existing dispatcher integration tests remain green.
+
+## Task 2 — Extract the typed runtime factory
+
+- [x] Add `easyeda-bridge-extension/src/api-runtime.ts`.
+- [x] Export a typed `ApiRuntime` interface and `createApiRuntime()` factory.
+- [x] Move `getApiCandidates`, `callFirst`, `readFirstPath`, `inspectApiInventory`, and `callAllowedApi` behavior into the factory.
+- [x] Bind factory functions in `createDispatcher()` without changing call sites or routing.
+- [x] Remove dispatcher imports used only by the extracted runtime.
+
+## Task 3 — Prove parity
+
+- [x] Run focused runtime and dispatcher tests.
+- [x] Reach full branch/line coverage for the extracted module.
+- [x] Run method-list parity and extension size-budget checks.
+- [x] Compare dispatcher source and built package sizes with `main`.
+- [x] Run full `pnpm verify`.
+- [x] Record final evidence here before opening the PR.
+
+## Execution evidence
+
+- TDD RED: the focused runtime test failed with module-not-found before `src/api-runtime.ts` existed.
+- Pre-extraction baseline: the API-introspection and dispatcher suites passed 98/98 tests; extension typecheck passed.
+- Focused parity: 6 API-runtime, 9 API-introspection, and 89 dispatcher tests pass (104 total).
+- Extracted-module coverage: 100% statements, branches, functions, and lines (`LF=51`, `LH=51`, `BRF=25`, `BRH=25`).
+- Public method contract: all 67 sorted bridge methods remain unchanged; method-list parity passes.
+- Dispatcher source size: 4,878 lines on `main` → 4,760 lines after extraction (-118).
+- Built dispatcher bundle: 151,841 bytes on `main` → 152,566 bytes (+725 bytes, approximately +0.48%).
+- Packaged extension: 160,594 bytes on `main` → 160,951 bytes (+357 bytes, approximately +0.22%); the size budget passes.
+- Full extension suite: 11 files / 159 tests pass.
+- Full server suite: 150 files / 1,740 tests pass.
+- Full `pnpm verify` passes Node.js/pnpm preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, server and extension tests, both builds, extension packaging/checksums, metadata alignment, generated compatibility validation, and VitePress documentation.

--- a/easyeda-bridge-extension/src/api-runtime.ts
+++ b/easyeda-bridge-extension/src/api-runtime.ts
@@ -1,0 +1,160 @@
+import {
+  getFunctionNames,
+  isAllowedApiClassName,
+  isAllowedApiPath,
+  normalizeApiClassName,
+  normalizeValue,
+  readMember,
+  withClassNameVariants,
+} from './api-introspection.js';
+import type { DispatcherToolkit } from './toolkit.js';
+import { isRecord, readPath, readPathParent, type JsonValue } from './utils.js';
+
+export type BridgeErrorFactory = (
+  code: string,
+  message: string,
+  suggestion: string,
+  data?: unknown,
+) => Error;
+
+type ApiRootToolkit = Pick<DispatcherToolkit, 'getEda' | 'getEDA' | 'getApi'>;
+
+type ApiCandidate = {
+  name: string;
+  root: unknown;
+};
+
+export interface ApiRuntime {
+  callFirst(paths: readonly string[], ...args: unknown[]): Promise<unknown>;
+  readFirstPath<T>(paths: readonly string[]): T | undefined;
+  inspectApiInventory(filter?: string): JsonValue;
+  callAllowedApi(path: string, args: readonly unknown[]): Promise<unknown>;
+}
+
+export function createApiRuntime(
+  toolkit: ApiRootToolkit,
+  createBridgeError: BridgeErrorFactory,
+  globalRoot: unknown = globalThis,
+): ApiRuntime {
+  function getApiCandidates(): ApiCandidate[] {
+    const candidates: ApiCandidate[] = [];
+    const edaObj = toolkit.getEda();
+    if (edaObj) candidates.push({ name: 'eda', root: edaObj });
+    const EDAObj = toolkit.getEDA();
+    if (EDAObj) candidates.push({ name: 'EDA', root: EDAObj });
+    const apiObj = toolkit.getApi();
+    if (apiObj) candidates.push({ name: 'api', root: apiObj });
+    candidates.push({ name: 'globalThis', root: globalRoot });
+    return candidates;
+  }
+
+  async function callFirst(paths: readonly string[], ...args: unknown[]): Promise<unknown> {
+    const allPaths = withClassNameVariants(paths);
+
+    for (const candidate of getApiCandidates()) {
+      for (const path of allPaths) {
+        const fn = readPath<unknown>(candidate.root, path);
+        if (typeof fn === 'function') {
+          return await fn.apply(readPathParent(candidate.root, path), args);
+        }
+      }
+    }
+
+    throw createBridgeError(
+      'METHOD_NOT_FOUND',
+      `No EasyEDA API implementation found for ${paths.join(' or ')}`,
+      'Verify the bridge extension supports the installed EasyEDA Pro version.',
+    );
+  }
+
+  function readFirstPath<T>(paths: readonly string[]): T | undefined {
+    for (const candidate of getApiCandidates()) {
+      for (const path of withClassNameVariants(paths)) {
+        const value = readPath<T>(candidate.root, path);
+        if (value !== undefined) return value;
+      }
+    }
+    return undefined;
+  }
+
+  function inspectApiInventory(filter?: string): JsonValue {
+    const normalizedFilter = filter?.toLowerCase().trim();
+    const classMap = new Map<
+      string,
+      {
+        className: string;
+        runtimePaths: string[];
+        methods: string[];
+      }
+    >();
+
+    for (const candidate of getApiCandidates()) {
+      const root = candidate.root;
+      if (!isRecord(root)) continue;
+
+      for (const key of Object.getOwnPropertyNames(root)) {
+        const className = normalizeApiClassName(key);
+        if (!isAllowedApiClassName(className)) continue;
+        if (normalizedFilter && !className.toLowerCase().includes(normalizedFilter)) continue;
+
+        const value = readMember(root, key);
+        const methods = getFunctionNames(value).sort((a, b) => a.localeCompare(b));
+        const existing = classMap.get(className) ?? {
+          className,
+          runtimePaths: [],
+          methods: [],
+        };
+        existing.runtimePaths.push(`${candidate.name}.${key}`);
+        existing.methods = Array.from(new Set([...existing.methods, ...methods])).sort((a, b) =>
+          a.localeCompare(b),
+        );
+        classMap.set(className, existing);
+      }
+    }
+
+    const classes = Array.from(classMap.values()).sort((a, b) =>
+      a.className.localeCompare(b.className),
+    );
+    return {
+      classes: classes as unknown as JsonValue,
+      total: classes.length,
+    };
+  }
+
+  async function callAllowedApi(path: string, args: readonly unknown[]): Promise<unknown> {
+    if (!isAllowedApiPath(path)) {
+      throw createBridgeError(
+        'UNAUTHORIZED',
+        `API path is not allowed: ${path}`,
+        'Use a documented EasyEDA API class method such as SCH_PrimitiveWire.getAll.',
+      );
+    }
+
+    for (const candidate of getApiCandidates()) {
+      for (const candidatePath of withClassNameVariants([path])) {
+        const fn = readPath<unknown>(candidate.root, candidatePath);
+        if (typeof fn !== 'function') continue;
+        const parent = readPathParent(candidate.root, candidatePath);
+        const result = await fn.apply(parent, args);
+        return {
+          path,
+          resolvedPath: `${candidate.name}.${candidatePath}`,
+          result: normalizeValue(result, 5),
+        };
+      }
+    }
+
+    throw createBridgeError(
+      'METHOD_NOT_FOUND',
+      `No EasyEDA API implementation found for ${path}`,
+      'Check easyeda_api_inventory for runtime-supported classes and methods.',
+    );
+  }
+
+  return {
+    callFirst,
+    readFirstPath,
+    inspectApiInventory,
+    callAllowedApi,
+  };
+}

--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -6,28 +6,17 @@
 // injected DispatcherToolkit (see toolkit.ts) so the identical code works both
 // baked into the extension script scope and eval'd via AsyncFunction.
 
+import { createApiRuntime, type ApiRuntime } from './api-runtime.js';
 import {
   compactPrimitiveSummary,
-  getFunctionNames,
-  isAllowedApiClassName,
-  isAllowedApiPath,
-  normalizeApiClassName,
   normalizeStandalone,
   normalizeValue,
   readMember,
   readStateValue,
-  withClassNameVariants,
 } from './api-introspection.js';
 import { normalizeBinaryResult, type BinaryResultPayload } from './binary-result.js';
 import type { Dispatcher, DispatcherToolkit } from './toolkit.js';
-import {
-  isRecord,
-  log,
-  logRecoverableError,
-  readPath,
-  readPathParent,
-  type JsonValue,
-} from './utils.js';
+import { isRecord, log, logRecoverableError, readPath, type JsonValue } from './utils.js';
 
 // Injected at build time via esbuild --define; identifies this bundle build.
 declare const __MCP_DISPATCHER_BUILD_ID__: string | undefined;
@@ -117,52 +106,15 @@ const METHOD_LIST: readonly string[] = [
 // The toolkit for the active dispatcher instance. Set by createDispatcher();
 // a hot-swapped bundle is a fresh module scope, so instances never share it.
 let tk: DispatcherToolkit;
+let callFirst: ApiRuntime['callFirst'];
+let readFirstPath: ApiRuntime['readFirstPath'];
+let inspectApiInventory: ApiRuntime['inspectApiInventory'];
+let callAllowedApi: ApiRuntime['callAllowedApi'];
 
 function newBridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
   const error = new Error(message);
   Object.assign(error, { code, suggestion, data });
   return error;
-}
-
-function getApiCandidates(): Array<{ name: string; root: unknown }> {
-  const candidates: Array<{ name: string; root: unknown }> = [];
-  const edaObj = tk.getEda();
-  if (edaObj) candidates.push({ name: 'eda', root: edaObj });
-  const EDAObj = tk.getEDA();
-  if (EDAObj) candidates.push({ name: 'EDA', root: EDAObj });
-  const apiObj = tk.getApi();
-  if (apiObj) candidates.push({ name: 'api', root: apiObj });
-  candidates.push({ name: 'globalThis', root: globalThis });
-  return candidates;
-}
-
-async function callFirst(paths: string[], ...args: unknown[]): Promise<unknown> {
-  const allPaths = withClassNameVariants(paths);
-
-  for (const candidate of getApiCandidates()) {
-    for (const path of allPaths) {
-      const fn = readPath<unknown>(candidate.root, path);
-      if (typeof fn === 'function') {
-        return await fn.apply(readPathParent(candidate.root, path), args);
-      }
-    }
-  }
-
-  throw newBridgeError(
-    'METHOD_NOT_FOUND',
-    `No EasyEDA API implementation found for ${paths.join(' or ')}`,
-    'Verify the bridge extension supports the installed EasyEDA Pro version.',
-  );
-}
-
-function readFirstPath<T>(paths: string[]): T | undefined {
-  for (const candidate of getApiCandidates()) {
-    for (const path of withClassNameVariants(paths)) {
-      const value = readPath<T>(candidate.root, path);
-      if (value !== undefined) return value;
-    }
-  }
-  return undefined;
 }
 
 function nativeScalarString(value: unknown): string {
@@ -1008,80 +960,6 @@ async function addCoordinateFallbackNets(
       logRecoverableError('failed to inspect schematic component pins for coordinate nets', error);
     }
   }
-}
-
-function inspectApiInventory(filter?: string): JsonValue {
-  const normalizedFilter = filter?.toLowerCase().trim();
-  const classMap = new Map<
-    string,
-    {
-      className: string;
-      runtimePaths: string[];
-      methods: string[];
-    }
-  >();
-
-  for (const candidate of getApiCandidates()) {
-    const root = candidate.root;
-    if (!isRecord(root)) continue;
-
-    for (const key of Object.getOwnPropertyNames(root)) {
-      const className = normalizeApiClassName(key);
-      if (!isAllowedApiClassName(className)) continue;
-      if (normalizedFilter && !className.toLowerCase().includes(normalizedFilter)) continue;
-
-      const value = readMember(root, key);
-      const methods = getFunctionNames(value).sort((a, b) => a.localeCompare(b));
-      const existing = classMap.get(className) ?? {
-        className,
-        runtimePaths: [],
-        methods: [],
-      };
-      existing.runtimePaths.push(`${candidate.name}.${key}`);
-      existing.methods = Array.from(new Set([...existing.methods, ...methods])).sort((a, b) =>
-        a.localeCompare(b),
-      );
-      classMap.set(className, existing);
-    }
-  }
-
-  const classes = Array.from(classMap.values()).sort((a, b) =>
-    a.className.localeCompare(b.className),
-  );
-  return {
-    classes: classes as unknown as JsonValue,
-    total: classes.length,
-  };
-}
-
-async function callAllowedApi(path: string, args: unknown[]): Promise<unknown> {
-  if (!isAllowedApiPath(path)) {
-    throw newBridgeError(
-      'UNAUTHORIZED',
-      `API path is not allowed: ${path}`,
-      'Use a documented EasyEDA API class method such as SCH_PrimitiveWire.getAll.',
-    );
-  }
-
-  for (const candidate of getApiCandidates()) {
-    for (const candidatePath of withClassNameVariants([path])) {
-      const fn = readPath<unknown>(candidate.root, candidatePath);
-      if (typeof fn !== 'function') continue;
-      const parent = readPathParent(candidate.root, candidatePath);
-      const result = await fn.apply(parent, args);
-      return {
-        path,
-        resolvedPath: `${candidate.name}.${candidatePath}`,
-        result: normalizeValue(result, 5),
-      };
-    }
-  }
-
-  throw newBridgeError(
-    'METHOD_NOT_FOUND',
-    `No EasyEDA API implementation found for ${path}`,
-    'Check easyeda_api_inventory for runtime-supported classes and methods.',
-  );
 }
 
 function readOtherPropertyValue(
@@ -4868,6 +4746,10 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
 
 export function createDispatcher(toolkit: DispatcherToolkit): Dispatcher {
   tk = toolkit;
+  ({ callFirst, readFirstPath, inspectApiInventory, callAllowedApi } = createApiRuntime(
+    toolkit,
+    newBridgeError,
+  ));
   textAlignModeCache.clear();
   log(`dispatcher initialized (build ${BUILD_ID}, ${METHOD_LIST.length} methods)`);
   return {

--- a/easyeda-bridge-extension/tests/api-runtime.test.ts
+++ b/easyeda-bridge-extension/tests/api-runtime.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createApiRuntime, type BridgeErrorFactory } from '../src/api-runtime.js';
+import type { DispatcherToolkit } from '../src/toolkit.js';
+
+function bridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
+  return Object.assign(new Error(message), { code, suggestion, data });
+}
+
+function mutableRoots() {
+  let eda: unknown;
+  let EDA: unknown;
+  let api: unknown;
+  const toolkit: Pick<DispatcherToolkit, 'getEda' | 'getEDA' | 'getApi'> = {
+    getEda: () => eda,
+    getEDA: () => EDA,
+    getApi: () => api,
+  };
+  return {
+    toolkit,
+    setEda: (value: unknown) => {
+      eda = value;
+    },
+    setEDA: (value: unknown) => {
+      EDA = value;
+    },
+    setApi: (value: unknown) => {
+      api = value;
+    },
+  };
+}
+
+describe('EasyEDA API runtime', () => {
+  it('re-reads roots, preserves precedence, class variants, and method receivers', async () => {
+    const roots = mutableRoots();
+    const globalRoot = {
+      SCH_Service: {
+        source: 'global',
+        identify() {
+          return this.source;
+        },
+      },
+    };
+    const runtime = createApiRuntime(roots.toolkit, bridgeError, globalRoot);
+
+    await expect(runtime.callFirst(['sch_Service.identify'])).resolves.toBe('global');
+
+    roots.setApi({ SCH_Service: { identify: () => 'api' } });
+    roots.setEDA({ SCH_Service: { identify: () => 'EDA' } });
+    roots.setEda({ SCH_Service: { identify: () => 'eda' } });
+
+    await expect(runtime.callFirst(['SCH_Service.identify'])).resolves.toBe('eda');
+  });
+
+  it('reads the first defined class value and keeps null as a resolved value', () => {
+    const roots = mutableRoots();
+    roots.setEda({ SCH_Missing: undefined, SCH_Nullable: null });
+    roots.setEDA({ SCH_Missing: { source: 'EDA' }, SCH_Nullable: { source: 'EDA' } });
+    const runtime = createApiRuntime(roots.toolkit, bridgeError, {});
+
+    expect(runtime.readFirstPath<{ source: string }>(['SCH_Missing'])).toEqual({ source: 'EDA' });
+    expect(runtime.readFirstPath(['SCH_Nullable'])).toBeNull();
+    expect(runtime.readFirstPath(['SCH_Absent'])).toBeUndefined();
+  });
+
+  it('ignores unavailable and non-record runtime roots in inventory', () => {
+    const roots = mutableRoots();
+    roots.setEda('not-an-object');
+    roots.setEDA(0);
+    roots.setApi(false);
+    const runtime = createApiRuntime(roots.toolkit, bridgeError, null);
+
+    expect(runtime.inspectApiInventory()).toEqual({ classes: [], total: 0 });
+  });
+
+  it('builds a normalized, filtered, deduplicated API inventory', () => {
+    const roots = mutableRoots();
+    roots.setEda({
+      sch_PrimitiveWire: {
+        create() {},
+        getAll() {},
+      },
+      SYS_Shell: { exec() {} },
+    });
+    roots.setEDA({
+      SCH_PrimitiveWire: {
+        get() {},
+        getAll() {},
+      },
+      PCB_PrimitiveVia: { getAll() {} },
+    });
+    const runtime = createApiRuntime(roots.toolkit, bridgeError, {});
+
+    expect(runtime.inspectApiInventory(' primitivewire ')).toEqual({
+      classes: [
+        {
+          className: 'SCH_PrimitiveWire',
+          runtimePaths: ['eda.sch_PrimitiveWire', 'EDA.SCH_PrimitiveWire'],
+          methods: ['create', 'get', 'getAll'],
+        },
+      ],
+      total: 1,
+    });
+    expect(runtime.inspectApiInventory()).toMatchObject({ total: 2 });
+  });
+
+  it('authorizes API calls, binds the receiver, and normalizes the result', async () => {
+    const roots = mutableRoots();
+    roots.setEda({
+      SCH_Service: {
+        value: 7,
+        read(extra: number) {
+          return { total: this.value + extra, getState_Name: () => 'service' };
+        },
+      },
+    });
+    const runtime = createApiRuntime(roots.toolkit, bridgeError, {});
+
+    await expect(runtime.callAllowedApi('sch_Service.read', [5])).resolves.toEqual({
+      path: 'sch_Service.read',
+      resolvedPath: 'eda.SCH_Service.read',
+      result: expect.objectContaining({
+        total: 12,
+        state: { Name: 'service' },
+        __methods: ['getState_Name'],
+      }),
+    });
+  });
+
+  it('returns bounded bridge errors for denied and missing methods', async () => {
+    const roots = mutableRoots();
+    const errorFactory = vi.fn<BridgeErrorFactory>(bridgeError);
+    const runtime = createApiRuntime(roots.toolkit, errorFactory, {});
+
+    await expect(runtime.callAllowedApi('SYS_Shell.exec', [])).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+      message: 'API path is not allowed: SYS_Shell.exec',
+    });
+    await expect(runtime.callAllowedApi('SCH_Service.missing', [])).rejects.toMatchObject({
+      code: 'METHOD_NOT_FOUND',
+      message: 'No EasyEDA API implementation found for SCH_Service.missing',
+    });
+    await expect(
+      runtime.callFirst(['SCH_Service.first', 'SCH_Service.second']),
+    ).rejects.toMatchObject({
+      code: 'METHOD_NOT_FOUND',
+      message: 'No EasyEDA API implementation found for SCH_Service.first or SCH_Service.second',
+    });
+    expect(errorFactory).toHaveBeenCalledTimes(3);
+  });
+});


### PR DESCRIPTION
## Summary

Extract EasyEDA runtime-root discovery, class/method resolution, API inventory assembly, and authorized `api.call` execution from the extension dispatcher into a typed `api-runtime.ts` factory.

This is the second bounded, behavior-preserving decomposition slice under #339. It does not close the parent issue and does not add or remove any public bridge capability.

## Contract parity

- Preserves runtime root precedence: `eda` → `EDA` → `api` → `globalThis`.
- Re-reads toolkit roots on every call so late EasyEDA runtime availability still works.
- Preserves lowercase/uppercase class-name variants and method receiver binding.
- Preserves first-defined value semantics, including `null` as a resolved value.
- Preserves API inventory filtering, allowlisting, normalization, deduplication, sorting, and response shape.
- Preserves `UNAUTHORIZED` and `METHOD_NOT_FOUND` codes, messages, suggestions, and call-result normalization.
- Keeps all 67 sorted public extension methods unchanged.

## Objective decomposition evidence

- `dispatcher.ts`: 4,878 lines on `main` → 4,760 lines (-118).
- Built dispatcher bundle: 151,841 bytes → 152,566 bytes (+725 bytes, approximately +0.48%).
- Packaged extension: 160,594 bytes → 160,951 bytes (+357 bytes, approximately +0.22%).
- Method-list parity and extension size-budget checks pass.

## Tests

- Added 6 focused API runtime contract tests covering root precedence, dynamic roots, class variants, receiver binding, first-value reads, non-record roots, inventory filtering/deduplication, authorized calls, normalization, and bounded errors.
- Extracted module coverage: 100% statements, branches, functions, and lines (`LF=51`, `LH=51`, `BRF=25`, `BRH=25`).
- Focused runtime/introspection/dispatcher parity: 104 tests passed.
- Extension suite: 11 files / 159 tests passed.
- Server suite: 150 files / 1,740 tests passed.
- Full `pnpm verify` passed runtime preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, tests, builds, extension packaging/checksums, metadata alignment, generated compatibility validation, and VitePress documentation.

## Follow-up

Further dispatcher domains will continue as separately reviewable, parity-tested PRs under #339.
