### PR TITLE
refactor(extension): extract PCB read operations

### DIFF
--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -21,6 +21,7 @@ import {
 } from './board-inspection.js';
 import { createCanvasOperations, type CanvasOperations } from './canvas-operations.js';
 import { createExportOperations, type ExportOperations } from './export-operations.js';
+import { createPcbReadOperations, type PcbReadOperations } from './pcb-read-operations.js';
 import { createProjectOperations, type ProjectOperations } from './project-operations.js';
 import type { Dispatcher, DispatcherToolkit } from './toolkit.js';
 import { isRecord, log, logRecoverableError, type JsonValue } from './utils.js';
@@ -115,6 +116,7 @@ let callAllowedApi: ApiRuntime['callAllowedApi'];
 let boardInspection: BoardInspectionOperations;
 let canvasOperations: CanvasOperations;
 let exportOperations: ExportOperations;
+let pcbReadOperations: PcbReadOperations;
 let projectOperations: ProjectOperations;
 
 function newBridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
@@ -2189,158 +2191,6 @@ async function inspectWiresApi(limit = 10, offset = 0): Promise<unknown> {
   };
 }
 
-/**
- * Classes pcbDeletePrimitivesApi checks, in lookup order. Confirmed live
- * (2026-07-07): PCB_PrimitiveComponent.delete() returns `true` for ANY id,
- * including ids belonging to other primitive types or ids that don't exist
- * at all — it does not validate ownership. The previous pcb.deleteComponent
- * implementation called only this method, so deleting a via or track
- * primitiveId silently did nothing while reporting success. PCB_Primitive's
- * own getPrimitiveTypeByPrimitiveId() is an empty stub in this runtime
- * (`async getPrimitiveTypeByPrimitiveId(t){}`) and cannot be used to route
- * by type, so each candidate class's real membership is checked directly via
- * getAllPrimitiveId() before calling its delete().
- */
-const PCB_DELETABLE_CLASSES = [
-  'PCB_PrimitiveComponent',
-  'PCB_PrimitiveVia',
-  'PCB_PrimitiveLine',
-  'PCB_PrimitivePad',
-  'PCB_PrimitivePolyline',
-  'PCB_PrimitivePour',
-  'PCB_PrimitiveArc',
-  'PCB_PrimitiveAttribute',
-  'PCB_PrimitiveDimension',
-  'PCB_PrimitiveFill',
-  'PCB_PrimitiveImage',
-  'PCB_PrimitiveObject',
-  'PCB_PrimitivePoured',
-  'PCB_PrimitiveRegion',
-  'PCB_PrimitiveString',
-] as const;
-
-async function pcbDeletePrimitivesApi(
-  primitiveIds: string[],
-): Promise<{ deleted: string[]; notFound: string[] }> {
-  const remaining = new Set(primitiveIds);
-  const deleted: string[] = [];
-
-  for (const className of PCB_DELETABLE_CLASSES) {
-    if (remaining.size === 0) break;
-    const cls = readFirstPath<any>([className]);
-    if (!cls || typeof cls.getAllPrimitiveId !== 'function' || typeof cls.delete !== 'function') {
-      continue;
-    }
-    let ownedIds: Set<string>;
-    try {
-      ownedIds = new Set((await cls.getAllPrimitiveId()) ?? []);
-    } catch (e) {
-      logRecoverableError(`pcb.deleteComponent: ${className}.getAllPrimitiveId failed`, e);
-      continue;
-    }
-    const matches = [...remaining].filter((id) => ownedIds.has(id));
-    if (matches.length === 0) continue;
-    try {
-      await cls.delete(matches);
-      for (const id of matches) {
-        remaining.delete(id);
-        deleted.push(id);
-      }
-    } catch (e) {
-      logRecoverableError(`pcb.deleteComponent: ${className}.delete failed`, e);
-    }
-  }
-
-  return { deleted, notFound: [...remaining] };
-}
-
-/**
- * PCB readback: list placed components, tracks, and vias. Field names below
- * are taken from getState_* getters observed live on real primitives
- * (created via the fixed pcb.addVia/pcb.addTrack and a manually-placed
- * footprint) — not guessed, unlike the schematic reflection-based readers.
- * Requires an active/focused PCB tab in EasyEDA Pro; DMT_Pcb.getCurrentPcbInfo()
- * returns null otherwise and these calls will return an empty list rather
- * than throw, since "no PCB open" is a normal state, not an error.
- */
-async function pcbListComponentsApi(limit?: number, offset = 0): Promise<unknown> {
-  await boardInspection.requireActivePcbContext();
-  const pcbCompClass = readFirstPath<any>(['PCB_PrimitiveComponent', 'pcb_PrimitiveComponent']);
-  if (!pcbCompClass || typeof pcbCompClass.getAll !== 'function') {
-    return { total: 0, items: [] };
-  }
-  const all = (await pcbCompClass.getAll()) || [];
-  const total = all.length;
-  const start = Math.max(0, offset);
-  const end = typeof limit === 'number' ? start + Math.max(1, limit) : undefined;
-  const items = all.slice(start, end).map((c: any) => {
-    const footprint = safeGetState(c, 'Footprint') as Record<string, unknown> | undefined;
-    const component = safeGetState(c, 'Component') as Record<string, unknown> | undefined;
-    return {
-      primitiveId: safeGetState(c, 'PrimitiveId') ?? '',
-      designator: safeGetState(c, 'Designator') ?? '',
-      footprintName: footprint?.name ?? '',
-      footprintUuid: footprint?.uuid ?? '',
-      footprintLibraryUuid: footprint?.libraryUuid ?? '',
-      deviceName: component?.name ?? '',
-      x: safeGetState(c, 'X'),
-      y: safeGetState(c, 'Y'),
-      rotation: safeGetState(c, 'Rotation'),
-      layer: safeGetState(c, 'Layer'),
-      locked: safeGetState(c, 'PrimitiveLock') ?? false,
-    };
-  });
-  return { total, items };
-}
-
-async function pcbListTracksApi(limit?: number, offset = 0): Promise<unknown> {
-  await boardInspection.requireActivePcbContext();
-  // Tracks are PCB_PrimitiveLine segments — see the pcb.addTrack case for why
-  // PCB_PrimitivePolyline is not used (its create() never resolved live).
-  const pcbLineClass = readFirstPath<any>(['PCB_PrimitiveLine', 'pcb_PrimitiveLine']);
-  if (!pcbLineClass || typeof pcbLineClass.getAll !== 'function') {
-    return { total: 0, items: [] };
-  }
-  const all = (await pcbLineClass.getAll()) || [];
-  const total = all.length;
-  const start = Math.max(0, offset);
-  const end = typeof limit === 'number' ? start + Math.max(1, limit) : undefined;
-  const items = all.slice(start, end).map((l: any) => ({
-    primitiveId: safeGetState(l, 'PrimitiveId') ?? '',
-    net: safeGetState(l, 'Net') ?? '',
-    layer: safeGetState(l, 'Layer'),
-    startX: safeGetState(l, 'StartX'),
-    startY: safeGetState(l, 'StartY'),
-    endX: safeGetState(l, 'EndX'),
-    endY: safeGetState(l, 'EndY'),
-    width: safeGetState(l, 'LineWidth'),
-    locked: safeGetState(l, 'PrimitiveLock') ?? false,
-  }));
-  return { total, items };
-}
-
-async function pcbListViasApi(limit?: number, offset = 0): Promise<unknown> {
-  await boardInspection.requireActivePcbContext();
-  const pcbViaClass = readFirstPath<any>(['PCB_PrimitiveVia', 'pcb_PrimitiveVia']);
-  if (!pcbViaClass || typeof pcbViaClass.getAll !== 'function') {
-    return { total: 0, items: [] };
-  }
-  const all = (await pcbViaClass.getAll()) || [];
-  const total = all.length;
-  const start = Math.max(0, offset);
-  const end = typeof limit === 'number' ? start + Math.max(1, limit) : undefined;
-  const items = all.slice(start, end).map((v: any) => ({
-    primitiveId: safeGetState(v, 'PrimitiveId') ?? '',
-    net: safeGetState(v, 'Net') ?? '',
-    x: safeGetState(v, 'X'),
-    y: safeGetState(v, 'Y'),
-    holeDiameter: safeGetState(v, 'HoleDiameter'),
-    diameter: safeGetState(v, 'Diameter'),
-    locked: safeGetState(v, 'PrimitiveLock') ?? false,
-  }));
-  return { total, items };
-}
-
 async function generateBomApi(params: any): Promise<unknown> {
   const comps = ((await listComponentsApi()) as { items: any[] }).items;
   const groupBy = params.groupBy || 'value';
@@ -4279,7 +4129,7 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
       // payload) back to the MCP tool layer, so structured deleted/notFound
       // detail would be lost if this threw instead.
       const ids = Array.isArray(params.primitiveIds) ? (params.primitiveIds as string[]) : [];
-      const result = await pcbDeletePrimitivesApi(ids);
+      const result = await pcbReadOperations.deletePrimitives(ids);
       return {
         success: result.notFound.length === 0,
         deletedCount: result.deleted.length,
@@ -4294,17 +4144,17 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
         params.property,
       );
     case 'pcb.listComponents':
-      return pcbListComponentsApi(
+      return pcbReadOperations.listComponents(
         typeof params.limit === 'number' ? params.limit : undefined,
         typeof params.offset === 'number' ? params.offset : 0,
       );
     case 'pcb.listTracks':
-      return pcbListTracksApi(
+      return pcbReadOperations.listTracks(
         typeof params.limit === 'number' ? params.limit : undefined,
         typeof params.offset === 'number' ? params.offset : 0,
       );
     case 'pcb.listVias':
-      return pcbListViasApi(
+      return pcbReadOperations.listVias(
         typeof params.limit === 'number' ? params.limit : undefined,
         typeof params.offset === 'number' ? params.offset : 0,
       );
@@ -4338,6 +4188,11 @@ export function createDispatcher(toolkit: DispatcherToolkit): Dispatcher {
     createBridgeError: newBridgeError,
   });
   exportOperations = createExportOperations({ callFirst, normalizeBinaryResult });
+  pcbReadOperations = createPcbReadOperations({
+    requireActivePcbContext: () => boardInspection.requireActivePcbContext(),
+    readFirstPath,
+    readState: safeGetState,
+  });
   projectOperations = createProjectOperations({ callFirst });
   textAlignModeCache.clear();
   log(`dispatcher initialized (build ${BUILD_ID}, ${METHOD_LIST.length} methods)`);

--- a/easyeda-bridge-extension/src/pcb-read-operations.ts
+++ b/easyeda-bridge-extension/src/pcb-read-operations.ts
@@ -1,0 +1,176 @@
+import type { ApiRuntime } from './api-runtime.js';
+import type { BoardInspectionOperations } from './board-inspection.js';
+import { logRecoverableError } from './utils.js';
+
+export type PrimitiveStateReader = (value: unknown, key: string) => unknown;
+
+export interface PcbReadOperationDependencies {
+  requireActivePcbContext: BoardInspectionOperations['requireActivePcbContext'];
+  readFirstPath: ApiRuntime['readFirstPath'];
+  readState: PrimitiveStateReader;
+}
+
+export interface PcbReadOperations {
+  listComponents(limit?: number, offset?: number): Promise<unknown>;
+  listTracks(limit?: number, offset?: number): Promise<unknown>;
+  listVias(limit?: number, offset?: number): Promise<unknown>;
+  deletePrimitives(primitiveIds: string[]): Promise<{ deleted: string[]; notFound: string[] }>;
+}
+
+/**
+ * Classes deletePrimitives checks, in lookup order. Confirmed live
+ * (2026-07-07): PCB_PrimitiveComponent.delete() returns `true` for ANY id,
+ * including ids belonging to other primitive types or ids that do not exist.
+ * Membership must therefore be checked through each concrete class before
+ * invoking its delete method.
+ */
+const PCB_DELETABLE_CLASSES = [
+  'PCB_PrimitiveComponent',
+  'PCB_PrimitiveVia',
+  'PCB_PrimitiveLine',
+  'PCB_PrimitivePad',
+  'PCB_PrimitivePolyline',
+  'PCB_PrimitivePour',
+  'PCB_PrimitiveArc',
+  'PCB_PrimitiveAttribute',
+  'PCB_PrimitiveDimension',
+  'PCB_PrimitiveFill',
+  'PCB_PrimitiveImage',
+  'PCB_PrimitiveObject',
+  'PCB_PrimitivePoured',
+  'PCB_PrimitiveRegion',
+  'PCB_PrimitiveString',
+] as const;
+
+function paginationEnd(limit: number | undefined, start: number): number | undefined {
+  return typeof limit === 'number' ? start + Math.max(1, limit) : undefined;
+}
+
+export function createPcbReadOperations({
+  requireActivePcbContext,
+  readFirstPath,
+  readState,
+}: PcbReadOperationDependencies): PcbReadOperations {
+  async function listComponents(limit?: number, offset = 0): Promise<unknown> {
+    await requireActivePcbContext();
+    const pcbCompClass = readFirstPath<any>(['PCB_PrimitiveComponent', 'pcb_PrimitiveComponent']);
+    if (!pcbCompClass || typeof pcbCompClass.getAll !== 'function') {
+      return { total: 0, items: [] };
+    }
+
+    const all = (await pcbCompClass.getAll()) || [];
+    const start = Math.max(0, offset);
+    const items = all.slice(start, paginationEnd(limit, start)).map((component: any) => {
+      const footprint = readState(component, 'Footprint') as Record<string, unknown> | undefined;
+      const device = readState(component, 'Component') as Record<string, unknown> | undefined;
+      return {
+        primitiveId: readState(component, 'PrimitiveId') ?? '',
+        designator: readState(component, 'Designator') ?? '',
+        footprintName: footprint?.name ?? '',
+        footprintUuid: footprint?.uuid ?? '',
+        footprintLibraryUuid: footprint?.libraryUuid ?? '',
+        deviceName: device?.name ?? '',
+        x: readState(component, 'X'),
+        y: readState(component, 'Y'),
+        rotation: readState(component, 'Rotation'),
+        layer: readState(component, 'Layer'),
+        locked: readState(component, 'PrimitiveLock') ?? false,
+      };
+    });
+    return { total: all.length, items };
+  }
+
+  async function listTracks(limit?: number, offset = 0): Promise<unknown> {
+    await requireActivePcbContext();
+    // Tracks are PCB_PrimitiveLine segments. PCB_PrimitivePolyline.create()
+    // never resolved in the live runtime used to validate pcb.addTrack.
+    const pcbLineClass = readFirstPath<any>(['PCB_PrimitiveLine', 'pcb_PrimitiveLine']);
+    if (!pcbLineClass || typeof pcbLineClass.getAll !== 'function') {
+      return { total: 0, items: [] };
+    }
+
+    const all = (await pcbLineClass.getAll()) || [];
+    const start = Math.max(0, offset);
+    const items = all.slice(start, paginationEnd(limit, start)).map((line: any) => ({
+      primitiveId: readState(line, 'PrimitiveId') ?? '',
+      net: readState(line, 'Net') ?? '',
+      layer: readState(line, 'Layer'),
+      startX: readState(line, 'StartX'),
+      startY: readState(line, 'StartY'),
+      endX: readState(line, 'EndX'),
+      endY: readState(line, 'EndY'),
+      width: readState(line, 'LineWidth'),
+      locked: readState(line, 'PrimitiveLock') ?? false,
+    }));
+    return { total: all.length, items };
+  }
+
+  async function listVias(limit?: number, offset = 0): Promise<unknown> {
+    await requireActivePcbContext();
+    const pcbViaClass = readFirstPath<any>(['PCB_PrimitiveVia', 'pcb_PrimitiveVia']);
+    if (!pcbViaClass || typeof pcbViaClass.getAll !== 'function') {
+      return { total: 0, items: [] };
+    }
+
+    const all = (await pcbViaClass.getAll()) || [];
+    const start = Math.max(0, offset);
+    const items = all.slice(start, paginationEnd(limit, start)).map((via: any) => ({
+      primitiveId: readState(via, 'PrimitiveId') ?? '',
+      net: readState(via, 'Net') ?? '',
+      x: readState(via, 'X'),
+      y: readState(via, 'Y'),
+      holeDiameter: readState(via, 'HoleDiameter'),
+      diameter: readState(via, 'Diameter'),
+      locked: readState(via, 'PrimitiveLock') ?? false,
+    }));
+    return { total: all.length, items };
+  }
+
+  async function deletePrimitives(
+    primitiveIds: string[],
+  ): Promise<{ deleted: string[]; notFound: string[] }> {
+    const remaining = new Set(primitiveIds);
+    const deleted: string[] = [];
+
+    for (const className of PCB_DELETABLE_CLASSES) {
+      if (remaining.size === 0) break;
+      const primitiveClass = readFirstPath<any>([className]);
+      if (
+        !primitiveClass ||
+        typeof primitiveClass.getAllPrimitiveId !== 'function' ||
+        typeof primitiveClass.delete !== 'function'
+      ) {
+        continue;
+      }
+
+      let ownedIds: Set<string>;
+      try {
+        ownedIds = new Set((await primitiveClass.getAllPrimitiveId()) ?? []);
+      } catch (error) {
+        logRecoverableError(`pcb.deleteComponent: ${className}.getAllPrimitiveId failed`, error);
+        continue;
+      }
+
+      const matches = [...remaining].filter((id) => ownedIds.has(id));
+      if (matches.length === 0) continue;
+      try {
+        await primitiveClass.delete(matches);
+        for (const id of matches) {
+          remaining.delete(id);
+          deleted.push(id);
+        }
+      } catch (error) {
+        logRecoverableError(`pcb.deleteComponent: ${className}.delete failed`, error);
+      }
+    }
+
+    return { deleted, notFound: [...remaining] };
+  }
+
+  return {
+    listComponents,
+    listTracks,
+    listVias,
+    deletePrimitives,
+  };
+}

--- a/easyeda-bridge-extension/tests/pcb-read-operations.test.ts
+++ b/easyeda-bridge-extension/tests/pcb-read-operations.test.ts
@@ -1,0 +1,349 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createPcbReadOperations } from '../src/pcb-read-operations.js';
+
+function makeOperations(runtime: Record<string, unknown> = {}) {
+  const requireActivePcbContext = vi.fn(async () => undefined);
+  const readFirstPath = vi.fn(<T>(paths: readonly string[]): T | undefined => {
+    for (const path of paths) {
+      if (path in runtime) return runtime[path] as T;
+    }
+    return undefined;
+  });
+  const readState = vi.fn((value: unknown, key: string): unknown => {
+    if (!value || typeof value !== 'object') return undefined;
+    const record = value as Record<string, unknown>;
+    const getter = record[`getState_${key}`];
+    if (typeof getter === 'function') return (getter as () => unknown).call(value);
+    return record[key];
+  });
+  return {
+    requireActivePcbContext,
+    readFirstPath,
+    readState,
+    operations: createPcbReadOperations({
+      requireActivePcbContext,
+      readFirstPath,
+      readState,
+    }),
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('PCB read operations', () => {
+  it('maps components through the live native state fields and paginates safely', async () => {
+    const components = [
+      {
+        getState_PrimitiveId: () => 'c0',
+        getState_Designator: () => 'R0',
+      },
+      {
+        getState_PrimitiveId: () => 'c1',
+        getState_Designator: () => 'R1',
+        getState_Footprint: () => ({ name: 'R0603', uuid: 'fp-1', libraryUuid: 'lib-1' }),
+        getState_Component: () => ({ name: 'Resistor' }),
+        getState_X: () => 10,
+        getState_Y: () => 20,
+        getState_Rotation: () => 90,
+        getState_Layer: () => 1,
+        getState_PrimitiveLock: () => true,
+      },
+      {
+        getState_PrimitiveId: () => 'c2',
+        getState_Designator: () => 'R2',
+      },
+    ];
+    const { operations, requireActivePcbContext } = makeOperations({
+      PCB_PrimitiveComponent: { getAll: async () => components },
+    });
+
+    await expect(operations.listComponents(0, 1)).resolves.toEqual({
+      total: 3,
+      items: [
+        {
+          primitiveId: 'c1',
+          designator: 'R1',
+          footprintName: 'R0603',
+          footprintUuid: 'fp-1',
+          footprintLibraryUuid: 'lib-1',
+          deviceName: 'Resistor',
+          x: 10,
+          y: 20,
+          rotation: 90,
+          layer: 1,
+          locked: true,
+        },
+      ],
+    });
+    expect(requireActivePcbContext).toHaveBeenCalledOnce();
+  });
+
+  it('normalizes a null component collection as an empty result', async () => {
+    const { operations } = makeOperations({
+      PCB_PrimitiveComponent: { getAll: async () => null },
+    });
+
+    await expect(operations.listComponents()).resolves.toEqual({ total: 0, items: [] });
+  });
+
+  it('uses the lower-case component alias and normalizes missing nested metadata', async () => {
+    const { operations } = makeOperations({
+      pcb_PrimitiveComponent: {
+        getAll: async () => [
+          {
+            getState_PrimitiveId: () => undefined,
+            getState_Designator: () => undefined,
+            getState_Footprint: () => undefined,
+            getState_Component: () => undefined,
+            getState_PrimitiveLock: () => undefined,
+          },
+        ],
+      },
+    });
+
+    await expect(operations.listComponents(undefined, -10)).resolves.toEqual({
+      total: 1,
+      items: [
+        {
+          primitiveId: '',
+          designator: '',
+          footprintName: '',
+          footprintUuid: '',
+          footprintLibraryUuid: '',
+          deviceName: '',
+          x: undefined,
+          y: undefined,
+          rotation: undefined,
+          layer: undefined,
+          locked: false,
+        },
+      ],
+    });
+  });
+
+  it('maps tracks from PCB_PrimitiveLine and preserves null collections as empty', async () => {
+    const line = {
+      getState_PrimitiveId: () => 'line1',
+      getState_Net: () => 'GND',
+      getState_Layer: () => 1,
+      getState_StartX: () => 10,
+      getState_StartY: () => 20,
+      getState_EndX: () => 30,
+      getState_EndY: () => 40,
+      getState_LineWidth: () => 5,
+      getState_PrimitiveLock: () => false,
+    };
+    const getAll = vi
+      .fn()
+      .mockResolvedValueOnce([line])
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce([{}]);
+    const { operations } = makeOperations({ PCB_PrimitiveLine: { getAll } });
+
+    await expect(operations.listTracks()).resolves.toEqual({
+      total: 1,
+      items: [
+        {
+          primitiveId: 'line1',
+          net: 'GND',
+          layer: 1,
+          startX: 10,
+          startY: 20,
+          endX: 30,
+          endY: 40,
+          width: 5,
+          locked: false,
+        },
+      ],
+    });
+    await expect(operations.listTracks()).resolves.toEqual({ total: 0, items: [] });
+    await expect(operations.listTracks()).resolves.toEqual({
+      total: 1,
+      items: [
+        {
+          primitiveId: '',
+          net: '',
+          layer: undefined,
+          startX: undefined,
+          startY: undefined,
+          endX: undefined,
+          endY: undefined,
+          width: undefined,
+          locked: false,
+        },
+      ],
+    });
+  });
+
+  it('maps vias and applies offset/limit after reading the total', async () => {
+    const via = (id: string) => ({
+      getState_PrimitiveId: () => id,
+      getState_Net: () => 'VCC',
+      getState_X: () => 1,
+      getState_Y: () => 2,
+      getState_HoleDiameter: () => 3,
+      getState_Diameter: () => 4,
+      getState_PrimitiveLock: () => undefined,
+    });
+    const getAll = vi
+      .fn()
+      .mockResolvedValueOnce([via('v0'), via('v1'), via('v2')])
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce([{}]);
+    const { operations } = makeOperations({
+      pcb_PrimitiveVia: { getAll },
+    });
+
+    await expect(operations.listVias(1, 1)).resolves.toEqual({
+      total: 3,
+      items: [
+        {
+          primitiveId: 'v1',
+          net: 'VCC',
+          x: 1,
+          y: 2,
+          holeDiameter: 3,
+          diameter: 4,
+          locked: false,
+        },
+      ],
+    });
+    await expect(operations.listVias()).resolves.toEqual({ total: 0, items: [] });
+    await expect(operations.listVias()).resolves.toEqual({
+      total: 1,
+      items: [
+        {
+          primitiveId: '',
+          net: '',
+          x: undefined,
+          y: undefined,
+          holeDiameter: undefined,
+          diameter: undefined,
+          locked: false,
+        },
+      ],
+    });
+  });
+
+  it('returns an empty list when a native read class is unavailable', async () => {
+    const { operations, requireActivePcbContext } = makeOperations();
+
+    await expect(operations.listComponents()).resolves.toEqual({ total: 0, items: [] });
+    await expect(operations.listTracks()).resolves.toEqual({ total: 0, items: [] });
+    await expect(operations.listVias()).resolves.toEqual({ total: 0, items: [] });
+    expect(requireActivePcbContext).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('PCB primitive deletion routing', () => {
+  it('routes each id only to the class that reports ownership and deduplicates input', async () => {
+    const componentDelete = vi.fn(async () => true);
+    const viaDelete = vi.fn(async () => true);
+    const { operations } = makeOperations({
+      PCB_PrimitiveComponent: {
+        getAllPrimitiveId: async () => ['component-1'],
+        delete: componentDelete,
+      },
+      PCB_PrimitiveVia: {
+        getAllPrimitiveId: async () => ['via-1'],
+        delete: viaDelete,
+      },
+    });
+
+    await expect(
+      operations.deletePrimitives(['component-1', 'via-1', 'component-1']),
+    ).resolves.toEqual({
+      deleted: ['component-1', 'via-1'],
+      notFound: [],
+    });
+    expect(componentDelete).toHaveBeenCalledWith(['component-1']);
+    expect(viaDelete).toHaveBeenCalledWith(['via-1']);
+  });
+
+  it('treats null or non-matching ownership results as not found', async () => {
+    const componentDelete = vi.fn(async () => true);
+    const viaDelete = vi.fn(async () => true);
+    const { operations } = makeOperations({
+      PCB_PrimitiveComponent: {
+        getAllPrimitiveId: async () => null,
+        delete: componentDelete,
+      },
+      PCB_PrimitiveVia: {
+        getAllPrimitiveId: async () => ['other-via'],
+        delete: viaDelete,
+      },
+    });
+
+    await expect(operations.deletePrimitives(['missing'])).resolves.toEqual({
+      deleted: [],
+      notFound: ['missing'],
+    });
+    expect(componentDelete).not.toHaveBeenCalled();
+    expect(viaDelete).not.toHaveBeenCalled();
+  });
+
+  it('continues after ownership reads fail and reports the id as not found', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const deletePrimitive = vi.fn(async () => true);
+    const { operations } = makeOperations({
+      PCB_PrimitiveComponent: {
+        getAllPrimitiveId: async () => Promise.reject(new Error('membership failed')),
+        delete: deletePrimitive,
+      },
+    });
+
+    await expect(operations.deletePrimitives(['component-1'])).resolves.toEqual({
+      deleted: [],
+      notFound: ['component-1'],
+    });
+    expect(deletePrimitive).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      '[easyeda-mcp-pro]',
+      'pcb.deleteComponent: PCB_PrimitiveComponent.getAllPrimitiveId failed',
+      expect.any(Error),
+    );
+  });
+
+  it('keeps matched ids pending when the owning class delete call fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const { operations } = makeOperations({
+      PCB_PrimitiveVia: {
+        getAllPrimitiveId: async () => ['via-1'],
+        delete: async () => Promise.reject(new Error('delete failed')),
+      },
+    });
+
+    await expect(operations.deletePrimitives(['via-1'])).resolves.toEqual({
+      deleted: [],
+      notFound: ['via-1'],
+    });
+    expect(warn).toHaveBeenCalledWith(
+      '[easyeda-mcp-pro]',
+      'pcb.deleteComponent: PCB_PrimitiveVia.delete failed',
+      expect.any(Error),
+    );
+  });
+
+  it('skips incomplete classes and stops checking once every id is deleted', async () => {
+    const laterMembership = vi.fn(async () => ['component-1']);
+    const { operations } = makeOperations({
+      PCB_PrimitiveComponent: {
+        getAllPrimitiveId: async () => ['component-1'],
+        delete: async () => true,
+      },
+      PCB_PrimitiveVia: { getAllPrimitiveId: async () => ['component-1'] },
+      PCB_PrimitiveLine: {
+        getAllPrimitiveId: laterMembership,
+        delete: async () => true,
+      },
+    });
+
+    await expect(operations.deletePrimitives(['component-1'])).resolves.toEqual({
+      deleted: ['component-1'],
+      notFound: [],
+    });
+    expect(laterMembership).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Extract the PCB read/list and ownership-verified primitive deletion boundary from the extension dispatcher into a typed `pcb-read-operations.ts` domain factory. The module now owns `pcb.listComponents`, `pcb.listTracks`, `pcb.listVias`, and the concrete-class membership routing used by `pcb.deleteComponent`.

This is the seventh bounded, behavior-preserving decomposition slice under #339. It does not close the parent issue and does not add or remove any public bridge capability.

## Contract parity

- Preserves the shared fail-closed active-PCB context guard for all three list methods.
- Preserves upper/lower-case EasyEDA class aliases and missing-class empty-list compatibility.
- Preserves exact component, track, and via public field mappings and fallback values.
- Preserves non-negative offset handling, minimum numeric limit of one, and total-before-pagination behavior.
- Preserves the live-confirmed `PCB_PrimitiveLine` track source.
- Preserves the 15-class primitive ownership lookup order.
- Preserves the mandatory `getAllPrimitiveId` membership check before invoking any native delete method.
- Preserves containment of membership-read and delete failures, including stable diagnostic labels.
- Preserves input deduplication and the `deleted` / `notFound` response shape.
- Keeps all 67 sorted public extension methods unchanged.

## Objective decomposition evidence

- `dispatcher.ts`: 4,349 lines on `main` → 4,204 lines (-145).
- Built dispatcher bundle: 157,067 bytes → 157,736 bytes (+669 bytes, approximately +0.43%).
- Packaged extension: 162,358 bytes → 162,520 bytes (+162 bytes, approximately +0.10%).
- Package and bundle remain within enforced budgets:
  - package: 162,520 / 200,000 bytes
  - extension entry: 218,151 / 260,000 bytes
  - dispatcher bundle: 157,736 / 185,000 bytes
- Method-list parity and package checksum verification pass.

## Tests

- Added 11 focused domain tests covering component/track/via mapping, aliases, pagination, null collections, missing native fields, missing classes, input deduplication, concrete ownership routing, null/non-matching ownership, membership failures, delete failures, incomplete classes, and early completion.
- Existing dispatcher integration tests continue to execute the four extracted public operations and verify exact public response structures.
- `pcb-read-operations.ts`: 50/50 lines, 10/10 functions, and 60/60 branches covered (100% statements, branches, functions, and lines).
- Focused dispatcher/domain parity: 2 files / 104 tests passed.
- Extension suite: 17 files / 211 tests passed.
- Server suite: 150 files / 1,740 tests passed.
- Full `pnpm verify` passed runtime preflight, formatting, root and extension typecheck, ESLint, tool/profile metadata, tests, builds, extension packaging/checksums, metadata alignment, compatibility generation, and VitePress documentation.
- Dependency audit passed with only the documented #334 advisory exception; peer dependency check found no issues.

## Follow-up

Further dispatcher domains will continue as separately reviewable, parity-tested PRs under #339.
