### PR TITLE
refactor(extension): extract PCB mutation operations

### DIFF
--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -21,6 +21,10 @@ import {
 } from './board-inspection.js';
 import { createCanvasOperations, type CanvasOperations } from './canvas-operations.js';
 import { createExportOperations, type ExportOperations } from './export-operations.js';
+import {
+  createPcbMutationOperations,
+  type PcbMutationOperations,
+} from './pcb-mutation-operations.js';
 import { createPcbReadOperations, type PcbReadOperations } from './pcb-read-operations.js';
 import { createPcbWriteOperations, type PcbWriteOperations } from './pcb-write-operations.js';
 import { createProjectOperations, type ProjectOperations } from './project-operations.js';
@@ -117,6 +121,7 @@ let callAllowedApi: ApiRuntime['callAllowedApi'];
 let boardInspection: BoardInspectionOperations;
 let canvasOperations: CanvasOperations;
 let exportOperations: ExportOperations;
+let pcbMutationOperations: PcbMutationOperations;
 let pcbReadOperations: PcbReadOperations;
 let pcbWriteOperations: PcbWriteOperations;
 let projectOperations: ProjectOperations;
@@ -4014,33 +4019,11 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
     case 'pcb.addVia':
       return pcbWriteOperations.addVia(params);
     case 'pcb.addZone':
-      return callFirst(
-        ['PCB_PrimitivePour.create', 'PCB_ComplexPolygon.create', 'pcb_PrimitivePour.create'],
-        params.points,
-        params.layer,
-        params.netName,
-        params.clearance,
-      );
-    case 'pcb.deleteComponent': {
-      // Returns full per-id status rather than throwing on partial failure:
-      // the bridge transport only preserves an error's message (not its data
-      // payload) back to the MCP tool layer, so structured deleted/notFound
-      // detail would be lost if this threw instead.
-      const ids = Array.isArray(params.primitiveIds) ? (params.primitiveIds as string[]) : [];
-      const result = await pcbReadOperations.deletePrimitives(ids);
-      return {
-        success: result.notFound.length === 0,
-        deletedCount: result.deleted.length,
-        deleted: result.deleted,
-        notFound: result.notFound,
-      };
-    }
+      return pcbMutationOperations.addZone(params);
+    case 'pcb.deleteComponent':
+      return pcbMutationOperations.deleteComponents(params);
     case 'pcb.modifyComponent':
-      return callFirst(
-        ['PCB_PrimitiveComponent.modify', 'pcb_PrimitiveComponent.modify'],
-        params.primitiveId,
-        params.property,
-      );
+      return pcbMutationOperations.modifyComponent(params);
     case 'pcb.listComponents':
       return pcbReadOperations.listComponents(
         typeof params.limit === 'number' ? params.limit : undefined,
@@ -4090,6 +4073,10 @@ export function createDispatcher(toolkit: DispatcherToolkit): Dispatcher {
     requireActivePcbContext: () => boardInspection.requireActivePcbContext(),
     readFirstPath,
     readState: safeGetState,
+  });
+  pcbMutationOperations = createPcbMutationOperations({
+    callFirst,
+    deletePrimitives: (ids) => pcbReadOperations.deletePrimitives(ids),
   });
   pcbWriteOperations = createPcbWriteOperations({
     callFirst,

--- a/easyeda-bridge-extension/src/pcb-mutation-operations.ts
+++ b/easyeda-bridge-extension/src/pcb-mutation-operations.ts
@@ -1,0 +1,58 @@
+import type { ApiRuntime } from './api-runtime.js';
+
+export interface PcbMutationOperationDependencies {
+  callFirst: ApiRuntime['callFirst'];
+  deletePrimitives(ids: string[]): Promise<{ deleted: string[]; notFound: string[] }>;
+}
+
+export interface PcbMutationOperations {
+  addZone(params: Record<string, unknown>): Promise<unknown>;
+  modifyComponent(params: Record<string, unknown>): Promise<unknown>;
+  deleteComponents(params: Record<string, unknown>): Promise<{
+    success: boolean;
+    deletedCount: number;
+    deleted: string[];
+    notFound: string[];
+  }>;
+}
+
+export function createPcbMutationOperations({
+  callFirst,
+  deletePrimitives,
+}: PcbMutationOperationDependencies): PcbMutationOperations {
+  async function addZone(params: Record<string, unknown>): Promise<unknown> {
+    return callFirst(
+      ['PCB_PrimitivePour.create', 'PCB_ComplexPolygon.create', 'pcb_PrimitivePour.create'],
+      params.points,
+      params.layer,
+      params.netName,
+      params.clearance,
+    );
+  }
+
+  async function modifyComponent(params: Record<string, unknown>): Promise<unknown> {
+    return callFirst(
+      ['PCB_PrimitiveComponent.modify', 'pcb_PrimitiveComponent.modify'],
+      params.primitiveId,
+      params.property,
+    );
+  }
+
+  async function deleteComponents(params: Record<string, unknown>): Promise<{
+    success: boolean;
+    deletedCount: number;
+    deleted: string[];
+    notFound: string[];
+  }> {
+    const ids = Array.isArray(params.primitiveIds) ? (params.primitiveIds as string[]) : [];
+    const result = await deletePrimitives(ids);
+    return {
+      success: result.notFound.length === 0,
+      deletedCount: result.deleted.length,
+      deleted: result.deleted,
+      notFound: result.notFound,
+    };
+  }
+
+  return { addZone, modifyComponent, deleteComponents };
+}

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -1444,6 +1444,36 @@ describe('createDispatcher', () => {
     ).rejects.toMatchObject({ code: 'INVALID_PARAMS' });
   });
 
+  it('routes PCB zone creation and component modification through the extracted mutation domain', async () => {
+    const create = vi.fn(async () => ({ primitiveId: 'zone1' }));
+    const modify = vi.fn(async () => ({ primitiveId: 'component1' }));
+    const dispatcher = createDispatcher(
+      makeToolkit({
+        PCB_PrimitivePour: { create },
+        PCB_PrimitiveComponent: { modify },
+      }),
+    );
+    const points = [
+      { x: 10, y: 20 },
+      { x: 30, y: 40 },
+    ];
+    const property = { x: 50, y: 60, rotation: 90 };
+
+    await dispatcher.dispatch('pcb.addZone', {
+      points,
+      layer: 1,
+      netName: 'GND',
+      clearance: 0.2,
+    });
+    await dispatcher.dispatch('pcb.modifyComponent', {
+      primitiveId: 'component1',
+      property,
+    });
+
+    expect(create).toHaveBeenCalledWith(points, 1, 'GND', 0.2);
+    expect(modify).toHaveBeenCalledWith('component1', property);
+  });
+
   // Live-verified (2026-07-07): SCH_PrimitiveCircle's field order was
   // recovered by reading the minified source of .modify() via .toString():
   // create(CenterX, CenterY, Radius, Color, FillColor, LineWidth, LineType,

--- a/easyeda-bridge-extension/tests/pcb-mutation-operations.test.ts
+++ b/easyeda-bridge-extension/tests/pcb-mutation-operations.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPcbMutationOperations } from '../src/pcb-mutation-operations.js';
+
+function createOperations() {
+  const callFirst = vi.fn(async (_paths: readonly string[], ...args: unknown[]) => ({ args }));
+  const deletePrimitives = vi.fn(
+    async (ids: string[]): Promise<{ deleted: string[]; notFound: string[] }> => ({
+      deleted: ids.filter((id) => id !== 'missing'),
+      notFound: ids.filter((id) => id === 'missing'),
+    }),
+  );
+  return {
+    callFirst,
+    deletePrimitives,
+    operations: createPcbMutationOperations({ callFirst, deletePrimitives }),
+  };
+}
+
+describe('createPcbMutationOperations', () => {
+  it('creates zones with the existing EasyEDA path order and arguments', async () => {
+    const { callFirst, operations } = createOperations();
+    const params = {
+      points: [0, 0, 10, 0, 10, 10],
+      layer: 1,
+      netName: 'GND',
+      clearance: 0.2,
+    };
+
+    await operations.addZone(params);
+
+    expect(callFirst).toHaveBeenCalledWith(
+      ['PCB_PrimitivePour.create', 'PCB_ComplexPolygon.create', 'pcb_PrimitivePour.create'],
+      params.points,
+      params.layer,
+      params.netName,
+      params.clearance,
+    );
+  });
+
+  it('modifies components with the existing primitive id and property order', async () => {
+    const { callFirst, operations } = createOperations();
+    const property = { X: 12, Y: 34, Rotation: 90 };
+
+    await operations.modifyComponent({ primitiveId: 'component-1', property });
+
+    expect(callFirst).toHaveBeenCalledWith(
+      ['PCB_PrimitiveComponent.modify', 'pcb_PrimitiveComponent.modify'],
+      'component-1',
+      property,
+    );
+  });
+
+  it('normalizes complete and partial deletion results without throwing', async () => {
+    const { deletePrimitives, operations } = createOperations();
+
+    await expect(
+      operations.deleteComponents({ primitiveIds: ['component-1', 'missing'] }),
+    ).resolves.toEqual({
+      success: false,
+      deletedCount: 1,
+      deleted: ['component-1'],
+      notFound: ['missing'],
+    });
+    expect(deletePrimitives).toHaveBeenCalledWith(['component-1', 'missing']);
+  });
+
+  it('treats a non-array primitiveIds value as an empty deletion request', async () => {
+    const { deletePrimitives, operations } = createOperations();
+
+    await expect(operations.deleteComponents({ primitiveIds: 'component-1' })).resolves.toEqual({
+      success: true,
+      deletedCount: 0,
+      deleted: [],
+      notFound: [],
+    });
+    expect(deletePrimitives).toHaveBeenCalledWith([]);
+  });
+});


### PR DESCRIPTION
## Summary

Extract the remaining PCB mutation routing from the extension dispatcher into a typed `PcbMutationOperations` domain module.

This is the ninth bounded, behavior-preserving delivery slice for #339. It does not add, remove, or rename any public extension method.

## Changes

- add `easyeda-bridge-extension/src/pcb-mutation-operations.ts`
- move the following mutation orchestration behind `createPcbMutationOperations(...)`:
  - `pcb.addZone`
  - `pcb.modifyComponent`
  - `pcb.deleteComponent`
- inject the existing native API runtime and ownership-aware primitive deletion service through an explicit typed interface
- keep low-level PCB class ownership discovery in the previously extracted read domain
- reduce `dispatcher.ts` to routing/delegation for these methods
- add focused parity tests for native fallback order, exact argument forwarding, complete/partial deletion, and malformed deletion input

## Behavior-parity evidence

The extraction preserves the existing EasyEDA Pro contracts:

- zone creation retains the fallback order `PCB_PrimitivePour.create` → `PCB_ComplexPolygon.create` → `pcb_PrimitivePour.create`
- zone points, layer, net name, and clearance are forwarded unchanged
- component modification retains the primary/lowercase API fallback and exact `(primitiveId, property)` order
- deletion still delegates to ownership-aware class routing from the PCB read domain
- complete and partial deletion still return structured `{ success, deletedCount, deleted, notFound }` results without throwing
- non-array `primitiveIds` still normalize to an empty deletion request
- public extension method list remains identical at 67 methods

## Maintainability impact

- `dispatcher.ts`: 4,107 → 4,094 lines
- new mutation domain: 100% statement/branch/function/line coverage
  - 6/6 lines
  - 4/4 functions
  - 2/2 branches
- focused PCB mutation/read/write/dispatcher parity: 115 tests

## Verification

- `pnpm verify`
  - 150 server test files / 1,740 tests passed
  - 19 extension test files / 222 tests passed
  - format, typecheck, lint, metadata, build, package, and docs gates passed
- `pnpm security:audit`
  - only the repository-documented temporary `@hono/node-server` advisory allowance remains
- `pnpm peers check`
- extension coverage gates
- extension package/checksum verification
- size budgets:
  - `.eext`: 163,086 / 200,000 bytes
  - extension entry: 219,404 / 260,000 bytes
  - dispatcher bundle: 158,989 / 185,000 bytes

## Scope

This PR intentionally does not close #339. Subsequent dispatcher domains will continue in separate bounded PRs.

Refs #339
