### PR TITLE
refactor(extension): extract board inspection

### DIFF
--- a/easyeda-bridge-extension/src/board-inspection.ts
+++ b/easyeda-bridge-extension/src/board-inspection.ts
@@ -31,6 +31,103 @@ function isActivePcbLayerName(name: string, copperLayerCount: number): boolean {
   return true;
 }
 
+async function readCopperLayerCount(pcbLayerClass: any): Promise<number> {
+  if (typeof pcbLayerClass?.getTheNumberOfCopperLayers !== 'function') return 0;
+  try {
+    const value = Number(await pcbLayerClass.getTheNumberOfCopperLayers());
+    return Number.isInteger(value) && value >= 2 ? value : 0;
+  } catch (error) {
+    logRecoverableError('failed to read copper layer count', error);
+    return 0;
+  }
+}
+
+function selectPhysicalStackupLayers(physicalStacking: any): any[] {
+  if (Array.isArray(physicalStacking?.layers)) return physicalStacking.layers;
+  if (Array.isArray(physicalStacking?.stackup)) return physicalStacking.stackup;
+  return [];
+}
+
+function readBoardThickness(physicalStacking: any): number | undefined {
+  if (typeof physicalStacking?.thicknessMm === 'number') return physicalStacking.thicknessMm;
+  if (typeof physicalStacking?.thickness === 'number') return physicalStacking.thickness;
+  return undefined;
+}
+
+interface BoundingBox {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
+function createEmptyBoundingBox(): BoundingBox {
+  return {
+    minX: Infinity,
+    maxX: -Infinity,
+    minY: Infinity,
+    maxY: -Infinity,
+  };
+}
+
+function updateBoundingBox(bounds: BoundingBox, x: number, y: number): void {
+  if (x < bounds.minX) bounds.minX = x;
+  if (x > bounds.maxX) bounds.maxX = x;
+  if (y < bounds.minY) bounds.minY = y;
+  if (y > bounds.maxY) bounds.maxY = y;
+}
+
+async function addOutlineLineBounds(pcbLineClass: any, bounds: BoundingBox): Promise<void> {
+  if (!pcbLineClass || typeof pcbLineClass.getAll !== 'function') return;
+  try {
+    const lines = await pcbLineClass.getAll();
+    for (const line of lines || []) {
+      if (typeof line.getState_Layer !== 'function' || line.getState_Layer() !== 11) continue;
+      const points = typeof line.getState_Points === 'function' ? line.getState_Points() : [];
+      for (const point of points || []) {
+        updateBoundingBox(bounds, point.x, point.y);
+      }
+    }
+  } catch (error) {
+    logRecoverableError('failed to read board outline lines', error);
+  }
+}
+
+async function addOutlineArcBounds(pcbArcClass: any, bounds: BoundingBox): Promise<void> {
+  if (!pcbArcClass || typeof pcbArcClass.getAll !== 'function') return;
+  try {
+    const arcs = await pcbArcClass.getAll();
+    for (const arc of arcs || []) {
+      if (typeof arc.getState_Layer !== 'function' || arc.getState_Layer() !== 11) continue;
+      const startX = typeof arc.getState_StartX === 'function' ? arc.getState_StartX() : 0;
+      const startY = typeof arc.getState_StartY === 'function' ? arc.getState_StartY() : 0;
+      const endX = typeof arc.getState_EndX === 'function' ? arc.getState_EndX() : 0;
+      const endY = typeof arc.getState_EndY === 'function' ? arc.getState_EndY() : 0;
+      updateBoundingBox(bounds, startX, startY);
+      updateBoundingBox(bounds, endX, endY);
+    }
+  } catch (error) {
+    logRecoverableError('failed to read board outline arcs', error);
+  }
+}
+
+async function countMountingHoles(pcbPadClass: any): Promise<number> {
+  if (!pcbPadClass || typeof pcbPadClass.getAll !== 'function') return 0;
+  try {
+    let mountingHoles = 0;
+    const pads = await pcbPadClass.getAll();
+    for (const pad of pads || []) {
+      const holeType = typeof pad.getState_HoleType === 'function' ? pad.getState_HoleType() : '';
+      const holeSize = typeof pad.getState_HoleSize === 'function' ? pad.getState_HoleSize() : 0;
+      if (holeType === 'MountingHole' || holeSize > 2) mountingHoles++;
+    }
+    return mountingHoles;
+  } catch (error) {
+    logRecoverableError('failed to read mounting-hole pads', error);
+    return 0;
+  }
+}
+
 export function createBoardInspectionOperations({
   readFirstPath,
   getGlobal,
@@ -61,17 +158,6 @@ export function createBoardInspectionOperations({
         'No active PCB document is focused.',
         'Open and focus a PCB document, then retry.',
       );
-    }
-  }
-
-  async function readCopperLayerCount(pcbLayerClass: any): Promise<number> {
-    if (typeof pcbLayerClass?.getTheNumberOfCopperLayers !== 'function') return 0;
-    try {
-      const value = Number(await pcbLayerClass.getTheNumberOfCopperLayers());
-      return Number.isInteger(value) && value >= 2 ? value : 0;
-    } catch (error) {
-      logRecoverableError('failed to read copper layer count', error);
-      return 0;
     }
   }
 
@@ -115,11 +201,7 @@ export function createBoardInspectionOperations({
       }
     }
 
-    const rawLayers = Array.isArray(physicalStacking?.layers)
-      ? physicalStacking.layers
-      : Array.isArray(physicalStacking?.stackup)
-        ? physicalStacking.stackup
-        : [];
+    const rawLayers = selectPhysicalStackupLayers(physicalStacking);
     const layers = rawLayers.map((layer: any) => ({
       name: layer?.name || '',
       type: layer?.type || '',
@@ -132,12 +214,7 @@ export function createBoardInspectionOperations({
       copperWeightOz:
         typeof layer?.copperWeightOz === 'number' ? layer.copperWeightOz : layer?.copperWeight,
     }));
-    const boardThickness =
-      typeof physicalStacking?.thicknessMm === 'number'
-        ? physicalStacking.thicknessMm
-        : typeof physicalStacking?.thickness === 'number'
-          ? physicalStacking.thickness
-          : undefined;
+    const boardThickness = readBoardThickness(physicalStacking);
     const available = Boolean(physicalStacking && layers.length > 0);
 
     return {
@@ -155,75 +232,16 @@ export function createBoardInspectionOperations({
     const pcbLineClass = readPath<any>(globalObj, 'pcb_PrimitiveLine');
     const pcbArcClass = readPath<any>(globalObj, 'pcb_PrimitiveArc');
     const pcbPadClass = readPath<any>(globalObj, 'pcb_PrimitivePad');
+    const bounds = createEmptyBoundingBox();
 
-    let minX = Infinity,
-      maxX = -Infinity;
-    let minY = Infinity,
-      maxY = -Infinity;
+    await addOutlineLineBounds(pcbLineClass, bounds);
+    await addOutlineArcBounds(pcbArcClass, bounds);
 
-    const updateBBox = (x: number, y: number) => {
-      if (x < minX) minX = x;
-      if (x > maxX) maxX = x;
-      if (y < minY) minY = y;
-      if (y > maxY) maxY = y;
-    };
-
-    if (pcbLineClass && typeof pcbLineClass.getAll === 'function') {
-      try {
-        const lines = await pcbLineClass.getAll();
-        for (const line of lines || []) {
-          if (typeof line.getState_Layer === 'function' && line.getState_Layer() === 11) {
-            const points = typeof line.getState_Points === 'function' ? line.getState_Points() : [];
-            for (const point of points || []) {
-              updateBBox(point.x, point.y);
-            }
-          }
-        }
-      } catch (error) {
-        logRecoverableError('failed to read board outline lines', error);
-      }
-    }
-
-    if (pcbArcClass && typeof pcbArcClass.getAll === 'function') {
-      try {
-        const arcs = await pcbArcClass.getAll();
-        for (const arc of arcs || []) {
-          if (typeof arc.getState_Layer === 'function' && arc.getState_Layer() === 11) {
-            const startX = typeof arc.getState_StartX === 'function' ? arc.getState_StartX() : 0;
-            const startY = typeof arc.getState_StartY === 'function' ? arc.getState_StartY() : 0;
-            const endX = typeof arc.getState_EndX === 'function' ? arc.getState_EndX() : 0;
-            const endY = typeof arc.getState_EndY === 'function' ? arc.getState_EndY() : 0;
-            updateBBox(startX, startY);
-            updateBBox(endX, endY);
-          }
-        }
-      } catch (error) {
-        logRecoverableError('failed to read board outline arcs', error);
-      }
-    }
-
-    const width = maxX > minX ? maxX - minX : 0;
-    const height = maxY > minY ? maxY - minY : 0;
-
-    let mountingHoles = 0;
-    if (pcbPadClass && typeof pcbPadClass.getAll === 'function') {
-      try {
-        const pads = await pcbPadClass.getAll();
-        for (const pad of pads || []) {
-          const holeType =
-            typeof pad.getState_HoleType === 'function' ? pad.getState_HoleType() : '';
-          const holeSize =
-            typeof pad.getState_HoleSize === 'function' ? pad.getState_HoleSize() : 0;
-          if (holeType === 'MountingHole' || holeSize > 2) {
-            mountingHoles++;
-          }
-        }
-      } catch (error) {
-        logRecoverableError('failed to read mounting-hole pads', error);
-      }
-    }
-
+    const width = bounds.maxX > bounds.minX ? bounds.maxX - bounds.minX : 0;
+    const height = bounds.maxY > bounds.minY ? bounds.maxY - bounds.minY : 0;
+    const mountingHoles = await countMountingHoles(pcbPadClass);
     const hasOutline = width > 0 && height > 0;
+
     return {
       widthMm: width,
       heightMm: height,

--- a/easyeda-bridge-extension/src/board-inspection.ts
+++ b/easyeda-bridge-extension/src/board-inspection.ts
@@ -1,0 +1,311 @@
+import type { ApiRuntime, BridgeErrorFactory } from './api-runtime.js';
+import type { DispatcherToolkit } from './toolkit.js';
+import { logRecoverableError, readPath } from './utils.js';
+
+export interface BoardInspectionDependencies {
+  readFirstPath: ApiRuntime['readFirstPath'];
+  getGlobal: DispatcherToolkit['getGlobal'];
+  createBridgeError: BridgeErrorFactory;
+}
+
+export interface BoardInspectionOperations {
+  requireActivePcbContext(): Promise<void>;
+  listLayers(): Promise<unknown>;
+  getStackup(): Promise<unknown>;
+  getDimensions(): Promise<unknown>;
+  getFeatures(): Promise<unknown>;
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isActivePcbLayerName(name: string, copperLayerCount: number): boolean {
+  const inner = /^Inner(\d+)$/i.exec(name);
+  if (inner) return Number(inner[1]) <= Math.max(0, copperLayerCount - 2);
+  // EasyEDA returns its entire layer catalogue (200 Custom slots and all 32
+  // possible inner layers) from getAllLayers(). Those catalogue placeholders
+  // are not layers in the active board. A renamed custom layer no longer
+  // matches this placeholder pattern and is retained.
+  if (/^Custom\d+$/i.test(name) || /^Dielectric\d+$/i.test(name)) return false;
+  return true;
+}
+
+export function createBoardInspectionOperations({
+  readFirstPath,
+  getGlobal,
+  createBridgeError,
+}: BoardInspectionDependencies): BoardInspectionOperations {
+  async function requireActivePcbContext(): Promise<void> {
+    const dmtPcb = readFirstPath<any>(['DMT_Pcb', 'dmt_Pcb']);
+    if (!dmtPcb || typeof dmtPcb.getCurrentPcbInfo !== 'function') {
+      // Older EasyEDA builds may not expose DMT_Pcb. Preserve compatibility and
+      // let the concrete PCB API call decide whether the context is usable.
+      return;
+    }
+
+    let currentPcb: unknown;
+    try {
+      currentPcb = await dmtPcb.getCurrentPcbInfo();
+    } catch (error) {
+      throw createBridgeError(
+        'CONTEXT_UNAVAILABLE',
+        'PCB data is unavailable in the current editor context.',
+        'Open and focus a PCB document, then retry.',
+        { cause: errorMessage(error) },
+      );
+    }
+    if (!currentPcb) {
+      throw createBridgeError(
+        'CONTEXT_UNAVAILABLE',
+        'No active PCB document is focused.',
+        'Open and focus a PCB document, then retry.',
+      );
+    }
+  }
+
+  async function readCopperLayerCount(pcbLayerClass: any): Promise<number> {
+    if (typeof pcbLayerClass?.getTheNumberOfCopperLayers !== 'function') return 0;
+    try {
+      const value = Number(await pcbLayerClass.getTheNumberOfCopperLayers());
+      return Number.isInteger(value) && value >= 2 ? value : 0;
+    } catch (error) {
+      logRecoverableError('failed to read copper layer count', error);
+      return 0;
+    }
+  }
+
+  async function listLayers(): Promise<unknown> {
+    await requireActivePcbContext();
+    const pcbLayerClass = readFirstPath<any>(['PCB_Layer', 'pcb_Layer']);
+    if (!pcbLayerClass || typeof pcbLayerClass.getAllLayers !== 'function') {
+      throw new Error('pcb_Layer class or getAllLayers method not found');
+    }
+    const copperLayerCount = await readCopperLayerCount(pcbLayerClass);
+    const rawLayers = await pcbLayerClass.getAllLayers();
+    const layers = Array.isArray(rawLayers) ? rawLayers : [];
+    return layers
+      .filter((layer: any) => isActivePcbLayerName(String(layer?.name ?? ''), copperLayerCount))
+      .map((layer: any, index: number) => ({
+        name: layer?.name || '',
+        type: layer?.type || '',
+        color: layer?.color || '',
+        visible: layer?.visible !== false,
+        order:
+          typeof layer?.order === 'number' && Number.isFinite(layer.order) && layer.order > 0
+            ? layer.order
+            : index,
+      }));
+  }
+
+  async function getStackup(): Promise<unknown> {
+    await requireActivePcbContext();
+    const pcbLayerClass = readFirstPath<any>(['PCB_Layer', 'pcb_Layer']);
+    if (!pcbLayerClass) {
+      throw new Error('pcb_Layer class not found');
+    }
+
+    const totalCopper = await readCopperLayerCount(pcbLayerClass);
+    let physicalStacking: any = null;
+    if (typeof pcbLayerClass.getCurrentPhysicalStackingConfiguration === 'function') {
+      try {
+        physicalStacking = await pcbLayerClass.getCurrentPhysicalStackingConfiguration();
+      } catch (error) {
+        logRecoverableError('failed to read physical stackup', error);
+      }
+    }
+
+    const rawLayers = Array.isArray(physicalStacking?.layers)
+      ? physicalStacking.layers
+      : Array.isArray(physicalStacking?.stackup)
+        ? physicalStacking.stackup
+        : [];
+    const layers = rawLayers.map((layer: any) => ({
+      name: layer?.name || '',
+      type: layer?.type || '',
+      thicknessMm: typeof layer?.thicknessMm === 'number' ? layer.thicknessMm : layer?.thickness,
+      material: layer?.material || '',
+      dielectricConstant:
+        typeof layer?.dielectricConstant === 'number'
+          ? layer.dielectricConstant
+          : layer?.dielectric,
+      copperWeightOz:
+        typeof layer?.copperWeightOz === 'number' ? layer.copperWeightOz : layer?.copperWeight,
+    }));
+    const boardThickness =
+      typeof physicalStacking?.thicknessMm === 'number'
+        ? physicalStacking.thicknessMm
+        : typeof physicalStacking?.thickness === 'number'
+          ? physicalStacking.thickness
+          : undefined;
+    const available = Boolean(physicalStacking && layers.length > 0);
+
+    return {
+      totalLayers: totalCopper,
+      boardThicknessMm: boardThickness,
+      layers,
+      available,
+      source: available ? 'physical_stackup' : 'copper_layer_count_only',
+    };
+  }
+
+  async function getDimensions(): Promise<unknown> {
+    await requireActivePcbContext();
+    const globalObj = getGlobal();
+    const pcbLineClass = readPath<any>(globalObj, 'pcb_PrimitiveLine');
+    const pcbArcClass = readPath<any>(globalObj, 'pcb_PrimitiveArc');
+    const pcbPadClass = readPath<any>(globalObj, 'pcb_PrimitivePad');
+
+    let minX = Infinity,
+      maxX = -Infinity;
+    let minY = Infinity,
+      maxY = -Infinity;
+
+    const updateBBox = (x: number, y: number) => {
+      if (x < minX) minX = x;
+      if (x > maxX) maxX = x;
+      if (y < minY) minY = y;
+      if (y > maxY) maxY = y;
+    };
+
+    if (pcbLineClass && typeof pcbLineClass.getAll === 'function') {
+      try {
+        const lines = await pcbLineClass.getAll();
+        for (const line of lines || []) {
+          if (typeof line.getState_Layer === 'function' && line.getState_Layer() === 11) {
+            const points = typeof line.getState_Points === 'function' ? line.getState_Points() : [];
+            for (const point of points || []) {
+              updateBBox(point.x, point.y);
+            }
+          }
+        }
+      } catch (error) {
+        logRecoverableError('failed to read board outline lines', error);
+      }
+    }
+
+    if (pcbArcClass && typeof pcbArcClass.getAll === 'function') {
+      try {
+        const arcs = await pcbArcClass.getAll();
+        for (const arc of arcs || []) {
+          if (typeof arc.getState_Layer === 'function' && arc.getState_Layer() === 11) {
+            const startX = typeof arc.getState_StartX === 'function' ? arc.getState_StartX() : 0;
+            const startY = typeof arc.getState_StartY === 'function' ? arc.getState_StartY() : 0;
+            const endX = typeof arc.getState_EndX === 'function' ? arc.getState_EndX() : 0;
+            const endY = typeof arc.getState_EndY === 'function' ? arc.getState_EndY() : 0;
+            updateBBox(startX, startY);
+            updateBBox(endX, endY);
+          }
+        }
+      } catch (error) {
+        logRecoverableError('failed to read board outline arcs', error);
+      }
+    }
+
+    const width = maxX > minX ? maxX - minX : 0;
+    const height = maxY > minY ? maxY - minY : 0;
+
+    let mountingHoles = 0;
+    if (pcbPadClass && typeof pcbPadClass.getAll === 'function') {
+      try {
+        const pads = await pcbPadClass.getAll();
+        for (const pad of pads || []) {
+          const holeType =
+            typeof pad.getState_HoleType === 'function' ? pad.getState_HoleType() : '';
+          const holeSize =
+            typeof pad.getState_HoleSize === 'function' ? pad.getState_HoleSize() : 0;
+          if (holeType === 'MountingHole' || holeSize > 2) {
+            mountingHoles++;
+          }
+        }
+      } catch (error) {
+        logRecoverableError('failed to read mounting-hole pads', error);
+      }
+    }
+
+    const hasOutline = width > 0 && height > 0;
+    return {
+      widthMm: width,
+      heightMm: height,
+      shape: hasOutline ? 'custom' : undefined,
+      mountingHoleCount: mountingHoles,
+      areaMm2: width * height,
+      hasOutline,
+    };
+  }
+
+  async function getFeatures(): Promise<unknown> {
+    await requireActivePcbContext();
+    const globalObj = getGlobal();
+    const pcbViaClass = readPath<any>(globalObj, 'pcb_PrimitiveVia');
+    // Tracks are PCB_PrimitiveLine segments (confirmed live: PCB_PrimitivePolyline
+    // never accepts a valid create() call). 'pcb_PrimitiveTrack' does not exist in
+    // the runtime at all, so this count was always silently 0.
+    const pcbTrackClass = readPath<any>(globalObj, 'pcb_PrimitiveLine');
+    const pcbPadClass = readPath<any>(globalObj, 'pcb_PrimitivePad');
+    const pcbPourClass = readPath<any>(globalObj, 'pcb_PrimitivePour');
+    const pcbCompClass = readPath<any>(globalObj, 'pcb_PrimitiveComponent');
+
+    let viasCount = 0;
+    let tracksCount = 0;
+    let padsCount = 0;
+    let zonesCount = 0;
+    let compsCount = 0;
+
+    try {
+      if (pcbViaClass && typeof pcbViaClass.getAll === 'function') {
+        viasCount = (await pcbViaClass.getAll())?.length || 0;
+      }
+    } catch (error) {
+      logRecoverableError('failed to count vias', error);
+    }
+
+    try {
+      if (pcbTrackClass && typeof pcbTrackClass.getAll === 'function') {
+        tracksCount = (await pcbTrackClass.getAll())?.length || 0;
+      }
+    } catch (error) {
+      logRecoverableError('failed to count tracks', error);
+    }
+
+    try {
+      if (pcbPadClass && typeof pcbPadClass.getAll === 'function') {
+        padsCount = (await pcbPadClass.getAll())?.length || 0;
+      }
+    } catch (error) {
+      logRecoverableError('failed to count pads', error);
+    }
+
+    try {
+      if (pcbPourClass && typeof pcbPourClass.getAll === 'function') {
+        zonesCount = (await pcbPourClass.getAll())?.length || 0;
+      }
+    } catch (error) {
+      logRecoverableError('failed to count zones', error);
+    }
+
+    try {
+      if (pcbCompClass && typeof pcbCompClass.getAll === 'function') {
+        compsCount = (await pcbCompClass.getAll())?.length || 0;
+      }
+    } catch (error) {
+      logRecoverableError('failed to count PCB components', error);
+    }
+
+    return {
+      vias: viasCount,
+      tracks: tracksCount,
+      zones: zonesCount,
+      pads: padsCount,
+      components: compsCount,
+    };
+  }
+
+  return {
+    requireActivePcbContext,
+    listLayers,
+    getStackup,
+    getDimensions,
+    getFeatures,
+  };
+}

--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -15,11 +15,15 @@ import {
   readStateValue,
 } from './api-introspection.js';
 import { createBinaryResultNormalizer } from './binary-result-policy.js';
+import {
+  createBoardInspectionOperations,
+  type BoardInspectionOperations,
+} from './board-inspection.js';
 import { createCanvasOperations, type CanvasOperations } from './canvas-operations.js';
 import { createExportOperations, type ExportOperations } from './export-operations.js';
 import { createProjectOperations, type ProjectOperations } from './project-operations.js';
 import type { Dispatcher, DispatcherToolkit } from './toolkit.js';
-import { isRecord, log, logRecoverableError, readPath, type JsonValue } from './utils.js';
+import { isRecord, log, logRecoverableError, type JsonValue } from './utils.js';
 
 // Injected at build time via esbuild --define; identifies this bundle build.
 declare const __MCP_DISPATCHER_BUILD_ID__: string | undefined;
@@ -108,6 +112,7 @@ let callFirst: ApiRuntime['callFirst'];
 let readFirstPath: ApiRuntime['readFirstPath'];
 let inspectApiInventory: ApiRuntime['inspectApiInventory'];
 let callAllowedApi: ApiRuntime['callAllowedApi'];
+let boardInspection: BoardInspectionOperations;
 let canvasOperations: CanvasOperations;
 let exportOperations: ExportOperations;
 let projectOperations: ProjectOperations;
@@ -2184,278 +2189,6 @@ async function inspectWiresApi(limit = 10, offset = 0): Promise<unknown> {
   };
 }
 
-async function requireActivePcbContext(): Promise<void> {
-  const dmtPcb = readFirstPath<any>(['DMT_Pcb', 'dmt_Pcb']);
-  if (!dmtPcb || typeof dmtPcb.getCurrentPcbInfo !== 'function') {
-    // Older EasyEDA builds may not expose DMT_Pcb. Preserve compatibility and
-    // let the concrete PCB API call decide whether the context is usable.
-    return;
-  }
-
-  let currentPcb: unknown;
-  try {
-    currentPcb = await dmtPcb.getCurrentPcbInfo();
-  } catch (error) {
-    throw newBridgeError(
-      'CONTEXT_UNAVAILABLE',
-      'PCB data is unavailable in the current editor context.',
-      'Open and focus a PCB document, then retry.',
-      { cause: errorMessage(error) },
-    );
-  }
-  if (!currentPcb) {
-    throw newBridgeError(
-      'CONTEXT_UNAVAILABLE',
-      'No active PCB document is focused.',
-      'Open and focus a PCB document, then retry.',
-    );
-  }
-}
-
-function isActivePcbLayerName(name: string, copperLayerCount: number): boolean {
-  const inner = /^Inner(\d+)$/i.exec(name);
-  if (inner) return Number(inner[1]) <= Math.max(0, copperLayerCount - 2);
-  // EasyEDA returns its entire layer catalogue (200 Custom slots and all 32
-  // possible inner layers) from getAllLayers(). Those catalogue placeholders
-  // are not layers in the active board. A renamed custom layer no longer
-  // matches this placeholder pattern and is retained.
-  if (/^Custom\d+$/i.test(name) || /^Dielectric\d+$/i.test(name)) return false;
-  return true;
-}
-
-async function readCopperLayerCount(pcbLayerClass: any): Promise<number> {
-  if (typeof pcbLayerClass?.getTheNumberOfCopperLayers !== 'function') return 0;
-  try {
-    const value = Number(await pcbLayerClass.getTheNumberOfCopperLayers());
-    return Number.isInteger(value) && value >= 2 ? value : 0;
-  } catch (error) {
-    logRecoverableError('failed to read copper layer count', error);
-    return 0;
-  }
-}
-
-async function listLayersApi(): Promise<unknown> {
-  await requireActivePcbContext();
-  const pcbLayerClass = readFirstPath<any>(['PCB_Layer', 'pcb_Layer']);
-  if (!pcbLayerClass || typeof pcbLayerClass.getAllLayers !== 'function') {
-    throw new Error('pcb_Layer class or getAllLayers method not found');
-  }
-  const copperLayerCount = await readCopperLayerCount(pcbLayerClass);
-  const rawLayers = await pcbLayerClass.getAllLayers();
-  const layers = Array.isArray(rawLayers) ? rawLayers : [];
-  return layers
-    .filter((layer: any) => isActivePcbLayerName(String(layer?.name ?? ''), copperLayerCount))
-    .map((layer: any, index: number) => ({
-      name: layer?.name || '',
-      type: layer?.type || '',
-      color: layer?.color || '',
-      visible: layer?.visible !== false,
-      order:
-        typeof layer?.order === 'number' && Number.isFinite(layer.order) && layer.order > 0
-          ? layer.order
-          : index,
-    }));
-}
-
-async function getStackupApi(): Promise<unknown> {
-  await requireActivePcbContext();
-  const pcbLayerClass = readFirstPath<any>(['PCB_Layer', 'pcb_Layer']);
-  if (!pcbLayerClass) {
-    throw new Error('pcb_Layer class not found');
-  }
-
-  const totalCopper = await readCopperLayerCount(pcbLayerClass);
-  let physicalStacking: any = null;
-  if (typeof pcbLayerClass.getCurrentPhysicalStackingConfiguration === 'function') {
-    try {
-      physicalStacking = await pcbLayerClass.getCurrentPhysicalStackingConfiguration();
-    } catch (error) {
-      logRecoverableError('failed to read physical stackup', error);
-    }
-  }
-
-  const rawLayers = Array.isArray(physicalStacking?.layers)
-    ? physicalStacking.layers
-    : Array.isArray(physicalStacking?.stackup)
-      ? physicalStacking.stackup
-      : [];
-  const layers = rawLayers.map((layer: any) => ({
-    name: layer?.name || '',
-    type: layer?.type || '',
-    thicknessMm: typeof layer?.thicknessMm === 'number' ? layer.thicknessMm : layer?.thickness,
-    material: layer?.material || '',
-    dielectricConstant:
-      typeof layer?.dielectricConstant === 'number' ? layer.dielectricConstant : layer?.dielectric,
-    copperWeightOz:
-      typeof layer?.copperWeightOz === 'number' ? layer.copperWeightOz : layer?.copperWeight,
-  }));
-  const boardThickness =
-    typeof physicalStacking?.thicknessMm === 'number'
-      ? physicalStacking.thicknessMm
-      : typeof physicalStacking?.thickness === 'number'
-        ? physicalStacking.thickness
-        : undefined;
-  const available = Boolean(physicalStacking && layers.length > 0);
-
-  return {
-    totalLayers: totalCopper,
-    boardThicknessMm: boardThickness,
-    layers,
-    available,
-    source: available ? 'physical_stackup' : 'copper_layer_count_only',
-  };
-}
-
-async function getDimensionsApi(): Promise<unknown> {
-  await requireActivePcbContext();
-  const globalObj = tk.getGlobal();
-  const pcbLineClass = readPath<any>(globalObj, 'pcb_PrimitiveLine');
-  const pcbArcClass = readPath<any>(globalObj, 'pcb_PrimitiveArc');
-  const pcbPadClass = readPath<any>(globalObj, 'pcb_PrimitivePad');
-
-  let minX = Infinity,
-    maxX = -Infinity;
-  let minY = Infinity,
-    maxY = -Infinity;
-
-  const updateBBox = (x: number, y: number) => {
-    if (x < minX) minX = x;
-    if (x > maxX) maxX = x;
-    if (y < minY) minY = y;
-    if (y > maxY) maxY = y;
-  };
-
-  if (pcbLineClass && typeof pcbLineClass.getAll === 'function') {
-    try {
-      const lines = await pcbLineClass.getAll();
-      for (const l of lines || []) {
-        if (typeof l.getState_Layer === 'function' && l.getState_Layer() === 11) {
-          const points = typeof l.getState_Points === 'function' ? l.getState_Points() : [];
-          for (const p of points || []) {
-            updateBBox(p.x, p.y);
-          }
-        }
-      }
-    } catch (e) {
-      logRecoverableError('failed to read board outline lines', e);
-    }
-  }
-
-  if (pcbArcClass && typeof pcbArcClass.getAll === 'function') {
-    try {
-      const arcs = await pcbArcClass.getAll();
-      for (const a of arcs || []) {
-        if (typeof a.getState_Layer === 'function' && a.getState_Layer() === 11) {
-          const sx = typeof a.getState_StartX === 'function' ? a.getState_StartX() : 0;
-          const sy = typeof a.getState_StartY === 'function' ? a.getState_StartY() : 0;
-          const ex = typeof a.getState_EndX === 'function' ? a.getState_EndX() : 0;
-          const ey = typeof a.getState_EndY === 'function' ? a.getState_EndY() : 0;
-          updateBBox(sx, sy);
-          updateBBox(ex, ey);
-        }
-      }
-    } catch (e) {
-      logRecoverableError('failed to read board outline arcs', e);
-    }
-  }
-
-  const width = maxX > minX ? maxX - minX : 0;
-  const height = maxY > minY ? maxY - minY : 0;
-
-  let mountingHoles = 0;
-  if (pcbPadClass && typeof pcbPadClass.getAll === 'function') {
-    try {
-      const pads = await pcbPadClass.getAll();
-      for (const p of pads || []) {
-        const hType = typeof p.getState_HoleType === 'function' ? p.getState_HoleType() : '';
-        const hSize = typeof p.getState_HoleSize === 'function' ? p.getState_HoleSize() : 0;
-        if (hType === 'MountingHole' || hSize > 2) {
-          mountingHoles++;
-        }
-      }
-    } catch (e) {
-      logRecoverableError('failed to read mounting-hole pads', e);
-    }
-  }
-
-  const hasOutline = width > 0 && height > 0;
-  return {
-    widthMm: width,
-    heightMm: height,
-    shape: hasOutline ? 'custom' : undefined,
-    mountingHoleCount: mountingHoles,
-    areaMm2: width * height,
-    hasOutline,
-  };
-}
-
-async function getFeaturesApi(): Promise<unknown> {
-  await requireActivePcbContext();
-  const globalObj = tk.getGlobal();
-  const pcbViaClass = readPath<any>(globalObj, 'pcb_PrimitiveVia');
-  // Tracks are PCB_PrimitiveLine segments (confirmed live: PCB_PrimitivePolyline
-  // never accepts a valid create() call). 'pcb_PrimitiveTrack' does not exist in
-  // the runtime at all, so this count was always silently 0.
-  const pcbTrackClass = readPath<any>(globalObj, 'pcb_PrimitiveLine');
-  const pcbPadClass = readPath<any>(globalObj, 'pcb_PrimitivePad');
-  const pcbPourClass = readPath<any>(globalObj, 'pcb_PrimitivePour');
-  const pcbCompClass = readPath<any>(globalObj, 'pcb_PrimitiveComponent');
-
-  let viasCount = 0;
-  let tracksCount = 0;
-  let padsCount = 0;
-  let zonesCount = 0;
-  let compsCount = 0;
-
-  try {
-    if (pcbViaClass && typeof pcbViaClass.getAll === 'function') {
-      viasCount = (await pcbViaClass.getAll())?.length || 0;
-    }
-  } catch (e) {
-    logRecoverableError('failed to count vias', e);
-  }
-
-  try {
-    if (pcbTrackClass && typeof pcbTrackClass.getAll === 'function') {
-      tracksCount = (await pcbTrackClass.getAll())?.length || 0;
-    }
-  } catch (e) {
-    logRecoverableError('failed to count tracks', e);
-  }
-
-  try {
-    if (pcbPadClass && typeof pcbPadClass.getAll === 'function') {
-      padsCount = (await pcbPadClass.getAll())?.length || 0;
-    }
-  } catch (e) {
-    logRecoverableError('failed to count pads', e);
-  }
-
-  try {
-    if (pcbPourClass && typeof pcbPourClass.getAll === 'function') {
-      zonesCount = (await pcbPourClass.getAll())?.length || 0;
-    }
-  } catch (e) {
-    logRecoverableError('failed to count zones', e);
-  }
-
-  try {
-    if (pcbCompClass && typeof pcbCompClass.getAll === 'function') {
-      compsCount = (await pcbCompClass.getAll())?.length || 0;
-    }
-  } catch (e) {
-    logRecoverableError('failed to count PCB components', e);
-  }
-
-  return {
-    vias: viasCount,
-    tracks: tracksCount,
-    zones: zonesCount,
-    pads: padsCount,
-    components: compsCount,
-  };
-}
-
 /**
  * Classes pcbDeletePrimitivesApi checks, in lookup order. Confirmed live
  * (2026-07-07): PCB_PrimitiveComponent.delete() returns `true` for ANY id,
@@ -2531,7 +2264,7 @@ async function pcbDeletePrimitivesApi(
  * than throw, since "no PCB open" is a normal state, not an error.
  */
 async function pcbListComponentsApi(limit?: number, offset = 0): Promise<unknown> {
-  await requireActivePcbContext();
+  await boardInspection.requireActivePcbContext();
   const pcbCompClass = readFirstPath<any>(['PCB_PrimitiveComponent', 'pcb_PrimitiveComponent']);
   if (!pcbCompClass || typeof pcbCompClass.getAll !== 'function') {
     return { total: 0, items: [] };
@@ -2561,7 +2294,7 @@ async function pcbListComponentsApi(limit?: number, offset = 0): Promise<unknown
 }
 
 async function pcbListTracksApi(limit?: number, offset = 0): Promise<unknown> {
-  await requireActivePcbContext();
+  await boardInspection.requireActivePcbContext();
   // Tracks are PCB_PrimitiveLine segments — see the pcb.addTrack case for why
   // PCB_PrimitivePolyline is not used (its create() never resolved live).
   const pcbLineClass = readFirstPath<any>(['PCB_PrimitiveLine', 'pcb_PrimitiveLine']);
@@ -2587,7 +2320,7 @@ async function pcbListTracksApi(limit?: number, offset = 0): Promise<unknown> {
 }
 
 async function pcbListViasApi(limit?: number, offset = 0): Promise<unknown> {
-  await requireActivePcbContext();
+  await boardInspection.requireActivePcbContext();
   const pcbViaClass = readFirstPath<any>(['PCB_PrimitiveVia', 'pcb_PrimitiveVia']);
   if (!pcbViaClass || typeof pcbViaClass.getAll !== 'function') {
     return { total: 0, items: [] };
@@ -4181,13 +3914,13 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
       return { result: normalizeValue(result, 5) };
     }
     case 'board.listLayers':
-      return listLayersApi();
+      return boardInspection.listLayers();
     case 'board.getStackup':
-      return getStackupApi();
+      return boardInspection.getStackup();
     case 'board.getDimensions':
-      return getDimensionsApi();
+      return boardInspection.getDimensions();
     case 'board.getFeatures':
-      return getFeaturesApi();
+      return boardInspection.getFeatures();
     case 'board.exportGerbers':
       return exportOperations.exportGerbers(params);
     case 'pcb.exportRouteContext':
@@ -4590,6 +4323,11 @@ export function createDispatcher(toolkit: DispatcherToolkit): Dispatcher {
     toolkit,
     newBridgeError,
   ));
+  boardInspection = createBoardInspectionOperations({
+    readFirstPath,
+    getGlobal: () => toolkit.getGlobal(),
+    createBridgeError: newBridgeError,
+  });
   const normalizeBinaryResult = createBinaryResultNormalizer({
     getBridgeMaxPayloadSize: () => toolkit.getBridgeMaxPayloadSize(),
     createBridgeError: newBridgeError,

--- a/easyeda-bridge-extension/tests/board-inspection.test.ts
+++ b/easyeda-bridge-extension/tests/board-inspection.test.ts
@@ -1,0 +1,347 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createBoardInspectionOperations } from '../src/board-inspection.js';
+
+function bridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
+  return Object.assign(new Error(message), { code, suggestion, data });
+}
+
+function makeOperations(
+  runtime: Record<string, unknown> = {},
+  globalRoot: Record<string, unknown> | null = {},
+) {
+  const readFirstPath = vi.fn(<T>(paths: readonly string[]): T | undefined => {
+    for (const path of paths) {
+      if (path in runtime) return runtime[path] as T;
+    }
+    return undefined;
+  });
+  const getGlobal = vi.fn(() => globalRoot);
+  return {
+    readFirstPath,
+    getGlobal,
+    operations: createBoardInspectionOperations({
+      readFirstPath,
+      getGlobal,
+      createBridgeError: bridgeError,
+    }),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('board inspection operations', () => {
+  it('preserves compatibility when DMT_Pcb is unavailable', async () => {
+    const { operations } = makeOperations();
+
+    await expect(operations.requireActivePcbContext()).resolves.toBeUndefined();
+  });
+
+  it('translates a failing PCB context read into the stable bridge error', async () => {
+    const { operations } = makeOperations({
+      DMT_Pcb: {
+        getCurrentPcbInfo: async () => {
+          throw new Error('message bus unavailable');
+        },
+      },
+    });
+
+    await expect(operations.requireActivePcbContext()).rejects.toMatchObject({
+      code: 'CONTEXT_UNAVAILABLE',
+      message: 'PCB data is unavailable in the current editor context.',
+      suggestion: 'Open and focus a PCB document, then retry.',
+      data: { cause: 'message bus unavailable' },
+    });
+  });
+
+  it('rejects a missing focused PCB before reading board data', async () => {
+    const getAllLayers = vi.fn(async () => []);
+    const { operations } = makeOperations({
+      DMT_Pcb: { getCurrentPcbInfo: async () => null },
+      PCB_Layer: { getAllLayers },
+    });
+
+    await expect(operations.listLayers()).rejects.toMatchObject({
+      code: 'CONTEXT_UNAVAILABLE',
+      message: 'No active PCB document is focused.',
+    });
+    expect(getAllLayers).not.toHaveBeenCalled();
+  });
+
+  it('filters inactive catalogue layers and normalizes public layer fields', async () => {
+    const { operations } = makeOperations({
+      DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) },
+      PCB_Layer: {
+        getTheNumberOfCopperLayers: async () => 4,
+        getAllLayers: async () => [
+          { name: 'Top Layer', type: 'SIGNAL', color: '#f00', visible: false, order: 7 },
+          { name: 'Bottom Layer', type: 'SIGNAL' },
+          { name: 'Inner1', type: 'SIGNAL' },
+          { name: 'Inner2', type: 'SIGNAL' },
+          { name: 'Inner3', type: 'SIGNAL' },
+          { name: 'Custom1', type: 'CUSTOM' },
+          { name: 'Dielectric1', type: 'OTHER' },
+          { name: 'Mechanical Layer', type: 'OTHER', order: Number.NaN },
+          { name: 'RF Keepout', type: 'CUSTOM', order: 0 },
+        ],
+      },
+    });
+
+    await expect(operations.listLayers()).resolves.toEqual([
+      { name: 'Top Layer', type: 'SIGNAL', color: '#f00', visible: false, order: 7 },
+      { name: 'Bottom Layer', type: 'SIGNAL', color: '', visible: true, order: 1 },
+      { name: 'Inner1', type: 'SIGNAL', color: '', visible: true, order: 2 },
+      { name: 'Inner2', type: 'SIGNAL', color: '', visible: true, order: 3 },
+      { name: 'Mechanical Layer', type: 'OTHER', color: '', visible: true, order: 4 },
+      { name: 'RF Keepout', type: 'CUSTOM', color: '', visible: true, order: 5 },
+    ]);
+  });
+
+  it('degrades invalid copper-layer counts and non-array layer results safely', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const getTheNumberOfCopperLayers = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('count failed'))
+      .mockResolvedValueOnce(1);
+    const getAllLayers = vi
+      .fn()
+      .mockResolvedValueOnce([{ name: 'Inner1' }])
+      .mockResolvedValueOnce({});
+    const { operations } = makeOperations({
+      DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) },
+      PCB_Layer: { getTheNumberOfCopperLayers, getAllLayers },
+    });
+
+    await expect(operations.listLayers()).resolves.toEqual([]);
+    await expect(operations.listLayers()).resolves.toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      '[easyeda-mcp-pro]',
+      'failed to read copper layer count',
+      expect.any(Error),
+    );
+  });
+
+  it('rejects listLayers when the layer API is unavailable', async () => {
+    const { operations } = makeOperations({
+      DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) },
+    });
+
+    await expect(operations.listLayers()).rejects.toThrow(
+      'pcb_Layer class or getAllLayers method not found',
+    );
+  });
+
+  it('maps a physical stackup without inventing missing values', async () => {
+    const { operations } = makeOperations({
+      DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) },
+      PCB_Layer: {
+        getTheNumberOfCopperLayers: async () => 4,
+        getCurrentPhysicalStackingConfiguration: async () => ({
+          thicknessMm: 1.6,
+          layers: [
+            {
+              name: 'Top',
+              type: 'copper',
+              thicknessMm: 0.035,
+              material: 'Cu',
+              dielectricConstant: 1,
+              copperWeightOz: 1,
+            },
+            {
+              name: 'Core',
+              type: 'dielectric',
+              thickness: 1.5,
+              material: 'FR4',
+              dielectric: 4.2,
+              copperWeight: 0,
+            },
+          ],
+        }),
+      },
+    });
+
+    await expect(operations.getStackup()).resolves.toEqual({
+      totalLayers: 4,
+      boardThicknessMm: 1.6,
+      layers: [
+        {
+          name: 'Top',
+          type: 'copper',
+          thicknessMm: 0.035,
+          material: 'Cu',
+          dielectricConstant: 1,
+          copperWeightOz: 1,
+        },
+        {
+          name: 'Core',
+          type: 'dielectric',
+          thicknessMm: 1.5,
+          material: 'FR4',
+          dielectricConstant: 4.2,
+          copperWeightOz: 0,
+        },
+      ],
+      available: true,
+      source: 'physical_stackup',
+    });
+  });
+
+  it('supports the alternate stackup shape and degrades a failed physical read', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const getCurrentPhysicalStackingConfiguration = vi
+      .fn()
+      .mockResolvedValueOnce({ thickness: 1.2, stackup: [{ name: 'Core' }] })
+      .mockRejectedValueOnce(new Error('stackup failed'));
+    const { operations } = makeOperations({
+      DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) },
+      PCB_Layer: {
+        getTheNumberOfCopperLayers: async () => 2,
+        getCurrentPhysicalStackingConfiguration,
+      },
+    });
+
+    await expect(operations.getStackup()).resolves.toMatchObject({
+      boardThicknessMm: 1.2,
+      layers: [{ name: 'Core' }],
+      available: true,
+      source: 'physical_stackup',
+    });
+    await expect(operations.getStackup()).resolves.toEqual({
+      totalLayers: 2,
+      boardThicknessMm: undefined,
+      layers: [],
+      available: false,
+      source: 'copper_layer_count_only',
+    });
+    expect(warn).toHaveBeenCalledWith(
+      '[easyeda-mcp-pro]',
+      'failed to read physical stackup',
+      expect.any(Error),
+    );
+  });
+
+  it('rejects getStackup when the layer class is unavailable', async () => {
+    const { operations } = makeOperations({
+      DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) },
+    });
+
+    await expect(operations.getStackup()).rejects.toThrow('pcb_Layer class not found');
+  });
+
+  it('calculates dimensions from outline lines, arcs, and mounting-hole pads', async () => {
+    const { operations } = makeOperations(
+      { DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) } },
+      {
+        pcb_PrimitiveLine: {
+          getAll: async () => [
+            {
+              getState_Layer: () => 11,
+              getState_Points: () => [
+                { x: 1, y: 2 },
+                { x: 11, y: 7 },
+              ],
+            },
+            { getState_Layer: () => 1, getState_Points: () => [{ x: 100, y: 100 }] },
+          ],
+        },
+        pcb_PrimitiveArc: {
+          getAll: async () => [
+            {
+              getState_Layer: () => 11,
+              getState_StartX: () => -1,
+              getState_StartY: () => -2,
+              getState_EndX: () => 9,
+              getState_EndY: () => 8,
+            },
+            { getState_Layer: () => 2 },
+          ],
+        },
+        pcb_PrimitivePad: {
+          getAll: async () => [
+            { getState_HoleType: () => 'MountingHole', getState_HoleSize: () => 1 },
+            { getState_HoleType: () => '', getState_HoleSize: () => 2.5 },
+            { getState_HoleType: () => '', getState_HoleSize: () => 1 },
+          ],
+        },
+      },
+    );
+
+    await expect(operations.getDimensions()).resolves.toEqual({
+      widthMm: 12,
+      heightMm: 10,
+      shape: 'custom',
+      mountingHoleCount: 2,
+      areaMm2: 120,
+      hasOutline: true,
+    });
+  });
+
+  it('returns an empty dimension summary when primitive reads fail', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const failingClass = { getAll: async () => Promise.reject(new Error('read failed')) };
+    const { operations } = makeOperations(
+      { DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) } },
+      {
+        pcb_PrimitiveLine: failingClass,
+        pcb_PrimitiveArc: failingClass,
+        pcb_PrimitivePad: failingClass,
+      },
+    );
+
+    await expect(operations.getDimensions()).resolves.toEqual({
+      widthMm: 0,
+      heightMm: 0,
+      shape: undefined,
+      mountingHoleCount: 0,
+      areaMm2: 0,
+      hasOutline: false,
+    });
+    expect(warn).toHaveBeenCalledTimes(3);
+  });
+
+  it('counts all supported board feature classes', async () => {
+    const { operations } = makeOperations(
+      { DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) } },
+      {
+        pcb_PrimitiveVia: { getAll: async () => [1, 2] },
+        pcb_PrimitiveLine: { getAll: async () => [1, 2, 3] },
+        pcb_PrimitivePad: { getAll: async () => [1, 2, 3, 4] },
+        pcb_PrimitivePour: { getAll: async () => [1] },
+        pcb_PrimitiveComponent: { getAll: async () => [1, 2, 3, 4, 5] },
+      },
+    );
+
+    await expect(operations.getFeatures()).resolves.toEqual({
+      vias: 2,
+      tracks: 3,
+      zones: 1,
+      pads: 4,
+      components: 5,
+    });
+  });
+
+  it('contains every individual feature-count failure', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const failing = { getAll: async () => Promise.reject(new Error('count failed')) };
+    const { operations } = makeOperations(
+      { DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) } },
+      {
+        pcb_PrimitiveVia: failing,
+        pcb_PrimitiveLine: failing,
+        pcb_PrimitivePad: failing,
+        pcb_PrimitivePour: failing,
+        pcb_PrimitiveComponent: failing,
+      },
+    );
+
+    await expect(operations.getFeatures()).resolves.toEqual({
+      vias: 0,
+      tracks: 0,
+      zones: 0,
+      pads: 0,
+      components: 0,
+    });
+    expect(warn).toHaveBeenCalledTimes(5);
+  });
+});

--- a/easyeda-bridge-extension/tests/board-inspection.test.ts
+++ b/easyeda-bridge-extension/tests/board-inspection.test.ts
@@ -321,6 +321,120 @@ describe('board inspection operations', () => {
     });
   });
 
+  it('preserves a non-Error PCB context failure as bridge error cause text', async () => {
+    const { operations } = makeOperations({
+      DMT_Pcb: {
+        getCurrentPcbInfo: async () => Promise.reject('message bus unavailable'),
+      },
+    });
+
+    await expect(operations.requireActivePcbContext()).rejects.toMatchObject({
+      code: 'CONTEXT_UNAVAILABLE',
+      data: { cause: 'message bus unavailable' },
+    });
+  });
+
+  it('normalizes absent layer metadata and stackup APIs without inventing values', async () => {
+    const getAllLayers = vi.fn(async () => [undefined]);
+    const { operations } = makeOperations({
+      DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) },
+      PCB_Layer: { getAllLayers },
+    });
+
+    await expect(operations.listLayers()).resolves.toEqual([
+      { name: '', type: '', color: '', visible: true, order: 0 },
+    ]);
+    await expect(operations.getStackup()).resolves.toEqual({
+      totalLayers: 0,
+      boardThicknessMm: undefined,
+      layers: [],
+      available: false,
+      source: 'copper_layer_count_only',
+    });
+  });
+
+  it('normalizes an undefined physical stackup layer without inventing fields', async () => {
+    const { operations } = makeOperations({
+      DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) },
+      PCB_Layer: {
+        getTheNumberOfCopperLayers: async () => 2,
+        getCurrentPhysicalStackingConfiguration: async () => ({ layers: [undefined] }),
+      },
+    });
+
+    await expect(operations.getStackup()).resolves.toEqual({
+      totalLayers: 2,
+      boardThicknessMm: undefined,
+      layers: [
+        {
+          name: '',
+          type: '',
+          thicknessMm: undefined,
+          material: '',
+          dielectricConstant: undefined,
+          copperWeightOz: undefined,
+        },
+      ],
+      available: true,
+      source: 'physical_stackup',
+    });
+  });
+
+  it('contains absent, null, and partial primitive dimension data', async () => {
+    const root: Record<string, unknown> = {};
+    const { operations } = makeOperations(
+      { DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) } },
+      root,
+    );
+    const emptyDimensions = {
+      widthMm: 0,
+      heightMm: 0,
+      shape: undefined,
+      mountingHoleCount: 0,
+      areaMm2: 0,
+      hasOutline: false,
+    };
+
+    await expect(operations.getDimensions()).resolves.toEqual(emptyDimensions);
+
+    root.pcb_PrimitiveLine = { getAll: async () => null };
+    root.pcb_PrimitiveArc = { getAll: async () => null };
+    root.pcb_PrimitivePad = { getAll: async () => null };
+    await expect(operations.getDimensions()).resolves.toEqual(emptyDimensions);
+
+    root.pcb_PrimitiveLine = {
+      getAll: async () => [
+        {},
+        { getState_Layer: () => 11 },
+        { getState_Layer: () => 11, getState_Points: () => null },
+      ],
+    };
+    root.pcb_PrimitiveArc = {
+      getAll: async () => [{}, { getState_Layer: () => 11 }],
+    };
+    root.pcb_PrimitivePad = { getAll: async () => [{}] };
+    await expect(operations.getDimensions()).resolves.toEqual(emptyDimensions);
+  });
+
+  it('contains absent feature classes and null feature collections', async () => {
+    const root: Record<string, unknown> = {};
+    const { operations } = makeOperations(
+      { DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) } },
+      root,
+    );
+    const emptyFeatures = { vias: 0, tracks: 0, zones: 0, pads: 0, components: 0 };
+
+    await expect(operations.getFeatures()).resolves.toEqual(emptyFeatures);
+
+    const nullCollection = { getAll: async () => null };
+    root.pcb_PrimitiveVia = nullCollection;
+    root.pcb_PrimitiveLine = nullCollection;
+    root.pcb_PrimitivePad = nullCollection;
+    root.pcb_PrimitivePour = nullCollection;
+    root.pcb_PrimitiveComponent = nullCollection;
+    await expect(operations.getFeatures()).resolves.toEqual(emptyFeatures);
+  });
+
   it('contains every individual feature-count failure', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     const failing = { getAll: async () => Promise.reject(new Error('count failed')) };

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -1305,6 +1305,54 @@ describe('createDispatcher', () => {
     });
   });
 
+  it('delegates board dimensions and feature summaries through the extracted domain', async () => {
+    const lineGetAll = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          getState_Layer: () => 11,
+          getState_Points: () => [
+            { x: 0, y: 0 },
+            { x: 10, y: 5 },
+          ],
+        },
+      ])
+      .mockResolvedValueOnce([1, 2, 3]);
+    const padGetAll = vi
+      .fn()
+      .mockResolvedValueOnce([
+        { getState_HoleType: () => 'MountingHole', getState_HoleSize: () => 1 },
+      ])
+      .mockResolvedValueOnce([1, 2]);
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        DMT_Pcb: { getCurrentPcbInfo: async () => ({ uuid: 'pcb-1' }) },
+        pcb_PrimitiveLine: { getAll: lineGetAll },
+        pcb_PrimitiveArc: { getAll: async () => [] },
+        pcb_PrimitivePad: { getAll: padGetAll },
+        pcb_PrimitiveVia: { getAll: async () => [1] },
+        pcb_PrimitivePour: { getAll: async () => [1, 2, 3, 4] },
+        pcb_PrimitiveComponent: { getAll: async () => [1, 2, 3, 4, 5] },
+      }),
+    );
+
+    await expect(dispatcher.dispatch('board.getDimensions', {})).resolves.toEqual({
+      widthMm: 10,
+      heightMm: 5,
+      shape: 'custom',
+      mountingHoleCount: 1,
+      areaMm2: 50,
+      hasOutline: true,
+    });
+    await expect(dispatcher.dispatch('board.getFeatures', {})).resolves.toEqual({
+      vias: 1,
+      tracks: 3,
+      zones: 4,
+      pads: 2,
+      components: 5,
+    });
+  });
+
   it('PCB list methods reject an inactive PCB context before calling primitive APIs', async () => {
     const getAll = vi.fn(async () => []);
     const dispatcher = createDispatcher(


### PR DESCRIPTION
## Summary

Extract the read-only PCB board inspection boundary from the extension dispatcher into a typed `board-inspection.ts` domain factory. The module now owns active-PCB context validation, active layer filtering, physical stackup projection, board outline dimensions, mounting-hole detection, and primitive feature counts. The existing PCB list operations reuse the same fail-closed context guard.

This is the sixth bounded, behavior-preserving decomposition slice under #339. It does not close the parent issue and does not add or remove any public bridge capability.

## Contract parity

- Preserves the compatibility fallback when older EasyEDA builds do not expose `DMT_Pcb`.
- Preserves the exact `CONTEXT_UNAVAILABLE` codes, messages, suggestions, and cause data, including non-`Error` rejection causes.
- Preserves active copper/custom-layer filtering and catalogue-placeholder suppression.
- Preserves physical-stackup field fallbacks without inventing board thickness or layer properties.
- Preserves board-outline bounding-box behavior across lines and arcs.
- Preserves mounting-hole classification and independent feature-count failure containment.
- Preserves missing, null, and partial native API collection fallbacks.
- Preserves the live-confirmed `PCB_PrimitiveLine` track source.
- Keeps the same active-PCB guard for `pcb.listComponents`, `pcb.listTracks`, and `pcb.listVias`.
- Keeps all 67 sorted public extension methods unchanged.

## Objective decomposition evidence

- `dispatcher.ts`: 4,611 lines on `main` → 4,349 lines (-262).
- Built dispatcher bundle: 155,104 bytes → 157,067 bytes (+1,963 bytes, approximately +1.27%).
- Packaged extension: 161,675 bytes → 162,358 bytes (+683 bytes, approximately +0.42%).
- Package and bundle remain within enforced budgets:
  - package: 162,358 / 200,000 bytes
  - extension entry: 217,482 / 260,000 bytes
  - dispatcher bundle: 157,067 / 185,000 bytes
- Method-list parity and package checksum verification pass.

## Tests

- Added 18 focused board-domain tests covering compatibility, fail-closed context errors, non-`Error` causes, layer catalogue filtering, absent metadata, copper-count degradation, stackup shapes/failures, undefined stackup entries, outline dimensions, mounting holes, missing/null/partial primitive APIs, feature counts, and independent failure containment.
- Added dispatcher integration coverage for board dimensions and feature summaries; existing dispatcher tests continue to cover layer, stackup, and inactive-PCB behavior.
- `board-inspection.ts`: 134/134 lines, 19/19 functions, and 159/159 branches covered (100% statements, branches, functions, and lines).
- Focused dispatcher/domain parity: 2 files / 111 tests passed.
- Extension suite: 16 files / 200 tests passed.
- Server suite: 150 files / 1,740 tests passed.
- Full `pnpm verify` passed runtime preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, tests, builds, extension packaging/checksums, metadata alignment, compatibility generation, and VitePress documentation.
- Dependency audit passed with only the documented #334 advisory exception; peer dependency check found no issues.
- The four Sonar maintainability findings from the first analysis were addressed by moving copper-count and projection helpers to module scope and decomposing outline/mounting-hole reads; behavior and error contracts remain unchanged.
- The Codecov partial-branch feedback from the second analysis was addressed with behavior tests for every compatibility and fallback branch; local LCOV now reports 159/159 branches.

## Follow-up

Further dispatcher domains will continue as separately reviewable, parity-tested PRs under #339.
