### PR TITLE
refactor(extension): extract export operations

### DIFF
--- a/easyeda-bridge-extension/src/binary-result-policy.ts
+++ b/easyeda-bridge-extension/src/binary-result-policy.ts
@@ -1,0 +1,48 @@
+import type { BridgeErrorFactory } from './api-runtime.js';
+import {
+  normalizeBinaryResult,
+  type BinaryResultNormalizer,
+  type BinaryResultPayload,
+} from './binary-result.js';
+
+const DEFAULT_PAYLOAD_SAFETY_MARGIN = 0.6;
+
+export interface BinaryResultPolicyDependencies {
+  getBridgeMaxPayloadSize: () => number;
+  createBridgeError: BridgeErrorFactory;
+  normalizeResult?: BinaryResultNormalizer;
+  safetyMargin?: number;
+}
+
+function isBinaryResultPayload(value: unknown): value is BinaryResultPayload {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    typeof (value as { base64?: unknown }).base64 === 'string' &&
+    typeof (value as { byteLength?: unknown }).byteLength === 'number'
+  );
+}
+
+export function createBinaryResultNormalizer({
+  getBridgeMaxPayloadSize,
+  createBridgeError,
+  normalizeResult = normalizeBinaryResult,
+  safetyMargin = DEFAULT_PAYLOAD_SAFETY_MARGIN,
+}: BinaryResultPolicyDependencies): BinaryResultNormalizer {
+  return async (value: unknown, fallbackFileName: string): Promise<unknown> => {
+    const normalized = await normalizeResult(value, fallbackFileName);
+    if (!isBinaryResultPayload(normalized)) return normalized;
+
+    const maxPayloadSize = getBridgeMaxPayloadSize();
+    const budget = Math.floor(maxPayloadSize * safetyMargin);
+    if (normalized.byteLength > budget) {
+      throw createBridgeError(
+        'PAYLOAD_TOO_LARGE',
+        `"${normalized.fileName}" is ${normalized.byteLength} bytes, which exceeds the safe transport budget (${budget} bytes, derived from the server's BRIDGE_MAX_PAYLOAD_SIZE=${maxPayloadSize}).`,
+        'Increase BRIDGE_MAX_PAYLOAD_SIZE in the MCP server environment, or (for canvas captures) zoom to a smaller region.',
+      );
+    }
+
+    return normalized;
+  };
+}

--- a/easyeda-bridge-extension/src/binary-result.ts
+++ b/easyeda-bridge-extension/src/binary-result.ts
@@ -62,6 +62,8 @@ export interface BinaryResultPayload {
   byteLength: number;
 }
 
+export type BinaryResultNormalizer = (value: unknown, fallbackFileName: string) => Promise<unknown>;
+
 /**
  * Convert any Blob/File dispatch result into a JSON-safe base64 payload; pass
  * through anything else (e.g. a plain netlist object) unchanged.

--- a/easyeda-bridge-extension/src/canvas-operations.ts
+++ b/easyeda-bridge-extension/src/canvas-operations.ts
@@ -1,6 +1,5 @@
 import type { ApiRuntime, BridgeErrorFactory } from './api-runtime.js';
-
-export type BinaryResultNormalizer = (value: unknown, fallbackFileName: string) => Promise<unknown>;
+import type { BinaryResultNormalizer } from './binary-result.js';
 
 export interface CanvasAnimationRoot {
   requestAnimationFrame?: (callback: () => void) => number;

--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -14,8 +14,9 @@ import {
   readMember,
   readStateValue,
 } from './api-introspection.js';
-import { normalizeBinaryResult, type BinaryResultPayload } from './binary-result.js';
+import { createBinaryResultNormalizer } from './binary-result-policy.js';
 import { createCanvasOperations, type CanvasOperations } from './canvas-operations.js';
+import { createExportOperations, type ExportOperations } from './export-operations.js';
 import { createProjectOperations, type ProjectOperations } from './project-operations.js';
 import type { Dispatcher, DispatcherToolkit } from './toolkit.js';
 import { isRecord, log, logRecoverableError, readPath, type JsonValue } from './utils.js';
@@ -28,11 +29,6 @@ const BUILD_ID =
     ? __MCP_DISPATCHER_BUILD_ID__
     : 'baked-dev';
 
-// Fraction of the server's advertised BRIDGE_MAX_PAYLOAD_SIZE we allow a single
-// binary (Blob/File) result to use, leaving headroom for base64 (~1.33x raw
-// bytes) plus JSON envelope overhead. Exceeding the server's actual limit closes
-// the whole WS connection, not just the offending call — so we self-limit first.
-const PAYLOAD_SAFETY_MARGIN = 0.6;
 /** Every bridge method handled by dispatch() below. Keep in lockstep with the
  *  switch cases AND the server's EasyedaApiMethodSchema (src/bridge/types.ts). */
 const METHOD_LIST: readonly string[] = [
@@ -113,6 +109,7 @@ let readFirstPath: ApiRuntime['readFirstPath'];
 let inspectApiInventory: ApiRuntime['inspectApiInventory'];
 let callAllowedApi: ApiRuntime['callAllowedApi'];
 let canvasOperations: CanvasOperations;
+let exportOperations: ExportOperations;
 let projectOperations: ProjectOperations;
 
 function newBridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
@@ -499,42 +496,6 @@ async function findForeignNetCollision(
   }
 
   return null;
-}
-
-function isBinaryResultPayload(value: unknown): value is BinaryResultPayload {
-  return (
-    !!value &&
-    typeof value === 'object' &&
-    typeof (value as { base64?: unknown }).base64 === 'string' &&
-    typeof (value as { byteLength?: unknown }).byteLength === 'number'
-  );
-}
-
-/**
- * Wraps `normalizeBinaryResult`, additionally rejecting a payload that would
- * exceed the server's advertised BRIDGE_MAX_PAYLOAD_SIZE (via the toolkit)
- * before it is ever handed to send(). Sending an oversized WS frame closes
- * the whole connection (code 4009) rather than just failing this one call,
- * so we throw a normal, small, structured error instead — handleRequest()
- * turns it into an ok:false response.
- */
-async function normalizeBinaryResultSafely(
-  value: unknown,
-  fallbackFileName: string,
-): Promise<unknown> {
-  const normalized = await normalizeBinaryResult(value, fallbackFileName);
-  if (isBinaryResultPayload(normalized)) {
-    const maxPayloadSize = tk.getBridgeMaxPayloadSize();
-    const budget = Math.floor(maxPayloadSize * PAYLOAD_SAFETY_MARGIN);
-    if (normalized.byteLength > budget) {
-      throw newBridgeError(
-        'PAYLOAD_TOO_LARGE',
-        `"${normalized.fileName}" is ${normalized.byteLength} bytes, which exceeds the safe transport budget (${budget} bytes, derived from the server's BRIDGE_MAX_PAYLOAD_SIZE=${maxPayloadSize}).`,
-        'Increase BRIDGE_MAX_PAYLOAD_SIZE in the MCP server environment, or (for canvas captures) zoom to a smaller region.',
-      );
-    }
-  }
-  return normalized;
 }
 
 function summarizeWirePrimitive(wire: unknown): Record<string, JsonValue | undefined> {
@@ -4228,18 +4189,9 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
     case 'board.getFeatures':
       return getFeaturesApi();
     case 'board.exportGerbers':
-      return normalizeBinaryResultSafely(
-        await callFirst(['PCB_ManufactureData.getGerberFile'], params),
-        'gerbers.zip',
-      );
+      return exportOperations.exportGerbers(params);
     case 'pcb.exportRouteContext':
-      return normalizeBinaryResultSafely(
-        await callFirst(
-          ['PCB_ManufactureData.getDsnFile'],
-          typeof params.fileName === 'string' ? params.fileName : undefined,
-        ),
-        'route-context.dsn',
-      );
+      return exportOperations.exportRouteContext(params);
     case 'system.getStatus': {
       const globals: Record<string, unknown> = {};
       const edaObj = tk.getEda();
@@ -4452,30 +4404,11 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
     case 'design.drc':
       return runPcbDrcCheck();
     case 'export.pickPlace':
-      return normalizeBinaryResultSafely(
-        await callFirst(['PCB_ManufactureData.getPickAndPlaceFile'], params),
-        `pick-place.${typeof params.format === 'string' ? params.format : 'csv'}`,
-      );
+      return exportOperations.exportPickPlace(params);
     case 'export.pdf':
-      return normalizeBinaryResultSafely(
-        await callFirst(
-          ['PCB_ManufactureData.getPdfFile', 'SCH_ManufactureData.getExportDocumentFile'],
-          params.what === 'board' ? params : { ...params, type: 'schematic' },
-        ),
-        'export.pdf',
-      );
+      return exportOperations.exportPdf(params);
     case 'export.netlist':
-      return normalizeBinaryResultSafely(
-        await callFirst(
-          [
-            'SCH_Netlist.getNetlist',
-            'SCH_ManufactureData.getNetlistFile',
-            'PCB_ManufactureData.getNetlistFile',
-          ],
-          params,
-        ),
-        `netlist.${typeof params.format === 'string' ? params.format : 'txt'}`,
-      );
+      return exportOperations.exportNetlist(params);
     case 'canvas.capture':
       return canvasOperations.capture(params);
     case 'canvas.captureRegion':
@@ -4657,11 +4590,16 @@ export function createDispatcher(toolkit: DispatcherToolkit): Dispatcher {
     toolkit,
     newBridgeError,
   ));
-  canvasOperations = createCanvasOperations({
-    callFirst,
-    normalizeBinaryResult: normalizeBinaryResultSafely,
+  const normalizeBinaryResult = createBinaryResultNormalizer({
+    getBridgeMaxPayloadSize: () => toolkit.getBridgeMaxPayloadSize(),
     createBridgeError: newBridgeError,
   });
+  canvasOperations = createCanvasOperations({
+    callFirst,
+    normalizeBinaryResult,
+    createBridgeError: newBridgeError,
+  });
+  exportOperations = createExportOperations({ callFirst, normalizeBinaryResult });
   projectOperations = createProjectOperations({ callFirst });
   textAlignModeCache.clear();
   log(`dispatcher initialized (build ${BUILD_ID}, ${METHOD_LIST.length} methods)`);

--- a/easyeda-bridge-extension/src/export-operations.ts
+++ b/easyeda-bridge-extension/src/export-operations.ts
@@ -1,0 +1,76 @@
+import type { ApiRuntime } from './api-runtime.js';
+import type { BinaryResultNormalizer } from './binary-result.js';
+
+export interface ExportOperationDependencies {
+  callFirst: ApiRuntime['callFirst'];
+  normalizeBinaryResult: BinaryResultNormalizer;
+}
+
+export interface ExportOperations {
+  exportGerbers(params: Record<string, unknown>): Promise<unknown>;
+  exportRouteContext(params: Record<string, unknown>): Promise<unknown>;
+  exportPickPlace(params: Record<string, unknown>): Promise<unknown>;
+  exportPdf(params: Record<string, unknown>): Promise<unknown>;
+  exportNetlist(params: Record<string, unknown>): Promise<unknown>;
+}
+
+export function createExportOperations({
+  callFirst,
+  normalizeBinaryResult,
+}: ExportOperationDependencies): ExportOperations {
+  async function exportGerbers(params: Record<string, unknown>): Promise<unknown> {
+    return normalizeBinaryResult(
+      await callFirst(['PCB_ManufactureData.getGerberFile'], params),
+      'gerbers.zip',
+    );
+  }
+
+  async function exportRouteContext(params: Record<string, unknown>): Promise<unknown> {
+    return normalizeBinaryResult(
+      await callFirst(
+        ['PCB_ManufactureData.getDsnFile'],
+        typeof params.fileName === 'string' ? params.fileName : undefined,
+      ),
+      'route-context.dsn',
+    );
+  }
+
+  async function exportPickPlace(params: Record<string, unknown>): Promise<unknown> {
+    return normalizeBinaryResult(
+      await callFirst(['PCB_ManufactureData.getPickAndPlaceFile'], params),
+      `pick-place.${typeof params.format === 'string' ? params.format : 'csv'}`,
+    );
+  }
+
+  async function exportPdf(params: Record<string, unknown>): Promise<unknown> {
+    return normalizeBinaryResult(
+      await callFirst(
+        ['PCB_ManufactureData.getPdfFile', 'SCH_ManufactureData.getExportDocumentFile'],
+        params.what === 'board' ? params : { ...params, type: 'schematic' },
+      ),
+      'export.pdf',
+    );
+  }
+
+  async function exportNetlist(params: Record<string, unknown>): Promise<unknown> {
+    return normalizeBinaryResult(
+      await callFirst(
+        [
+          'SCH_Netlist.getNetlist',
+          'SCH_ManufactureData.getNetlistFile',
+          'PCB_ManufactureData.getNetlistFile',
+        ],
+        params,
+      ),
+      `netlist.${typeof params.format === 'string' ? params.format : 'txt'}`,
+    );
+  }
+
+  return {
+    exportGerbers,
+    exportRouteContext,
+    exportPickPlace,
+    exportPdf,
+    exportNetlist,
+  };
+}

--- a/easyeda-bridge-extension/tests/binary-result-policy.test.ts
+++ b/easyeda-bridge-extension/tests/binary-result-policy.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createBinaryResultNormalizer } from '../src/binary-result-policy.js';
+
+function bridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
+  return Object.assign(new Error(message), { code, suggestion, data });
+}
+
+describe('binary result payload policy', () => {
+  it('passes non-binary normalized results through without reading the transport budget', async () => {
+    const getBridgeMaxPayloadSize = vi.fn(() => 1000);
+    const normalizeResult = vi.fn(async () => ({ value: 'plain' }));
+    const normalize = createBinaryResultNormalizer({
+      getBridgeMaxPayloadSize,
+      createBridgeError: bridgeError,
+      normalizeResult,
+    });
+
+    await expect(normalize('input', 'fallback.txt')).resolves.toEqual({ value: 'plain' });
+    expect(normalizeResult).toHaveBeenCalledWith('input', 'fallback.txt');
+    expect(getBridgeMaxPayloadSize).not.toHaveBeenCalled();
+  });
+
+  it('accepts binary payloads at the floored safety budget', async () => {
+    const payload = {
+      base64: 'YQ==',
+      mimeType: 'application/octet-stream',
+      fileName: 'result.bin',
+      byteLength: 600,
+    };
+    const normalize = createBinaryResultNormalizer({
+      getBridgeMaxPayloadSize: () => 1001,
+      createBridgeError: bridgeError,
+      normalizeResult: async () => payload,
+    });
+
+    await expect(normalize('input', 'fallback.bin')).resolves.toBe(payload);
+  });
+
+  it('rejects payloads above the safe transport budget with the stable bridge error', async () => {
+    const payload = {
+      base64: 'YQ==',
+      mimeType: 'application/zip',
+      fileName: 'gerbers.zip',
+      byteLength: 601,
+    };
+    const normalize = createBinaryResultNormalizer({
+      getBridgeMaxPayloadSize: () => 1000,
+      createBridgeError: bridgeError,
+      normalizeResult: async () => payload,
+    });
+
+    await expect(normalize('input', 'fallback.zip')).rejects.toMatchObject({
+      code: 'PAYLOAD_TOO_LARGE',
+      message:
+        '"gerbers.zip" is 601 bytes, which exceeds the safe transport budget (600 bytes, derived from the server\'s BRIDGE_MAX_PAYLOAD_SIZE=1000).',
+      suggestion:
+        'Increase BRIDGE_MAX_PAYLOAD_SIZE in the MCP server environment, or (for canvas captures) zoom to a smaller region.',
+    });
+  });
+
+  it('does not mistake partial lookalike objects for binary payloads', async () => {
+    const getBridgeMaxPayloadSize = vi.fn(() => 1);
+    const lookalike = { base64: 'YQ==', byteLength: '1000' };
+    const normalize = createBinaryResultNormalizer({
+      getBridgeMaxPayloadSize,
+      createBridgeError: bridgeError,
+      normalizeResult: async () => lookalike,
+    });
+
+    await expect(normalize('input', 'fallback.bin')).resolves.toBe(lookalike);
+    expect(getBridgeMaxPayloadSize).not.toHaveBeenCalled();
+  });
+});

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -127,6 +127,51 @@ describe('createDispatcher', () => {
     expect(getManufactureData).toHaveBeenCalledWith(exportParams);
   });
 
+  it('delegates every binary export method through the extracted domain', async () => {
+    const getGerberFile = vi.fn(async (params: unknown) => ({ kind: 'gerbers', params }));
+    const getDsnFile = vi.fn(async (fileName: unknown) => ({ kind: 'dsn', fileName }));
+    const getPickAndPlaceFile = vi.fn(async (params: unknown) => ({ kind: 'pick-place', params }));
+    const getPdfFile = vi.fn(async (params: unknown) => ({ kind: 'pdf', params }));
+    const getNetlist = vi.fn(async (params: unknown) => ({ kind: 'netlist', params }));
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        PCB_ManufactureData: {
+          getGerberFile,
+          getDsnFile,
+          getPickAndPlaceFile,
+          getPdfFile,
+        },
+        SCH_Netlist: { getNetlist },
+      }),
+    );
+
+    await expect(dispatcher.dispatch('board.exportGerbers', { layers: 'all' })).resolves.toEqual({
+      kind: 'gerbers',
+      params: { layers: 'all' },
+    });
+    await expect(
+      dispatcher.dispatch('pcb.exportRouteContext', { fileName: 'board.dsn' }),
+    ).resolves.toEqual({ kind: 'dsn', fileName: 'board.dsn' });
+    await expect(dispatcher.dispatch('export.pickPlace', { format: 'csv' })).resolves.toEqual({
+      kind: 'pick-place',
+      params: { format: 'csv' },
+    });
+    await expect(dispatcher.dispatch('export.pdf', { what: 'board' })).resolves.toEqual({
+      kind: 'pdf',
+      params: { what: 'board' },
+    });
+    await expect(dispatcher.dispatch('export.netlist', { format: 'spice' })).resolves.toEqual({
+      kind: 'netlist',
+      params: { format: 'spice' },
+    });
+
+    expect(getGerberFile).toHaveBeenCalledWith({ layers: 'all' });
+    expect(getDsnFile).toHaveBeenCalledWith('board.dsn');
+    expect(getPickAndPlaceFile).toHaveBeenCalledWith({ format: 'csv' });
+    expect(getPdfFile).toHaveBeenCalledWith({ what: 'board' });
+    expect(getNetlist).toHaveBeenCalledWith({ format: 'spice' });
+  });
+
   it('returns a dispatcher with a sorted, non-empty method list and a build id', () => {
     const dispatcher = createDispatcher(makeToolkit({}));
     expect(dispatcher.methodList.length).toBeGreaterThan(40);

--- a/easyeda-bridge-extension/tests/export-operations.test.ts
+++ b/easyeda-bridge-extension/tests/export-operations.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createExportOperations } from '../src/export-operations.js';
+
+function makeOperations() {
+  const callFirst = vi.fn(async () => 'native-result');
+  const normalizeBinaryResult = vi.fn(async (value, fileName) => ({ value, fileName }));
+  return {
+    callFirst,
+    normalizeBinaryResult,
+    operations: createExportOperations({ callFirst, normalizeBinaryResult }),
+  };
+}
+
+describe('export operations', () => {
+  it('exports Gerbers with the original API path, params, and fallback name', async () => {
+    const { callFirst, normalizeBinaryResult, operations } = makeOperations();
+    const params = { includeDrill: true };
+
+    await expect(operations.exportGerbers(params)).resolves.toEqual({
+      value: 'native-result',
+      fileName: 'gerbers.zip',
+    });
+    expect(callFirst).toHaveBeenCalledWith(['PCB_ManufactureData.getGerberFile'], params);
+    expect(normalizeBinaryResult).toHaveBeenCalledWith('native-result', 'gerbers.zip');
+  });
+
+  it('exports route context with only a string file name', async () => {
+    const { callFirst, operations } = makeOperations();
+
+    await operations.exportRouteContext({ fileName: 'board.dsn' });
+    await operations.exportRouteContext({ fileName: 42 });
+
+    expect(callFirst).toHaveBeenNthCalledWith(1, ['PCB_ManufactureData.getDsnFile'], 'board.dsn');
+    expect(callFirst).toHaveBeenNthCalledWith(2, ['PCB_ManufactureData.getDsnFile'], undefined);
+  });
+
+  it('preserves pick-and-place format fallback behavior', async () => {
+    const { normalizeBinaryResult, operations } = makeOperations();
+
+    await operations.exportPickPlace({ format: 'tsv' });
+    await operations.exportPickPlace({ format: 7 });
+
+    expect(normalizeBinaryResult).toHaveBeenNthCalledWith(1, 'native-result', 'pick-place.tsv');
+    expect(normalizeBinaryResult).toHaveBeenNthCalledWith(2, 'native-result', 'pick-place.csv');
+  });
+
+  it('keeps board PDF params unchanged and marks every other request schematic', async () => {
+    const { callFirst, operations } = makeOperations();
+    const boardParams = { what: 'board', pageSize: 'A4' };
+    const schematicParams = { what: 'schematic', pageSize: 'A3' };
+
+    await operations.exportPdf(boardParams);
+    await operations.exportPdf(schematicParams);
+
+    expect(callFirst).toHaveBeenNthCalledWith(
+      1,
+      ['PCB_ManufactureData.getPdfFile', 'SCH_ManufactureData.getExportDocumentFile'],
+      boardParams,
+    );
+    expect(callFirst).toHaveBeenNthCalledWith(
+      2,
+      ['PCB_ManufactureData.getPdfFile', 'SCH_ManufactureData.getExportDocumentFile'],
+      { ...schematicParams, type: 'schematic' },
+    );
+  });
+
+  it('uses the original netlist fallback chain and file-name fallback', async () => {
+    const { callFirst, normalizeBinaryResult, operations } = makeOperations();
+    const params = { format: 'spice', includeModels: true };
+
+    await operations.exportNetlist(params);
+    await operations.exportNetlist({ format: false });
+
+    const paths = [
+      'SCH_Netlist.getNetlist',
+      'SCH_ManufactureData.getNetlistFile',
+      'PCB_ManufactureData.getNetlistFile',
+    ];
+    expect(callFirst).toHaveBeenNthCalledWith(1, paths, params);
+    expect(callFirst).toHaveBeenNthCalledWith(2, paths, { format: false });
+    expect(normalizeBinaryResult).toHaveBeenNthCalledWith(1, 'native-result', 'netlist.spice');
+    expect(normalizeBinaryResult).toHaveBeenNthCalledWith(2, 'native-result', 'netlist.txt');
+  });
+});


### PR DESCRIPTION
## Summary

Extract `board.exportGerbers`, `pcb.exportRouteContext`, `export.pickPlace`, `export.pdf`, and `export.netlist` from the extension dispatcher into a typed `export-operations.ts` domain factory. Also move the shared binary-result transport budget into a typed `binary-result-policy.ts` factory so canvas and export operations consume the same bounded normalization policy.

This is the fifth bounded, behavior-preserving decomposition slice under #339. It does not close the parent issue and does not add or remove any public bridge capability.

## Contract parity

- Preserves all EasyEDA manufacturing/export API path orders and exact argument forwarding.
- Preserves Gerber, DSN, pick-and-place, PDF, and netlist fallback filenames.
- Preserves board-versus-schematic PDF parameter behavior.
- Preserves the 60% payload safety margin derived from `BRIDGE_MAX_PAYLOAD_SIZE`.
- Preserves the exact `PAYLOAD_TOO_LARGE` code, message, and suggestion.
- Keeps one shared binary normalization policy for canvas captures and export results.
- Keeps all 67 sorted public extension methods unchanged.

## Objective decomposition evidence

- `dispatcher.ts`: 4,673 lines on `main` → 4,611 lines (-62).
- Built dispatcher bundle: 153,845 bytes → 155,104 bytes (+1,259 bytes, approximately +0.82%).
- Packaged extension: 161,319 bytes → 161,675 bytes (+356 bytes, approximately +0.22%).
- Package and bundle remain within enforced budgets:
  - package: 161,675 / 200,000 bytes
  - extension entry: 215,505 / 260,000 bytes
  - dispatcher bundle: 155,104 / 185,000 bytes
- Method-list parity and package checksum verification pass.

## Tests

- Added 5 focused export-domain tests for exact API paths, arguments, parameter transforms, and fallback filenames.
- Added 4 focused payload-policy tests for pass-through, boundary acceptance, stable oversize rejection, and lookalike-object handling.
- Added a dispatcher integration contract that executes all five extracted public methods.
- `export-operations.ts` coverage: 100% statements, branches, functions, and lines.
- `binary-result-policy.ts` coverage: 100% statements, branches, functions, and lines.
- Focused dispatcher/domain parity: 6 files / 123 tests passed.
- Extension suite: 15 files / 181 tests passed.
- Server suite: 150 files / 1,740 tests passed.
- Full `pnpm verify` passed runtime preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, tests, builds, extension packaging/checksums, metadata alignment, compatibility generation, and VitePress documentation.
- Dependency audit passed with only the documented #334 advisory exception; peer dependency check found no issues.

## Follow-up

Further dispatcher domains will continue as separately reviewable, parity-tested PRs under #339.
