### PR TITLE
refactor(extension): extract project operations

### DIFF
--- a/docs/superpowers/plans/2026-07-23-dispatcher-project-domain-extraction.md
+++ b/docs/superpowers/plans/2026-07-23-dispatcher-project-domain-extraction.md
@@ -1,0 +1,52 @@
+# Dispatcher Project Domain Extraction Implementation Plan
+
+**Goal:** Move `project.open`, `project.save`, and `project.export` behind one typed project-operation factory without changing runtime path precedence, arguments, results, errors, or public method contracts.
+
+**Architecture:** Add `project-operations.ts` with a single injected `callFirst` dependency from `api-runtime.ts`. The dispatcher binds the factory during `createDispatcher()` and keeps only three thin switch delegates.
+
+## Constraints
+
+- Preserve all 67 public bridge methods.
+- Preserve `project.open` path order and exact `projectId` forwarding.
+- Preserve the five-path save fallback order and zero-argument invocation.
+- Preserve project export path order and exact params-object forwarding.
+- Preserve errors from the shared API runtime without wrapping or translation.
+- Keep package output within the repository size budget.
+
+## Task 1 — Lock the project contract
+
+- [x] Add focused tests for open, save, and export path/argument forwarding.
+- [x] Add one dispatcher integration contract that executes all three delegates.
+- [x] Run the focused module test before implementation and record module-not-found RED.
+- [x] Confirm the existing 90 dispatcher integration tests remain green before extraction.
+
+## Task 2 — Extract the typed project factory
+
+- [x] Add `easyeda-bridge-extension/src/project-operations.ts`.
+- [x] Export typed dependency and operation interfaces.
+- [x] Bind the factory in `createDispatcher()`.
+- [x] Replace the three switch implementations with thin delegates.
+
+## Task 3 — Prove parity
+
+- [x] Reach 100% statement, branch, function, and line coverage for the new module.
+- [x] Run focused project and dispatcher tests.
+- [x] Run method-list parity and extension size-budget checks.
+- [x] Compare source, dispatcher bundle, and `.eext` sizes against `main`.
+- [x] Run full `pnpm verify`.
+- [x] Record final evidence before opening the PR.
+
+## Execution evidence
+
+- TDD RED: the focused project-domain test failed with module-not-found before `src/project-operations.ts` existed.
+- Pre-extraction baseline: all 90 dispatcher integration tests and extension typecheck passed.
+- Focused parity: 3 project-domain and 91 dispatcher tests pass (94 total).
+- Extracted-module coverage: 100% statements, functions, and lines (`LF=4`, `LH=4`); the module has no conditional branches (`BRF=0`).
+- Dispatcher delegate coverage: `project.open`, `project.save`, and `project.export` each execute once in the integration suite; factory binding executes 104 times.
+- Public method contract: all 67 sorted bridge methods remain unchanged; method-list parity passes.
+- Dispatcher source size: 4,679 lines on `main` → 4,673 lines after extraction (-6).
+- Built dispatcher bundle: 153,348 bytes on `main` → 153,845 bytes (+497 bytes, approximately +0.32%).
+- Packaged extension: 161,147 bytes on `main` → 161,319 bytes (+172 bytes, approximately +0.11%); the size budget passes.
+- Full extension suite: 13 files / 171 tests pass.
+- Full server suite: 150 files / 1,740 tests pass.
+- Full `pnpm verify` passes Node.js/pnpm preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, server and extension tests, both builds, extension packaging/checksums, metadata alignment, generated compatibility validation, and VitePress documentation.

--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -16,6 +16,7 @@ import {
 } from './api-introspection.js';
 import { normalizeBinaryResult, type BinaryResultPayload } from './binary-result.js';
 import { createCanvasOperations, type CanvasOperations } from './canvas-operations.js';
+import { createProjectOperations, type ProjectOperations } from './project-operations.js';
 import type { Dispatcher, DispatcherToolkit } from './toolkit.js';
 import { isRecord, log, logRecoverableError, readPath, type JsonValue } from './utils.js';
 
@@ -112,6 +113,7 @@ let readFirstPath: ApiRuntime['readFirstPath'];
 let inspectApiInventory: ApiRuntime['inspectApiInventory'];
 let callAllowedApi: ApiRuntime['callAllowedApi'];
 let canvasOperations: CanvasOperations;
+let projectOperations: ProjectOperations;
 
 function newBridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
   const error = new Error(message);
@@ -3371,20 +3373,11 @@ async function findFloatingPinsApi(): Promise<{
 async function dispatch(method: string, params: Record<string, unknown> = {}): Promise<unknown> {
   switch (method) {
     case 'project.open':
-      return callFirst(['dmt_Project.openProject', 'project.open'], params.projectId);
+      return projectOperations.open(params);
     case 'project.save':
-      return callFirst([
-        'dmt_Workspace.saveAll',
-        'dmt_Workspace.saveActiveDocument',
-        'sch_Document.save',
-        'pcb_Document.save',
-        'pnl_Document.save',
-      ]);
+      return projectOperations.save(params);
     case 'project.export':
-      return callFirst(
-        ['PCB_ManufactureData.getManufactureData', 'SCH_ManufactureData.getExportDocumentFile'],
-        params,
-      );
+      return projectOperations.export(params);
     case 'schematic.listNets':
       return listNetsApi();
     case 'schematic.getNetDetail': {
@@ -4669,6 +4662,7 @@ export function createDispatcher(toolkit: DispatcherToolkit): Dispatcher {
     normalizeBinaryResult: normalizeBinaryResultSafely,
     createBridgeError: newBridgeError,
   });
+  projectOperations = createProjectOperations({ callFirst });
   textAlignModeCache.clear();
   log(`dispatcher initialized (build ${BUILD_ID}, ${METHOD_LIST.length} methods)`);
   return {

--- a/easyeda-bridge-extension/src/project-operations.ts
+++ b/easyeda-bridge-extension/src/project-operations.ts
@@ -1,0 +1,38 @@
+import type { ApiRuntime } from './api-runtime.js';
+
+export interface ProjectOperationDependencies {
+  callFirst: ApiRuntime['callFirst'];
+}
+
+export interface ProjectOperations {
+  open(params: Record<string, unknown>): Promise<unknown>;
+  save(params: Record<string, unknown>): Promise<unknown>;
+  export(params: Record<string, unknown>): Promise<unknown>;
+}
+
+export function createProjectOperations({
+  callFirst,
+}: ProjectOperationDependencies): ProjectOperations {
+  async function open(params: Record<string, unknown>): Promise<unknown> {
+    return callFirst(['dmt_Project.openProject', 'project.open'], params.projectId);
+  }
+
+  async function save(_params: Record<string, unknown>): Promise<unknown> {
+    return callFirst([
+      'dmt_Workspace.saveAll',
+      'dmt_Workspace.saveActiveDocument',
+      'sch_Document.save',
+      'pcb_Document.save',
+      'pnl_Document.save',
+    ]);
+  }
+
+  async function exportProject(params: Record<string, unknown>): Promise<unknown> {
+    return callFirst(
+      ['PCB_ManufactureData.getManufactureData', 'SCH_ManufactureData.getExportDocumentFile'],
+      params,
+    );
+  }
+
+  return { open, save, export: exportProject };
+}

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -99,6 +99,34 @@ function fakeSchematicPart(
 }
 
 describe('createDispatcher', () => {
+  it('delegates project open, save, and export through the extracted domain', async () => {
+    const openProject = vi.fn(async () => 'opened');
+    const saveAll = vi.fn(async () => 'saved');
+    const getManufactureData = vi.fn(async (params: unknown) => ({ exported: params }));
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        dmt_Project: { openProject },
+        dmt_Workspace: { saveAll },
+        PCB_ManufactureData: { getManufactureData },
+      }),
+    );
+    const exportParams = { projectId: 'project-1', format: 'zip' };
+
+    await expect(dispatcher.dispatch('project.open', { projectId: 'project-1' })).resolves.toBe(
+      'opened',
+    );
+    await expect(dispatcher.dispatch('project.save', { projectId: 'project-1' })).resolves.toBe(
+      'saved',
+    );
+    await expect(dispatcher.dispatch('project.export', exportParams)).resolves.toEqual({
+      exported: exportParams,
+    });
+
+    expect(openProject).toHaveBeenCalledWith('project-1');
+    expect(saveAll).toHaveBeenCalledWith();
+    expect(getManufactureData).toHaveBeenCalledWith(exportParams);
+  });
+
   it('returns a dispatcher with a sorted, non-empty method list and a build id', () => {
     const dispatcher = createDispatcher(makeToolkit({}));
     expect(dispatcher.methodList.length).toBeGreaterThan(40);

--- a/easyeda-bridge-extension/tests/project-operations.test.ts
+++ b/easyeda-bridge-extension/tests/project-operations.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createProjectOperations } from '../src/project-operations.js';
+
+describe('project operations', () => {
+  it('opens a project with the original path order and project id', async () => {
+    const callFirst = vi.fn(async () => 'opened');
+    const operations = createProjectOperations({ callFirst });
+
+    await expect(operations.open({ projectId: 'project-1' })).resolves.toBe('opened');
+    expect(callFirst).toHaveBeenCalledWith(
+      ['dmt_Project.openProject', 'project.open'],
+      'project-1',
+    );
+  });
+
+  it('saves through the exact zero-argument fallback chain', async () => {
+    const callFirst = vi.fn(async () => 'saved');
+    const operations = createProjectOperations({ callFirst });
+
+    await expect(operations.save({ projectId: 'ignored' })).resolves.toBe('saved');
+    expect(callFirst).toHaveBeenCalledWith([
+      'dmt_Workspace.saveAll',
+      'dmt_Workspace.saveActiveDocument',
+      'sch_Document.save',
+      'pcb_Document.save',
+      'pnl_Document.save',
+    ]);
+  });
+
+  it('exports with the original path order and exact params object', async () => {
+    const callFirst = vi.fn(async () => 'exported');
+    const operations = createProjectOperations({ callFirst });
+    const params = { projectId: 'project-1', format: 'zip', includeLibraries: true };
+
+    await expect(operations.export(params)).resolves.toBe('exported');
+    expect(callFirst).toHaveBeenCalledWith(
+      ['PCB_ManufactureData.getManufactureData', 'SCH_ManufactureData.getExportDocumentFile'],
+      params,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Extract `project.open`, `project.save`, and `project.export` from the extension dispatcher into a typed `project-operations.ts` domain factory.

This is the fourth bounded, behavior-preserving decomposition slice under #339. It does not close the parent issue and does not add or remove any public bridge capability.

## Contract parity

- Preserves `project.open` path precedence and exact `projectId` forwarding.
- Preserves the five-path save fallback order and zero-argument invocation.
- Preserves project export path precedence and exact params-object forwarding.
- Preserves shared API-runtime errors without wrapping or translation.
- Keeps all 67 sorted public extension methods unchanged.

## Objective decomposition evidence

- `dispatcher.ts`: 4,679 lines on `main` → 4,673 lines (-6).
- Built dispatcher bundle: 153,348 bytes → 153,845 bytes (+497 bytes, approximately +0.32%).
- Packaged extension: 161,147 bytes → 161,319 bytes (+172 bytes, approximately +0.11%).
- Method-list parity and extension size-budget checks pass.

## Tests

- Added 3 focused project-domain tests for exact open, save, and export path/argument contracts.
- Added a dispatcher integration contract that executes all three delegates.
- Extracted module coverage: 100% statements, functions, and lines (`LF=4`, `LH=4`); the module has no conditional branches (`BRF=0`).
- Dispatcher delegates each execute in the extension integration suite.
- Focused project/dispatcher parity: 94 tests passed.
- Extension suite: 13 files / 171 tests passed.
- Server suite: 150 files / 1,740 tests passed.
- Full `pnpm verify` passed runtime preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, tests, builds, extension packaging/checksums, metadata alignment, generated compatibility validation, and VitePress documentation.

## Follow-up

Further dispatcher domains will continue as separately reviewable, parity-tested PRs under #339.
