### PR TITLE
chore(security): harden supply-chain workflows

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -53,5 +53,5 @@
       "commitMessagePrefix": "chore(deps):"
     }
   ],
-  "minimumReleaseAge": "3 days"
+  "minimumReleaseAge": "7 days"
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           node-version: '24.18.0'
 
           package-manager-cache: false
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Verify runtime policy
         run: pnpm runtime:check
       - name: Validate Codecov configuration
@@ -176,7 +176,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
           package-manager-cache: false
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Verify runtime policy
         run: pnpm runtime:check
       - run: pnpm typecheck
@@ -207,7 +207,7 @@ jobs:
           node-version: '24.18.0'
 
           package-manager-cache: false
-      - run: pnpm install --frozen-lockfile
+      - run: pnpm install --frozen-lockfile --ignore-scripts
       - name: Verify runtime policy
         run: pnpm runtime:check
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -46,7 +46,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Verify runtime policy
         run: pnpm runtime:check

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -84,7 +84,7 @@ jobs:
           package-manager-cache: false
       - name: Install dependencies
         if: ${{ env.RELEASE_RUN == 'true' }}
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Verify runtime policy
         if: ${{ env.RELEASE_RUN == 'true' }}
@@ -183,7 +183,9 @@ jobs:
           ARCH="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
           ASSET="mcp-publisher_${OS}_${ARCH}.tar.gz"
           BASE="https://github.com/modelcontextprotocol/registry/releases/download"
-          curl -sSLO "${BASE}/${MCP_PUBLISHER_VERSION}/${ASSET}"
+          curl --fail --silent --show-error --location \
+            --proto '=https' --tlsv1.2 \
+            --output "$ASSET" "${BASE}/${MCP_PUBLISHER_VERSION}/${ASSET}"
           tar xzf mcp-publisher_*.tar.gz mcp-publisher
           chmod +x mcp-publisher
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -8,7 +8,7 @@ name: Scorecard
     - cron: '30 4 * * 1'
   workflow_dispatch: {}
 
-permissions: read-all
+permissions: {}
 
 jobs:
   analysis:

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 engine-strict=true
 manage-package-manager-versions=false
+min-release-age=7

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY scripts/check-runtime.mjs ./scripts/check-runtime.mjs
 RUN node scripts/check-runtime.mjs --require-pnpm
 
 # Install dependencies (including devDependencies for build)
-RUN pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy tsconfig and source directories
 COPY tsconfig.json tsconfig.build.json ./

--- a/easyeda-bridge-extension/scripts/verify-dist.mjs
+++ b/easyeda-bridge-extension/scripts/verify-dist.mjs
@@ -87,7 +87,7 @@ const entry = typeof manifest.entry === 'string' ? manifest.entry : '';
 const normalizedEntry = entry.replace(/^\.\//, '');
 const entryCandidates = [normalizedEntry, `${normalizedEntry}.js`];
 const entryCandidatePaths = entryCandidates.map(resolvePathWithinRoot);
-const entryEscapesRoot = entryCandidatePaths.some((candidate) => candidate === undefined);
+const entryEscapesRoot = entryCandidatePaths.includes(undefined);
 if (
   !entry ||
   entryEscapesRoot ||

--- a/easyeda-bridge-extension/scripts/verify-dist.mjs
+++ b/easyeda-bridge-extension/scripts/verify-dist.mjs
@@ -1,16 +1,23 @@
 import { existsSync, readFileSync, statSync } from 'fs';
 import { execFileSync } from 'child_process';
-import { join } from 'path';
+import { dirname, isAbsolute, join, relative, resolve, sep } from 'path';
 import { fileURLToPath } from 'url';
-import { dirname } from 'path';
 import { CHECKSUM_MANIFEST_NAME, verifyChecksumManifest } from './checksums.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const root = join(__dirname, '..');
+const root = resolve(__dirname, '..');
 
 const required = ['dist/index.js', 'extension.json', 'images/logo.png'];
 const marketplaceSourceFiles = ['README.md', 'CHANGELOG.md'];
+
+function resolvePathWithinRoot(candidate) {
+  const resolvedPath = resolve(root, candidate);
+  const relativePath = relative(root, resolvedPath);
+  const pathSegments = relativePath.split(sep);
+  if (!relativePath || isAbsolute(relativePath) || pathSegments[0] === '..') return undefined;
+  return resolvedPath;
+}
 
 function readPngDimensions(path) {
   const buffer = readFileSync(path);
@@ -79,7 +86,13 @@ const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'));
 const entry = typeof manifest.entry === 'string' ? manifest.entry : '';
 const normalizedEntry = entry.replace(/^\.\//, '');
 const entryCandidates = [normalizedEntry, `${normalizedEntry}.js`];
-if (!entry || !entryCandidates.some((candidate) => existsSync(join(root, candidate)))) {
+const entryCandidatePaths = entryCandidates.map(resolvePathWithinRoot);
+const entryEscapesRoot = entryCandidatePaths.some((candidate) => candidate === undefined);
+if (
+  !entry ||
+  entryEscapesRoot ||
+  !entryCandidatePaths.some((candidate) => candidate !== undefined && existsSync(candidate))
+) {
   console.error(`INVALID ENTRY: ${entry || '<missing>'}`);
   ok = false;
 } else {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,9 +4,14 @@ packages:
 
 allowBuilds:
   esbuild: true
-minimumReleaseAge: 4320
+minimumReleaseAge: 10080
+# Exact-version exceptions for the reviewed security overrides from #333/#334.
+minimumReleaseAgeExclude:
+  - fast-uri@3.1.4
+  - hono@4.12.31
 minimumReleaseAgeStrict: true
 minimumReleaseAgeIgnoreMissingTime: false
+trustPolicy: no-downgrade
 trustLockfile: false
 blockExoticSubdeps: true
 

--- a/scripts/e2e/waiter.mjs
+++ b/scripts/e2e/waiter.mjs
@@ -170,7 +170,7 @@ if (connected) {
     );
     await sleep(1000);
     const r = buf.slice(p, p + 1000);
-    console.log(`${method}:`, r.slice(0, 300));
+    console.log('%s: %s', method, r.slice(0, 300));
   }
 }
 

--- a/tests/unit/repository/dependency-updater-policy.test.ts
+++ b/tests/unit/repository/dependency-updater-policy.test.ts
@@ -28,7 +28,7 @@ describe('dependency updater ownership', () => {
   it('delays fresh releases and keeps the dependency dashboard plus vulnerability alerts enabled', () => {
     const config = JSON.parse(readFileSync(renovateConfigPath, 'utf8')) as RenovateConfig;
 
-    expect(config.minimumReleaseAge).toBe('3 days');
+    expect(config.minimumReleaseAge).toBe('7 days');
     expect(config.dependencyDashboard).toBe(true);
     expect(config.osvVulnerabilityAlerts).toBe(true);
   });

--- a/tests/unit/repository/security-tooling-policy.test.ts
+++ b/tests/unit/repository/security-tooling-policy.test.ts
@@ -80,12 +80,17 @@ describe('repository security tooling policy', () => {
     );
     expect(packageJson.scripts?.['security:audit']).toBe('node scripts/check-dependency-audit.mjs');
     const workspace = readText('pnpm-workspace.yaml');
-    expect(workspace).toContain('minimumReleaseAge: 4320');
+    expect(workspace).toContain('minimumReleaseAge: 10080');
+    expect(workspace).toContain('minimumReleaseAgeExclude:');
+    expect(workspace).toContain('fast-uri@3.1.4');
+    expect(workspace).toContain('hono@4.12.31');
     expect(workspace).toContain('minimumReleaseAgeStrict: true');
     expect(workspace).toContain('minimumReleaseAgeIgnoreMissingTime: false');
+    expect(workspace).toContain('trustPolicy: no-downgrade');
     expect(workspace).toContain('trustLockfile: false');
     expect(workspace).toContain('blockExoticSubdeps: true');
     expect(workspace).toContain('body-parser: 2.3.0');
+    expect(readText('.npmrc')).toContain('min-release-age=7');
   });
 
   it('runs Semgrep, workflow hardening, and Trivy as separate CI concerns', () => {
@@ -196,9 +201,32 @@ describe('repository security tooling policy', () => {
     expect(guide).toContain('dependency-audit-report');
   });
 
-  it('hardens release and benchmark dependency installation', () => {
+  it('hardens CI, release, documentation, and container dependency installation', () => {
+    const ciWorkflow = readText('.github/workflows/ci.yml');
+    const docsWorkflow = readText('.github/workflows/deploy-docs.yml');
     const releaseWorkflow = readText('.github/workflows/release-please.yml');
     const benchmarkWorkflow = readText('.github/workflows/golden-benchmark.yml');
+    const scorecardWorkflow = readText('.github/workflows/scorecard.yml');
+    const dockerfile = readText('Dockerfile');
+
+    expect(ciWorkflow.match(/pnpm install --frozen-lockfile --ignore-scripts/g)).toHaveLength(3);
+    expect(docsWorkflow).toContain('pnpm install --frozen-lockfile --ignore-scripts');
+    expect(releaseWorkflow).toContain('pnpm install --frozen-lockfile --ignore-scripts');
+    expect(dockerfile).toContain('RUN pnpm install --frozen-lockfile --ignore-scripts');
+    expect(scorecardWorkflow).not.toContain('permissions: read-all');
+    expect(releaseWorkflow).toContain('curl --fail --silent --show-error --location \\');
+    expect(releaseWorkflow).toContain("--proto '=https' --tlsv1.2 \\");
+    expect(releaseWorkflow).toContain(
+      '--output "$ASSET" "${BASE}/${MCP_PUBLISHER_VERSION}/${ASSET}"',
+    );
+
+    const verifyDist = readText('easyeda-bridge-extension/scripts/verify-dist.mjs');
+    expect(verifyDist).toContain('function resolvePathWithinRoot(candidate)');
+    expect(verifyDist).toContain("pathSegments[0] === '..'");
+    expect(verifyDist).toContain('entryEscapesRoot');
+
+    const e2eWaiter = readText('scripts/e2e/waiter.mjs');
+    expect(e2eWaiter).toContain("console.log('%s: %s', method, r.slice(0, 300));");
 
     expect(releaseWorkflow).toContain(
       'uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610',


### PR DESCRIPTION
## Summary

Harden the repository supply-chain and workflow boundaries based on fresh SonarQube CLI, Semgrep CI, OSV-Scanner, actionlint, zizmor, and Trivy scans.

## Scanner results and triage

- Semgrep Pro CI completed across code, supply-chain, and secrets with **0 blocking findings**. Monitor findings were source-reviewed; this PR addresses the actionable workflow, dependency-quarantine, path-boundary, and format-string findings.
- SonarQube CLI secret analysis completed with **0 issues**. The SonarCloud project quality gate is green with **0 security hotspots**.
- OSV-Scanner found only the already documented `@hono/node-server@1.19.14` advisory (`GHSA-frvp-7c67-39w9`), governed by the exact, time-bounded #334 exception.
- Sonar dependency-risk analysis is unavailable on the current Sonar plan, so OSV plus the repository fail-closed audit remains authoritative for dependency advisories.

## Changes

- Disable dependency lifecycle scripts in CI, documentation, release, and Docker builder installs.
- Extend npm, pnpm, and Renovate release quarantine from 3 to 7 days.
- Enable pnpm `trustPolicy: no-downgrade`.
- Add exact-version release-age exceptions only for the reviewed security overrides from #333/#334.
- Remove Scorecard's workflow-wide `read-all` and retain explicit job permissions.
- Require HTTPS/TLS 1.2 and fail-closed curl behavior for the MCP publisher download.
- Reject extension manifest entry paths that escape the package root.
- Replace an E2E dynamic format string with a fixed format string.
- Lock all policies with repository tests.

## Verification

- Clean install after deleting both `node_modules` trees: `pnpm install --frozen-lockfile --ignore-scripts`.
- Confirmed active policy values: npm 7 days, pnpm 10,080 minutes, `trustPolicy=no-downgrade`.
- Negative fixture: `entry=../../../../etc/passwd` is rejected as `INVALID ENTRY` with exit code 1.
- Full verification: **150 files / 1,740 server tests** and **13 files / 171 extension tests**.
- Formatting, root and extension typecheck, ESLint, metadata/tool profiles, builds, extension packaging/checksums, compatibility generation, and docs build passed.
- `pnpm security:audit`: only the documented #334 advisory exception.
- `pnpm peers check`: no issues.
- actionlint: passed.
- zizmor medium+: 0 findings.
- Trivy config HIGH/CRITICAL: 0 findings.
- Hadolint reported only existing informational `DL3059` notices.

Local Docker image creation could not start because the VPS exec user lacks access to `/var/run/docker.sock`; the PR `container-security` job is the authoritative build and image validation gate.
