### PR TITLE
refactor(extension): extract PCB write operations

### DIFF
--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -22,6 +22,7 @@ import {
 import { createCanvasOperations, type CanvasOperations } from './canvas-operations.js';
 import { createExportOperations, type ExportOperations } from './export-operations.js';
 import { createPcbReadOperations, type PcbReadOperations } from './pcb-read-operations.js';
+import { createPcbWriteOperations, type PcbWriteOperations } from './pcb-write-operations.js';
 import { createProjectOperations, type ProjectOperations } from './project-operations.js';
 import type { Dispatcher, DispatcherToolkit } from './toolkit.js';
 import { isRecord, log, logRecoverableError, type JsonValue } from './utils.js';
@@ -117,6 +118,7 @@ let boardInspection: BoardInspectionOperations;
 let canvasOperations: CanvasOperations;
 let exportOperations: ExportOperations;
 let pcbReadOperations: PcbReadOperations;
+let pcbWriteOperations: PcbWriteOperations;
 let projectOperations: ProjectOperations;
 
 function newBridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
@@ -4003,118 +4005,14 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
       const libraryUuid = typeof params.libraryUuid === 'string' ? params.libraryUuid : undefined;
       return callFirst(['LIB_Device.getByLcscIds'], [lcscId], libraryUuid, false);
     }
-    case 'pcb.addTrack': {
-      // PCB_PrimitivePolyline.create's real argument order could not be
-      // determined live (every points/layer/width/net permutation tried
-      // against the runtime rejected with a generic "cannot create polygon
-      // primitive" error). PCB_PrimitiveLine.create's signature WAS resolved
-      // live by passing 8 distinguishable values and reading back
-      // getState_*: create(net, layer, startX, startY, endX, endY,
-      // lineWidth, locked) — note net comes FIRST, unlike the previous
-      // (points, layer, width, net) call this replaces. A multi-point track
-      // is drawn as one PCB_PrimitiveLine segment per consecutive point
-      // pair, all sharing netName so they merge into one electrical track
-      // (same coordinate-driven merge model as schematic wires).
-      const rawPoints: Array<{ x: number; y: number }> = Array.isArray(params.points)
-        ? params.points
-        : [];
-      if (rawPoints.length < 2) {
-        throw newBridgeError(
-          'INVALID_PARAMS',
-          'pcb.addTrack requires at least 2 points',
-          'Provide a points array with at least a start and end coordinate.',
-        );
-      }
-      const netName = params.netName as string | undefined;
-      const layer = params.layer;
-      const width = params.width;
-      const createdIds: string[] = [];
-      for (let i = 1; i < rawPoints.length; i += 1) {
-        const start = rawPoints[i - 1];
-        const end = rawPoints[i];
-        const created = await callFirst(
-          ['PCB_PrimitiveLine.create', 'pcb_PrimitiveLine.create'],
-          netName,
-          layer,
-          start.x,
-          start.y,
-          end.x,
-          end.y,
-          width,
-          false,
-        );
-        createdIds.push(extractPrimitiveId(created));
-      }
-      return { primitiveId: createdIds[0], primitiveIds: createdIds };
-    }
+    case 'pcb.addTrack':
+      return pcbWriteOperations.addTrack(params);
     case 'pcb.addText':
-      // PCB_PrimitiveString.create's field order was recovered
-      // (2026-07-07) by reading the minified source of .modify() via
-      // .toString() — its destructured input object gives the exact
-      // positional order: create(Layer, X, Y, Text, FontFamily, FontSize,
-      // LineWidth, AlignMode, Rotation, Reverse, Expansion, Mirror,
-      // PrimitiveLock) — 13 args, confirmed live via readback on the Top
-      // Silkscreen layer. fontFamily must be a name the runtime's font
-      // list actually contains (validated internally); the default below
-      // ("NotoSansMonoCJKsc-Regular") was live-verified to work.
-      return callFirst(
-        ['PCB_PrimitiveString.create', 'pcb_PrimitiveString.create'],
-        params.layer,
-        params.x,
-        params.y,
-        params.text,
-        params.fontFamily ?? 'NotoSansMonoCJKsc-Regular',
-        params.fontSize ?? 1,
-        params.lineWidth ?? 0.15,
-        params.alignMode ?? 0,
-        params.rotation ?? 0,
-        params.reverse ?? false,
-        params.expansion ?? 0,
-        params.mirror ?? false,
-        params.locked ?? false,
-      );
+      return pcbWriteOperations.addText(params);
     case 'pcb.addSilkscreenLine':
-      // Reuses PCB_PrimitiveLine.create (the same primitive pcb.addTrack
-      // draws copper tracks with) but with an empty net name and a
-      // non-copper layer — a purely decorative/organizational line (e.g.
-      // silkscreen section dividers) rather than an electrical connection.
-      // Signature confirmed live (2026-07-07): create(net, layer, startX,
-      // startY, endX, endY, lineWidth, locked).
-      return callFirst(
-        ['PCB_PrimitiveLine.create', 'pcb_PrimitiveLine.create'],
-        '',
-        params.layer,
-        params.startX,
-        params.startY,
-        params.endX,
-        params.endY,
-        params.lineWidth ?? 0.2,
-        false,
-      );
+      return pcbWriteOperations.addSilkscreenLine(params);
     case 'pcb.addVia':
-      // PCB_PrimitiveVia.create's real argument order was resolved live by
-      // passing 9 distinguishable values and reading back getState_*:
-      // create(net, x, y, holeDiameter, diameter, viaType,
-      // designRuleBlindViaName, locked, solderMaskExpansion) — note net
-      // comes FIRST and hole/outer diameter are SWAPPED relative to the
-      // previous (x, y, outerDiameter, holeSize, net) call this replaces,
-      // which silently wrote garbage (net into X, diameter into Y, etc.)
-      // while still reporting success. holeDiameter/diameter are passed
-      // through in whatever native unit the caller supplies (unconverted,
-      // same as x/y) — the exact real-world unit was not independently
-      // cross-checked against a known physical dimension.
-      return callFirst(
-        ['PCB_PrimitiveVia.create', 'pcb_PrimitiveVia.create'],
-        params.netName,
-        params.x,
-        params.y,
-        params.holeSize,
-        params.outerDiameter,
-        0,
-        '',
-        false,
-        undefined,
-      );
+      return pcbWriteOperations.addVia(params);
     case 'pcb.addZone':
       return callFirst(
         ['PCB_PrimitivePour.create', 'PCB_ComplexPolygon.create', 'pcb_PrimitivePour.create'],
@@ -4192,6 +4090,11 @@ export function createDispatcher(toolkit: DispatcherToolkit): Dispatcher {
     requireActivePcbContext: () => boardInspection.requireActivePcbContext(),
     readFirstPath,
     readState: safeGetState,
+  });
+  pcbWriteOperations = createPcbWriteOperations({
+    callFirst,
+    extractPrimitiveId,
+    createBridgeError: newBridgeError,
   });
   projectOperations = createProjectOperations({ callFirst });
   textAlignModeCache.clear();

--- a/easyeda-bridge-extension/src/pcb-write-operations.ts
+++ b/easyeda-bridge-extension/src/pcb-write-operations.ts
@@ -1,0 +1,121 @@
+import type { ApiRuntime, BridgeErrorFactory } from './api-runtime.js';
+
+export type PrimitiveIdExtractor = (value: unknown) => string;
+
+export interface PcbWriteOperationDependencies {
+  callFirst: ApiRuntime['callFirst'];
+  extractPrimitiveId: PrimitiveIdExtractor;
+  createBridgeError: BridgeErrorFactory;
+}
+
+export interface PcbWriteOperations {
+  addTrack(params: Record<string, unknown>): Promise<unknown>;
+  addText(params: Record<string, unknown>): Promise<unknown>;
+  addSilkscreenLine(params: Record<string, unknown>): Promise<unknown>;
+  addVia(params: Record<string, unknown>): Promise<unknown>;
+}
+
+export function createPcbWriteOperations({
+  callFirst,
+  extractPrimitiveId,
+  createBridgeError,
+}: PcbWriteOperationDependencies): PcbWriteOperations {
+  async function addTrack(params: Record<string, unknown>): Promise<unknown> {
+    // PCB_PrimitivePolyline.create's real argument order could not be
+    // determined live. PCB_PrimitiveLine.create was confirmed as
+    // create(net, layer, startX, startY, endX, endY, lineWidth, locked).
+    const points: Array<{ x: number; y: number }> = Array.isArray(params.points)
+      ? params.points
+      : [];
+    if (points.length < 2) {
+      throw createBridgeError(
+        'INVALID_PARAMS',
+        'pcb.addTrack requires at least 2 points',
+        'Provide a points array with at least a start and end coordinate.',
+      );
+    }
+
+    const createdIds: string[] = [];
+    for (let index = 1; index < points.length; index += 1) {
+      const start = points[index - 1];
+      const end = points[index];
+      const created = await callFirst(
+        ['PCB_PrimitiveLine.create', 'pcb_PrimitiveLine.create'],
+        params.netName,
+        params.layer,
+        start.x,
+        start.y,
+        end.x,
+        end.y,
+        params.width,
+        false,
+      );
+      createdIds.push(extractPrimitiveId(created));
+    }
+
+    return { primitiveId: createdIds[0], primitiveIds: createdIds };
+  }
+
+  async function addText(params: Record<string, unknown>): Promise<unknown> {
+    // PCB_PrimitiveString.create was live-confirmed as:
+    // create(layer, x, y, text, fontFamily, fontSize, lineWidth, alignMode,
+    // rotation, reverse, expansion, mirror, primitiveLock).
+    return callFirst(
+      ['PCB_PrimitiveString.create', 'pcb_PrimitiveString.create'],
+      params.layer,
+      params.x,
+      params.y,
+      params.text,
+      params.fontFamily ?? 'NotoSansMonoCJKsc-Regular',
+      params.fontSize ?? 1,
+      params.lineWidth ?? 0.15,
+      params.alignMode ?? 0,
+      params.rotation ?? 0,
+      params.reverse ?? false,
+      params.expansion ?? 0,
+      params.mirror ?? false,
+      params.locked ?? false,
+    );
+  }
+
+  async function addSilkscreenLine(params: Record<string, unknown>): Promise<unknown> {
+    // Reuse PCB_PrimitiveLine.create with an empty net and a non-copper layer
+    // so the result remains decorative rather than electrical.
+    return callFirst(
+      ['PCB_PrimitiveLine.create', 'pcb_PrimitiveLine.create'],
+      '',
+      params.layer,
+      params.startX,
+      params.startY,
+      params.endX,
+      params.endY,
+      params.lineWidth ?? 0.2,
+      false,
+    );
+  }
+
+  async function addVia(params: Record<string, unknown>): Promise<unknown> {
+    // PCB_PrimitiveVia.create was live-confirmed as:
+    // create(net, x, y, holeDiameter, diameter, viaType,
+    // designRuleBlindViaName, locked, solderMaskExpansion).
+    return callFirst(
+      ['PCB_PrimitiveVia.create', 'pcb_PrimitiveVia.create'],
+      params.netName,
+      params.x,
+      params.y,
+      params.holeSize,
+      params.outerDiameter,
+      0,
+      '',
+      false,
+      undefined,
+    );
+  }
+
+  return {
+    addTrack,
+    addText,
+    addSilkscreenLine,
+    addVia,
+  };
+}

--- a/easyeda-bridge-extension/tests/pcb-write-operations.test.ts
+++ b/easyeda-bridge-extension/tests/pcb-write-operations.test.ts
@@ -1,0 +1,218 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPcbWriteOperations } from '../src/pcb-write-operations.js';
+
+function bridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
+  return Object.assign(new Error(message), { code, suggestion, data });
+}
+
+function makeOperations() {
+  const callFirst = vi.fn(async (...args: unknown[]) => ({
+    primitiveId: `id-${callFirst.mock.calls.length}`,
+    args,
+  }));
+  const extractPrimitiveId = vi.fn((value: unknown) =>
+    String((value as { primitiveId?: unknown } | null)?.primitiveId ?? ''),
+  );
+  return {
+    callFirst,
+    extractPrimitiveId,
+    operations: createPcbWriteOperations({
+      callFirst,
+      extractPrimitiveId,
+      createBridgeError: bridgeError,
+    }),
+  };
+}
+
+describe('PCB write operations', () => {
+  it('rejects missing or undersized track point arrays before native calls', async () => {
+    const { callFirst, operations } = makeOperations();
+
+    await expect(operations.addTrack({ points: 'not-an-array' })).rejects.toMatchObject({
+      code: 'INVALID_PARAMS',
+      message: 'pcb.addTrack requires at least 2 points',
+      suggestion: 'Provide a points array with at least a start and end coordinate.',
+    });
+    await expect(operations.addTrack({ points: [{ x: 0, y: 0 }] })).rejects.toMatchObject({
+      code: 'INVALID_PARAMS',
+    });
+    expect(callFirst).not.toHaveBeenCalled();
+  });
+
+  it('creates one native line per consecutive track point pair', async () => {
+    const { callFirst, extractPrimitiveId, operations } = makeOperations();
+
+    await expect(
+      operations.addTrack({
+        points: [
+          { x: 1, y: 2 },
+          { x: 3, y: 4 },
+          { x: 5, y: 6 },
+        ],
+        netName: 'GND',
+        layer: 1,
+        width: 0.25,
+      }),
+    ).resolves.toEqual({
+      primitiveId: 'id-1',
+      primitiveIds: ['id-1', 'id-2'],
+    });
+
+    expect(callFirst).toHaveBeenNthCalledWith(
+      1,
+      ['PCB_PrimitiveLine.create', 'pcb_PrimitiveLine.create'],
+      'GND',
+      1,
+      1,
+      2,
+      3,
+      4,
+      0.25,
+      false,
+    );
+    expect(callFirst).toHaveBeenNthCalledWith(
+      2,
+      ['PCB_PrimitiveLine.create', 'pcb_PrimitiveLine.create'],
+      'GND',
+      1,
+      3,
+      4,
+      5,
+      6,
+      0.25,
+      false,
+    );
+    expect(extractPrimitiveId).toHaveBeenCalledTimes(2);
+  });
+
+  it('applies the exact PCB text defaults when optional fields are absent', async () => {
+    const { callFirst, operations } = makeOperations();
+
+    await operations.addText({ layer: 3, x: 10, y: 20, text: 'REF' });
+
+    expect(callFirst).toHaveBeenCalledWith(
+      ['PCB_PrimitiveString.create', 'pcb_PrimitiveString.create'],
+      3,
+      10,
+      20,
+      'REF',
+      'NotoSansMonoCJKsc-Regular',
+      1,
+      0.15,
+      0,
+      0,
+      false,
+      0,
+      false,
+      false,
+    );
+  });
+
+  it('preserves explicit PCB text values including zero and false', async () => {
+    const { callFirst, operations } = makeOperations();
+    const params = {
+      layer: 4,
+      x: 1,
+      y: 2,
+      text: 'TXT',
+      fontFamily: 'CustomFont',
+      fontSize: 0,
+      lineWidth: 0,
+      alignMode: 0,
+      rotation: 0,
+      reverse: false,
+      expansion: 0,
+      mirror: false,
+      locked: false,
+    };
+
+    await operations.addText(params);
+
+    expect(callFirst).toHaveBeenCalledWith(
+      ['PCB_PrimitiveString.create', 'pcb_PrimitiveString.create'],
+      4,
+      1,
+      2,
+      'TXT',
+      'CustomFont',
+      0,
+      0,
+      0,
+      0,
+      false,
+      0,
+      false,
+      false,
+    );
+  });
+
+  it('creates silkscreen lines with an empty net and preserves width fallback', async () => {
+    const { callFirst, operations } = makeOperations();
+
+    await operations.addSilkscreenLine({
+      layer: 3,
+      startX: 1,
+      startY: 2,
+      endX: 3,
+      endY: 4,
+    });
+    await operations.addSilkscreenLine({
+      layer: 3,
+      startX: 5,
+      startY: 6,
+      endX: 7,
+      endY: 8,
+      lineWidth: 0,
+    });
+
+    expect(callFirst).toHaveBeenNthCalledWith(
+      1,
+      ['PCB_PrimitiveLine.create', 'pcb_PrimitiveLine.create'],
+      '',
+      3,
+      1,
+      2,
+      3,
+      4,
+      0.2,
+      false,
+    );
+    expect(callFirst).toHaveBeenNthCalledWith(
+      2,
+      ['PCB_PrimitiveLine.create', 'pcb_PrimitiveLine.create'],
+      '',
+      3,
+      5,
+      6,
+      7,
+      8,
+      0,
+      false,
+    );
+  });
+
+  it('creates vias with the live-verified native argument order', async () => {
+    const { callFirst, operations } = makeOperations();
+
+    await operations.addVia({
+      netName: 'VCC',
+      x: 100,
+      y: 200,
+      holeSize: 30,
+      outerDiameter: 60,
+    });
+
+    expect(callFirst).toHaveBeenCalledWith(
+      ['PCB_PrimitiveVia.create', 'pcb_PrimitiveVia.create'],
+      'VCC',
+      100,
+      200,
+      30,
+      60,
+      0,
+      '',
+      false,
+      undefined,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Extract the four live-verified PCB creation operations from the extension dispatcher into a typed `PcbWriteOperations` domain module.

This is the eighth bounded, behavior-preserving delivery slice for #339. It does not add, remove, or rename any public extension method.

## Changes

- add `easyeda-bridge-extension/src/pcb-write-operations.ts`
- move the following implementations behind `createPcbWriteOperations(...)`:
  - `pcb.addTrack`
  - `pcb.addText`
  - `pcb.addSilkscreenLine`
  - `pcb.addVia`
- inject the existing `callFirst`, bridge-error factory, and primitive-ID extractor through an explicit typed interface
- reduce `dispatcher.ts` to routing/delegation for these methods
- add focused parity tests for native argument order, defaults, multi-segment track results, and invalid track input

## Behavior-parity evidence

The extraction preserves the existing live-confirmed EasyEDA Pro contracts:

- track segments call `PCB_PrimitiveLine.create(net, layer, startX, startY, endX, endY, lineWidth, locked)`
- multi-point tracks create one line per adjacent point pair and return the same first/all primitive ID shape
- fewer than two track points still fail with `INVALID_PARAMS`
- PCB text preserves all previous nullish defaults and the 13-argument native order
- silkscreen lines still use an empty net name and default line width `0.2`
- vias preserve the native net-first, hole-before-outer-diameter argument order
- public extension method list remains identical at 67 methods

## Maintainability impact

- `dispatcher.ts`: 4,204 → 4,107 lines
- new domain module: 100% statement/branch/function/line coverage
  - 14/14 lines
  - 5/5 functions
  - 24/24 branches
- focused dispatcher/domain tests: 99 passing

## Verification

- `pnpm verify`
  - 150 server test files / 1,740 tests passed
  - 18 extension test files / 217 tests passed
  - format, typecheck, lint, metadata, build, package, and docs gates passed
- `pnpm security:audit`
  - only the repository-documented temporary `@hono/node-server` advisory allowance remains
- `pnpm peers check`
- extension coverage gates
- extension package/checksum verification
- size budgets:
  - `.eext`: 162,828 / 200,000 bytes
  - extension entry: 218,764 / 260,000 bytes
  - dispatcher bundle: 158,349 / 185,000 bytes

## Scope

This PR intentionally does not close #339. Subsequent dispatcher domains will continue in separate bounded PRs.

Refs #339
