### PR TITLE
refactor(extension): extract canvas operations

### DIFF
--- a/docs/superpowers/plans/2026-07-23-dispatcher-canvas-domain-extraction.md
+++ b/docs/superpowers/plans/2026-07-23-dispatcher-canvas-domain-extraction.md
@@ -40,12 +40,13 @@
 
 - TDD RED: the focused canvas test failed with module-not-found before `src/canvas-operations.ts` existed.
 - Pre-extraction baseline: all 89 dispatcher integration tests and extension typecheck passed.
-- Focused parity: 7 canvas-domain and 89 dispatcher tests pass (96 total).
+- Focused parity: 7 canvas-domain and 90 dispatcher tests pass (97 total).
 - Extracted-module coverage: 100% statements, branches, functions, and lines (`LF=33`, `LH=33`, `BRF=15`, `BRH=15`).
+- Codecov follow-up: the initial patch report found the `canvas.capture` and `canvas.locate` dispatcher delegates uncovered; a dispatcher integration contract now executes both paths and verifies binary normalization plus locate argument forwarding (`DA:4487=1`, `DA:4489=3`, `DA:4491=1`).
 - Public method contract: all 67 sorted bridge methods remain unchanged; method-list parity passes.
 - Dispatcher source size: 4,760 lines on `main` → 4,679 lines after extraction (-81).
 - Built dispatcher bundle: 152,566 bytes on `main` → 153,348 bytes (+782 bytes, approximately +0.51%).
 - Packaged extension: 160,951 bytes on `main` → 161,147 bytes (+196 bytes, approximately +0.12%); the size budget passes.
-- Full extension suite: 12 files / 166 tests pass.
+- Full extension suite: 12 files / 167 tests pass.
 - Full server suite: 150 files / 1,740 tests pass.
 - Full `pnpm verify` passes Node.js/pnpm preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, server and extension tests, both builds, extension packaging/checksums, metadata alignment, generated compatibility validation, and VitePress documentation.

--- a/docs/superpowers/plans/2026-07-23-dispatcher-canvas-domain-extraction.md
+++ b/docs/superpowers/plans/2026-07-23-dispatcher-canvas-domain-extraction.md
@@ -1,0 +1,51 @@
+# Dispatcher Canvas Domain Extraction Implementation Plan
+
+**Goal:** Move `canvas.capture`, `canvas.captureRegion`, and `canvas.locate` behind one typed canvas-operation factory without changing binary payload normalization, transport-budget enforcement, repaint timing, errors, or public method contracts.
+
+**Architecture:** Add `canvas-operations.ts` with injected `callFirst`, binary-result normalizer, bridge-error factory, and animation-frame root. The dispatcher retains the shared payload-size policy and binds the domain factory during `createDispatcher()`. Canvas switch cases become thin delegates.
+
+## Constraints
+
+- Preserve all 67 public bridge methods.
+- Keep binary payload and `BRIDGE_MAX_PAYLOAD_SIZE` safety logic in the dispatcher shared layer.
+- Preserve capture filenames, tab handling, region coordinate normalization, zero-area/finite validation, and exact errors.
+- Preserve zoom-before-capture ordering and the bounded two-frame repaint wait.
+- Preserve `canvas.locate` argument forwarding.
+- Keep package output within the repository size budget.
+
+## Task 1 — Lock the canvas contract
+
+- [x] Add focused tests for full capture, non-string tab handling, normalized region capture, invalid coordinates, zero-area bounds, rejected zoom, animation-frame settlement, bounded frame timeout, and locate forwarding.
+- [x] Run the focused test before implementation and record module-not-found RED.
+- [x] Confirm the existing 89 dispatcher integration tests remain green.
+
+## Task 2 — Extract the typed canvas factory
+
+- [x] Add `easyeda-bridge-extension/src/canvas-operations.ts`.
+- [x] Export typed dependencies and `CanvasOperations` interfaces.
+- [x] Move region normalization and repaint waiting into the module.
+- [x] Implement capture, capture-region, and locate operations with injected dependencies.
+- [x] Bind the factory in `createDispatcher()` and replace switch bodies with delegates.
+
+## Task 3 — Prove parity
+
+- [x] Reach 100% statement, branch, function, and line coverage for the new module.
+- [x] Run focused module and dispatcher tests.
+- [x] Run method-list parity and extension size-budget checks.
+- [x] Compare source, dispatcher bundle, and `.eext` sizes against `main`.
+- [x] Run full `pnpm verify`.
+- [x] Record final evidence before opening the PR.
+
+## Execution evidence
+
+- TDD RED: the focused canvas test failed with module-not-found before `src/canvas-operations.ts` existed.
+- Pre-extraction baseline: all 89 dispatcher integration tests and extension typecheck passed.
+- Focused parity: 7 canvas-domain and 89 dispatcher tests pass (96 total).
+- Extracted-module coverage: 100% statements, branches, functions, and lines (`LF=33`, `LH=33`, `BRF=15`, `BRH=15`).
+- Public method contract: all 67 sorted bridge methods remain unchanged; method-list parity passes.
+- Dispatcher source size: 4,760 lines on `main` → 4,679 lines after extraction (-81).
+- Built dispatcher bundle: 152,566 bytes on `main` → 153,348 bytes (+782 bytes, approximately +0.51%).
+- Packaged extension: 160,951 bytes on `main` → 161,147 bytes (+196 bytes, approximately +0.12%); the size budget passes.
+- Full extension suite: 12 files / 166 tests pass.
+- Full server suite: 150 files / 1,740 tests pass.
+- Full `pnpm verify` passes Node.js/pnpm preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, server and extension tests, both builds, extension packaging/checksums, metadata alignment, generated compatibility validation, and VitePress documentation.

--- a/easyeda-bridge-extension/src/canvas-operations.ts
+++ b/easyeda-bridge-extension/src/canvas-operations.ts
@@ -1,0 +1,125 @@
+import type { ApiRuntime, BridgeErrorFactory } from './api-runtime.js';
+
+export type BinaryResultNormalizer = (value: unknown, fallbackFileName: string) => Promise<unknown>;
+
+export interface CanvasAnimationRoot {
+  requestAnimationFrame?: (callback: () => void) => number;
+}
+
+export interface CanvasOperationDependencies {
+  callFirst: ApiRuntime['callFirst'];
+  normalizeBinaryResult: BinaryResultNormalizer;
+  createBridgeError: BridgeErrorFactory;
+  animationRoot?: CanvasAnimationRoot;
+}
+
+export interface CanvasOperations {
+  capture(params: Record<string, unknown>): Promise<unknown>;
+  captureRegion(params: Record<string, unknown>): Promise<unknown>;
+  locate(params: Record<string, unknown>): Promise<unknown>;
+}
+
+interface CanvasRegion {
+  left: number;
+  right: number;
+  top: number;
+  bottom: number;
+}
+
+export function createCanvasOperations({
+  callFirst,
+  normalizeBinaryResult,
+  createBridgeError,
+  animationRoot = globalThis,
+}: CanvasOperationDependencies): CanvasOperations {
+  function normalizeCanvasRegion(value: CanvasRegion): CanvasRegion {
+    const coordinates = [value.left, value.right, value.top, value.bottom];
+    if (!coordinates.every(Number.isFinite)) {
+      throw createBridgeError(
+        'INVALID_PARAMS',
+        'Capture region coordinates must be finite numbers.',
+        'Provide finite left, right, top, and bottom document coordinates.',
+      );
+    }
+
+    const region = {
+      left: Math.min(value.left, value.right),
+      right: Math.max(value.left, value.right),
+      top: Math.max(value.top, value.bottom),
+      bottom: Math.min(value.top, value.bottom),
+    };
+    if (region.left === region.right || region.top === region.bottom) {
+      throw createBridgeError(
+        'INVALID_PARAMS',
+        'Capture region must have non-zero width and height.',
+        'Expand the bounds around the component before capturing it.',
+      );
+    }
+    return region;
+  }
+
+  async function waitForCanvasPaint(): Promise<void> {
+    const requestFrame = animationRoot.requestAnimationFrame;
+    if (typeof requestFrame === 'function') {
+      await new Promise<void>((resolve) => {
+        let settled = false;
+        const finish = () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timeout);
+          resolve();
+        };
+        // A minimized/background Electron window can suspend animation frames.
+        // Keep capture bounded instead of waiting indefinitely for repaint.
+        const timeout = setTimeout(finish, 75);
+        requestFrame.call(animationRoot, () => requestFrame.call(animationRoot, finish));
+      });
+      return;
+    }
+
+    // Vitest/Node and older extension shells may not expose requestAnimationFrame.
+    // A macrotask still lets an asynchronously scheduled canvas update settle.
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  }
+
+  async function capture(params: Record<string, unknown>): Promise<unknown> {
+    const tabId = typeof params.tabId === 'string' ? params.tabId : undefined;
+    const blob = await callFirst(['DMT_EditorControl.getCurrentRenderedAreaImage'], tabId);
+    return normalizeBinaryResult(blob, 'capture.png');
+  }
+
+  async function captureRegion(params: Record<string, unknown>): Promise<unknown> {
+    const region = normalizeCanvasRegion(params as unknown as CanvasRegion);
+    const tabId = params.tabId;
+    const zoomed = await callFirst(
+      ['DMT_EditorControl.zoomToRegion'],
+      region.left,
+      region.right,
+      region.top,
+      region.bottom,
+      tabId,
+    );
+    if (zoomed === false) {
+      throw createBridgeError(
+        'EASYEDA_API_ERROR',
+        'EasyEDA could not zoom to the requested capture region.',
+        'Verify that the target tab is open and the region uses document/canvas coordinates.',
+      );
+    }
+    await waitForCanvasPaint();
+    const blob = await callFirst(['DMT_EditorControl.getCurrentRenderedAreaImage'], tabId);
+    return normalizeBinaryResult(blob, 'capture-region.png');
+  }
+
+  async function locate(params: Record<string, unknown>): Promise<unknown> {
+    return callFirst(
+      ['DMT_EditorControl.zoomTo'],
+      params.x,
+      params.y,
+      params.scaleRatio,
+      params.tabId,
+    );
+  }
+
+  return { capture, captureRegion, locate };
+}

--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -15,6 +15,7 @@ import {
   readStateValue,
 } from './api-introspection.js';
 import { normalizeBinaryResult, type BinaryResultPayload } from './binary-result.js';
+import { createCanvasOperations, type CanvasOperations } from './canvas-operations.js';
 import type { Dispatcher, DispatcherToolkit } from './toolkit.js';
 import { isRecord, log, logRecoverableError, readPath, type JsonValue } from './utils.js';
 
@@ -110,6 +111,7 @@ let callFirst: ApiRuntime['callFirst'];
 let readFirstPath: ApiRuntime['readFirstPath'];
 let inspectApiInventory: ApiRuntime['inspectApiInventory'];
 let callAllowedApi: ApiRuntime['callAllowedApi'];
+let canvasOperations: CanvasOperations;
 
 function newBridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
   const error = new Error(message);
@@ -531,64 +533,6 @@ async function normalizeBinaryResultSafely(
     }
   }
   return normalized;
-}
-
-interface CanvasRegion {
-  left: number;
-  right: number;
-  top: number;
-  bottom: number;
-}
-
-function normalizeCanvasRegion(value: CanvasRegion): CanvasRegion {
-  const coordinates = [value.left, value.right, value.top, value.bottom];
-  if (!coordinates.every(Number.isFinite)) {
-    throw newBridgeError(
-      'INVALID_PARAMS',
-      'Capture region coordinates must be finite numbers.',
-      'Provide finite left, right, top, and bottom document coordinates.',
-    );
-  }
-
-  const region = {
-    left: Math.min(value.left, value.right),
-    right: Math.max(value.left, value.right),
-    top: Math.max(value.top, value.bottom),
-    bottom: Math.min(value.top, value.bottom),
-  };
-  if (region.left === region.right || region.top === region.bottom) {
-    throw newBridgeError(
-      'INVALID_PARAMS',
-      'Capture region must have non-zero width and height.',
-      'Expand the bounds around the component before capturing it.',
-    );
-  }
-  return region;
-}
-
-async function waitForCanvasPaint(): Promise<void> {
-  const requestFrame = (globalThis as { requestAnimationFrame?: (callback: () => void) => number })
-    .requestAnimationFrame;
-  if (typeof requestFrame === 'function') {
-    await new Promise<void>((resolve) => {
-      let settled = false;
-      const finish = () => {
-        if (settled) return;
-        settled = true;
-        clearTimeout(timeout);
-        resolve();
-      };
-      // A minimized/background Electron window can suspend animation frames.
-      // Keep capture bounded instead of waiting indefinitely for repaint.
-      const timeout = setTimeout(finish, 75);
-      requestFrame.call(globalThis, () => requestFrame.call(globalThis, finish));
-    });
-    return;
-  }
-
-  // Vitest/Node and older extension shells may not expose requestAnimationFrame.
-  // A macrotask still lets an asynchronously scheduled canvas update settle.
-  await new Promise<void>((resolve) => setTimeout(resolve, 0));
 }
 
 function summarizeWirePrimitive(wire: unknown): Record<string, JsonValue | undefined> {
@@ -4539,42 +4483,12 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
         ),
         `netlist.${typeof params.format === 'string' ? params.format : 'txt'}`,
       );
-    case 'canvas.capture': {
-      const tabId = typeof params.tabId === 'string' ? params.tabId : undefined;
-      const blob = await callFirst(['DMT_EditorControl.getCurrentRenderedAreaImage'], tabId);
-      return normalizeBinaryResultSafely(blob, 'capture.png');
-    }
-    case 'canvas.captureRegion': {
-      const { tabId } = params as { tabId?: string };
-      const region = normalizeCanvasRegion(params as unknown as CanvasRegion);
-      const zoomed = await callFirst(
-        ['DMT_EditorControl.zoomToRegion'],
-        region.left,
-        region.right,
-        region.top,
-        region.bottom,
-        tabId,
-      );
-      if (zoomed === false) {
-        throw newBridgeError(
-          'EASYEDA_API_ERROR',
-          'EasyEDA could not zoom to the requested capture region.',
-          'Verify that the target tab is open and the region uses document/canvas coordinates.',
-        );
-      }
-      await waitForCanvasPaint();
-      const blob = await callFirst(['DMT_EditorControl.getCurrentRenderedAreaImage'], tabId);
-      return normalizeBinaryResultSafely(blob, 'capture-region.png');
-    }
-    case 'canvas.locate': {
-      const { x, y, scaleRatio, tabId } = params as {
-        x?: number;
-        y?: number;
-        scaleRatio?: number;
-        tabId?: string;
-      };
-      return callFirst(['DMT_EditorControl.zoomTo'], x, y, scaleRatio, tabId);
-    }
+    case 'canvas.capture':
+      return canvasOperations.capture(params);
+    case 'canvas.captureRegion':
+      return canvasOperations.captureRegion(params);
+    case 'canvas.locate':
+      return canvasOperations.locate(params);
     case 'library.getDeviceByLcscId': {
       const lcscId = String(params.lcscId ?? '');
       const libraryUuid = typeof params.libraryUuid === 'string' ? params.libraryUuid : undefined;
@@ -4750,6 +4664,11 @@ export function createDispatcher(toolkit: DispatcherToolkit): Dispatcher {
     toolkit,
     newBridgeError,
   ));
+  canvasOperations = createCanvasOperations({
+    callFirst,
+    normalizeBinaryResult: normalizeBinaryResultSafely,
+    createBridgeError: newBridgeError,
+  });
   textAlignModeCache.clear();
   log(`dispatcher initialized (build ${BUILD_ID}, ${METHOD_LIST.length} methods)`);
   return {

--- a/easyeda-bridge-extension/tests/canvas-operations.test.ts
+++ b/easyeda-bridge-extension/tests/canvas-operations.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createCanvasOperations,
+  type CanvasOperationDependencies,
+} from '../src/canvas-operations.js';
+
+function bridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
+  return Object.assign(new Error(message), { code, suggestion, data });
+}
+
+function makeOperations(
+  overrides: Partial<CanvasOperationDependencies> = {},
+): ReturnType<typeof createCanvasOperations> {
+  return createCanvasOperations({
+    callFirst: vi.fn(async () => new Blob(['png'], { type: 'image/png' })),
+    normalizeBinaryResult: vi.fn(async (value, fileName) => ({ value, fileName })),
+    createBridgeError: bridgeError,
+    animationRoot: {},
+    ...overrides,
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('canvas operations', () => {
+  it('captures the current area and normalizes string/non-string tab ids', async () => {
+    const callFirst = vi.fn(async () => 'blob');
+    const normalizeBinaryResult = vi.fn(async (value, fileName) => ({ value, fileName }));
+    const operations = makeOperations({ callFirst, normalizeBinaryResult });
+
+    await expect(operations.capture({ tabId: 'tab-1' })).resolves.toEqual({
+      value: 'blob',
+      fileName: 'capture.png',
+    });
+    await operations.capture({ tabId: 7 });
+
+    expect(callFirst).toHaveBeenNthCalledWith(
+      1,
+      ['DMT_EditorControl.getCurrentRenderedAreaImage'],
+      'tab-1',
+    );
+    expect(callFirst).toHaveBeenNthCalledWith(
+      2,
+      ['DMT_EditorControl.getCurrentRenderedAreaImage'],
+      undefined,
+    );
+    expect(normalizeBinaryResult).toHaveBeenCalledWith('blob', 'capture.png');
+  });
+
+  it('normalizes region bounds, waits a macrotask, then captures', async () => {
+    vi.useFakeTimers();
+    const callOrder: string[] = [];
+    const callFirst = vi.fn(async (paths: readonly string[]) => {
+      if (paths[0] === 'DMT_EditorControl.zoomToRegion') {
+        callOrder.push('zoom');
+        return true;
+      }
+      callOrder.push('capture');
+      return 'region-blob';
+    });
+    const operations = makeOperations({ callFirst });
+
+    const resultPromise = operations.captureRegion({
+      left: 100,
+      right: 0,
+      top: 0,
+      bottom: 50,
+      tabId: 'tab-1',
+    });
+    await vi.runAllTimersAsync();
+    await expect(resultPromise).resolves.toEqual({
+      value: 'region-blob',
+      fileName: 'capture-region.png',
+    });
+
+    expect(callFirst).toHaveBeenNthCalledWith(
+      1,
+      ['DMT_EditorControl.zoomToRegion'],
+      0,
+      100,
+      50,
+      0,
+      'tab-1',
+    );
+    expect(callFirst).toHaveBeenNthCalledWith(
+      2,
+      ['DMT_EditorControl.getCurrentRenderedAreaImage'],
+      'tab-1',
+    );
+    expect(callOrder).toEqual(['zoom', 'capture']);
+  });
+
+  it('rejects non-finite and zero-area regions before touching EasyEDA', async () => {
+    const callFirst = vi.fn(async () => true);
+    const operations = makeOperations({ callFirst });
+
+    await expect(
+      operations.captureRegion({ left: Number.NaN, right: 10, top: 10, bottom: 0 }),
+    ).rejects.toMatchObject({
+      code: 'INVALID_PARAMS',
+      message: 'Capture region coordinates must be finite numbers.',
+    });
+    await expect(
+      operations.captureRegion({ left: 10, right: 10, top: 20, bottom: 0 }),
+    ).rejects.toMatchObject({
+      code: 'INVALID_PARAMS',
+      message: 'Capture region must have non-zero width and height.',
+    });
+    await expect(
+      operations.captureRegion({ left: 0, right: 10, top: 5, bottom: 5 }),
+    ).rejects.toMatchObject({ code: 'INVALID_PARAMS' });
+    expect(callFirst).not.toHaveBeenCalled();
+  });
+
+  it('does not capture when EasyEDA rejects the region zoom', async () => {
+    const callFirst = vi.fn(async () => false);
+    const normalizeBinaryResult = vi.fn(async () => undefined);
+    const operations = makeOperations({ callFirst, normalizeBinaryResult });
+
+    await expect(
+      operations.captureRegion({ left: 0, right: 10, top: 10, bottom: 0 }),
+    ).rejects.toMatchObject({
+      code: 'EASYEDA_API_ERROR',
+      message: 'EasyEDA could not zoom to the requested capture region.',
+    });
+    expect(callFirst).toHaveBeenCalledOnce();
+    expect(normalizeBinaryResult).not.toHaveBeenCalled();
+  });
+
+  it('waits for two animation frames before capture', async () => {
+    const callbacks: Array<() => void> = [];
+    const requestAnimationFrame = vi.fn((callback: () => void) => {
+      callbacks.push(callback);
+      return callbacks.length;
+    });
+    const callFirst = vi.fn(async (paths: readonly string[]) =>
+      paths[0] === 'DMT_EditorControl.zoomToRegion' ? true : 'frame-blob',
+    );
+    const operations = makeOperations({
+      callFirst,
+      animationRoot: { requestAnimationFrame },
+    });
+
+    const resultPromise = operations.captureRegion({ left: 0, right: 10, top: 10, bottom: 0 });
+    await Promise.resolve();
+    expect(callbacks).toHaveLength(1);
+    callbacks[0]?.();
+    expect(callbacks).toHaveLength(2);
+    callbacks[1]?.();
+    await expect(resultPromise).resolves.toMatchObject({ fileName: 'capture-region.png' });
+    callbacks[1]?.();
+    expect(callFirst).toHaveBeenCalledTimes(2);
+  });
+
+  it('bounds a suspended animation frame wait with the repaint timeout', async () => {
+    vi.useFakeTimers();
+    const requestAnimationFrame = vi.fn(() => 1);
+    const callFirst = vi.fn(async (paths: readonly string[]) =>
+      paths[0] === 'DMT_EditorControl.zoomToRegion' ? true : 'timeout-blob',
+    );
+    const operations = makeOperations({
+      callFirst,
+      animationRoot: { requestAnimationFrame },
+    });
+
+    const resultPromise = operations.captureRegion({ left: 0, right: 10, top: 10, bottom: 0 });
+    await vi.advanceTimersByTimeAsync(75);
+    await expect(resultPromise).resolves.toMatchObject({ fileName: 'capture-region.png' });
+    expect(requestAnimationFrame).toHaveBeenCalledOnce();
+    expect(callFirst).toHaveBeenCalledTimes(2);
+  });
+
+  it('forwards locate coordinates without inventing defaults', async () => {
+    const callFirst = vi.fn(async () => 'located');
+    const operations = makeOperations({ callFirst });
+
+    await expect(operations.locate({ x: 12, y: -4, scaleRatio: 2, tabId: 'tab-2' })).resolves.toBe(
+      'located',
+    );
+    await operations.locate({});
+
+    expect(callFirst).toHaveBeenNthCalledWith(1, ['DMT_EditorControl.zoomTo'], 12, -4, 2, 'tab-2');
+    expect(callFirst).toHaveBeenNthCalledWith(
+      2,
+      ['DMT_EditorControl.zoomTo'],
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+    );
+  });
+});

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -834,6 +834,37 @@ describe('createDispatcher', () => {
     ]);
   });
 
+  it('delegates canvas capture and locate through the extracted domain', async () => {
+    const getCurrentRenderedAreaImage = vi.fn(async () => new Blob(['png'], { type: 'image/png' }));
+    const zoomTo = vi.fn(async () => true);
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        DMT_EditorControl: { getCurrentRenderedAreaImage, zoomTo },
+      }),
+    );
+
+    const capture = (await dispatcher.dispatch('canvas.capture', { tabId: 'tab-1' })) as {
+      base64: string;
+      fileName: string;
+      byteLength: number;
+    };
+    const located = await dispatcher.dispatch('canvas.locate', {
+      x: 12,
+      y: -4,
+      scaleRatio: 2,
+      tabId: 'tab-2',
+    });
+
+    expect(getCurrentRenderedAreaImage).toHaveBeenCalledWith('tab-1');
+    expect(capture).toMatchObject({
+      base64: Buffer.from('png').toString('base64'),
+      fileName: 'capture.png',
+      byteLength: 3,
+    });
+    expect(zoomTo).toHaveBeenCalledWith(12, -4, 2, 'tab-2');
+    expect(located).toBe(true);
+  });
+
   it('canvas.captureRegion normalizes bounds before capturing the settled viewport', async () => {
     const callOrder: string[] = [];
     const zoomToRegion = vi.fn(async () => {


### PR DESCRIPTION
## Summary

Extract `canvas.capture`, `canvas.captureRegion`, and `canvas.locate` from the extension dispatcher into a typed `canvas-operations.ts` domain factory.

This is the third bounded, behavior-preserving decomposition slice under #339. It does not close the parent issue and does not add or remove any public bridge capability.

## Contract parity

- Preserves full-canvas and region-capture filenames.
- Preserves full-capture string-only `tabId` handling and region-capture argument forwarding.
- Preserves finite-coordinate and zero-area validation, including error codes, messages, and suggestions.
- Preserves coordinate normalization and zoom-before-capture ordering.
- Preserves the bounded two-animation-frame repaint wait and the 75 ms background-window timeout.
- Preserves `canvas.locate` argument forwarding without inventing defaults.
- Keeps binary-result normalization and bridge payload-size enforcement in the shared dispatcher layer.
- Keeps all 67 sorted public extension methods unchanged.

## Objective decomposition evidence

- `dispatcher.ts`: 4,760 lines on `main` → 4,679 lines (-81).
- Built dispatcher bundle: 152,566 bytes → 153,348 bytes (+782 bytes, approximately +0.51%).
- Packaged extension: 160,951 bytes → 161,147 bytes (+196 bytes, approximately +0.12%).
- Method-list parity and extension size-budget checks pass.

## Tests

- Added 7 focused canvas-domain tests covering full capture, tab normalization, normalized region capture, invalid and zero-area regions, rejected zoom, two-frame settlement, bounded suspended-frame recovery, duplicate callback idempotency, and locate forwarding.
- Added a dispatcher integration contract that executes `canvas.capture` and `canvas.locate`, verifying shared binary normalization and exact locate arguments.
- Extracted module coverage: 100% statements, branches, functions, and lines (`LF=33`, `LH=33`, `BRF=15`, `BRH=15`).
- Dispatcher delegate coverage: `DA:4487=1`, `DA:4489=3`, `DA:4491=1`.
- Focused canvas/dispatcher parity: 97 tests passed.
- Extension suite: 12 files / 167 tests passed.
- Server suite: 150 files / 1,740 tests passed.
- Full `pnpm verify` passed runtime preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, tests, builds, extension packaging/checksums, metadata alignment, generated compatibility validation, and VitePress documentation.

## Automated review follow-up

The initial Codecov patch report identified the `canvas.capture` and `canvas.locate` dispatcher delegate lines as uncovered. Commit `fbea20f` adds the integration contract that executes both paths. The full extension coverage and repository verification suites were rerun after the change.

## Follow-up

Further dispatcher domains will continue as separately reviewable, parity-tested PRs under #339.
