### PR TITLE
refactor(extension): extract schematic inspection operations

### DIFF
--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -28,6 +28,10 @@ import {
 import { createPcbReadOperations, type PcbReadOperations } from './pcb-read-operations.js';
 import { createPcbWriteOperations, type PcbWriteOperations } from './pcb-write-operations.js';
 import { createProjectOperations, type ProjectOperations } from './project-operations.js';
+import {
+  createSchematicInspectionOperations,
+  type SchematicInspectionOperations,
+} from './schematic-inspection.js';
 import type { Dispatcher, DispatcherToolkit } from './toolkit.js';
 import { isRecord, log, logRecoverableError, type JsonValue } from './utils.js';
 
@@ -125,6 +129,7 @@ let pcbMutationOperations: PcbMutationOperations;
 let pcbReadOperations: PcbReadOperations;
 let pcbWriteOperations: PcbWriteOperations;
 let projectOperations: ProjectOperations;
+let schematicInspection: SchematicInspectionOperations;
 
 function newBridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
   const error = new Error(message);
@@ -1025,187 +1030,6 @@ async function listComponentsApi(limit?: number, offset = 0): Promise<unknown> {
     });
   }
   return { total, items: result };
-}
-
-interface RawPrimitiveBBox {
-  minX: number;
-  maxX: number;
-  minY: number;
-  maxY: number;
-}
-
-/**
- * Real rendered (sheet-space) bounding box per primitive, via the runtime's own
- * SCH_Primitive.getPrimitivesBBox -- already rotation/mirror-aware since it reads
- * the live rendered geometry rather than recomputing it from origin+rotation.
- */
-async function primitiveBoundsApi(primitiveIds: unknown): Promise<unknown> {
-  const schPrimitiveClass = readFirstPath<any>(['SCH_Primitive', 'sch_Primitive']);
-  if (!schPrimitiveClass) {
-    throw new Error('SCH_Primitive class not found in EasyEDA Pro API');
-  }
-  const ids = Array.isArray(primitiveIds)
-    ? primitiveIds.filter((id): id is string => typeof id === 'string' && id.length > 0)
-    : [];
-
-  const items: Array<{ primitiveId: string; bounds: RawPrimitiveBBox | null }> = [];
-  for (const id of ids) {
-    let bounds: RawPrimitiveBBox | null = null;
-    try {
-      bounds = (await schPrimitiveClass.getPrimitivesBBox([id])) ?? null;
-    } catch (err) {
-      logRecoverableError(`failed to read bounding box for primitive ${id}`, err);
-    }
-    items.push({ primitiveId: id, bounds });
-  }
-
-  let combined: RawPrimitiveBBox | null = null;
-  if (ids.length > 0) {
-    try {
-      combined = (await schPrimitiveClass.getPrimitivesBBox(ids)) ?? null;
-    } catch (err) {
-      logRecoverableError('failed to read combined bounding box', err);
-    }
-  }
-
-  return { items, combined };
-}
-
-type SheetInfoSource = 'current_page' | 'focused_document' | 'current_schematic_page_list';
-
-type SheetInfoAttempt = {
-  stage: string;
-  status: 'value' | 'empty' | 'unavailable';
-  error?: string;
-};
-
-function asNonEmptyRecord(value: unknown): Record<string, unknown> | undefined {
-  if (!isRecord(value) || Object.keys(value).length === 0) return undefined;
-  return value;
-}
-
-function asRecordArray(value: unknown): Array<Record<string, unknown>> {
-  if (!Array.isArray(value)) return [];
-  return value.filter((item): item is Record<string, unknown> => isRecord(item));
-}
-
-async function trySheetInfoCall(
-  stage: string,
-  paths: string[],
-  attempts: SheetInfoAttempt[],
-  ...args: unknown[]
-): Promise<unknown> {
-  try {
-    const value = normalizeValue(await callFirst(paths, ...args), 5);
-    const meaningful = Array.isArray(value)
-      ? value.length > 0
-      : Boolean(asNonEmptyRecord(value)) || (value !== null && value !== undefined);
-    attempts.push({ stage, status: meaningful ? 'value' : 'empty' });
-    return value;
-  } catch (error) {
-    attempts.push({
-      stage,
-      status: 'unavailable',
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return undefined;
-  }
-}
-
-async function getSchematicSheetInfoApi(): Promise<unknown> {
-  const attempts: SheetInfoAttempt[] = [];
-  let source: SheetInfoSource | undefined;
-
-  let currentPage = asNonEmptyRecord(
-    await trySheetInfoCall('current_page', ['DMT_Schematic.getCurrentSchematicPageInfo'], attempts),
-  );
-  if (currentPage) source = 'current_page';
-
-  let pages = asRecordArray(
-    await trySheetInfoCall(
-      'current_page_list',
-      ['DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo'],
-      attempts,
-    ),
-  );
-  if (pages.length === 0) {
-    pages = asRecordArray(
-      await trySheetInfoCall('all_page_list', ['DMT_Schematic.getAllSchematicPagesInfo'], attempts),
-    );
-  }
-
-  const focusedDocument = asNonEmptyRecord(
-    await trySheetInfoCall(
-      'focused_document',
-      ['DMT_SelectControl.getCurrentDocumentInfo'],
-      attempts,
-    ),
-  );
-  const focusedPageUuid =
-    typeof focusedDocument?.uuid === 'string' && focusedDocument.uuid.trim()
-      ? focusedDocument.uuid
-      : undefined;
-
-  let currentSchematic: Record<string, unknown> | undefined;
-  if (!currentPage || pages.length === 0) {
-    currentSchematic = asNonEmptyRecord(
-      await trySheetInfoCall(
-        'current_schematic',
-        ['DMT_Schematic.getCurrentSchematicInfo'],
-        attempts,
-      ),
-    );
-  }
-
-  if (!currentPage && focusedPageUuid) {
-    currentPage = asNonEmptyRecord(
-      await trySheetInfoCall(
-        'focused_document_page',
-        ['DMT_Schematic.getSchematicPageInfo'],
-        attempts,
-        focusedPageUuid,
-      ),
-    );
-    if (currentPage) source = 'focused_document';
-  }
-
-  const schematicPages = asRecordArray(currentSchematic?.page);
-  if (pages.length === 0 && schematicPages.length > 0) pages = schematicPages;
-
-  if (!currentPage && focusedPageUuid && pages.length > 0) {
-    currentPage = pages.find((page) => page.uuid === focusedPageUuid);
-    if (currentPage) source = 'focused_document';
-  }
-
-  if (!currentPage && pages.length === 1 && currentSchematic) {
-    currentPage = pages[0];
-    source = 'current_schematic_page_list';
-  }
-
-  const diagnostics = {
-    stage: 'focused_sheet_resolution',
-    currentPageAvailable: Boolean(currentPage),
-    pageListAvailable: pages.length > 0,
-    focusedDocumentAvailable: Boolean(focusedDocument),
-    attempts,
-  };
-
-  if (!currentPage) {
-    throw newBridgeError(
-      'SHEET_INFO_UNAVAILABLE',
-      'EasyEDA did not expose metadata for the focused schematic page.',
-      'Focus the schematic editor tab and retry. The diagnostics identify which runtime paths were empty or unavailable.',
-      diagnostics,
-    );
-  }
-
-  return {
-    currentPage,
-    pages,
-    source,
-    focusedDocument,
-    diagnostics,
-  };
 }
 
 async function listNetsApi(budget?: NetDetailBudget): Promise<unknown> {
@@ -2962,9 +2786,9 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
         typeof params.offset === 'number' ? params.offset : 0,
       );
     case 'schematic.getSheetInfo':
-      return getSchematicSheetInfoApi();
+      return schematicInspection.getSheetInfo();
     case 'schematic.primitiveBounds':
-      return primitiveBoundsApi(params.primitiveIds);
+      return schematicInspection.primitiveBounds(params.primitiveIds);
     case 'schematic.searchDevice':
       return callFirst(
         ['LIB_Device.search', 'lib_Device.search'],
@@ -3144,50 +2968,8 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
         params.lineType ?? 0,
         params.fillStyle ?? 'none',
       );
-    case 'schematic.listRectangles': {
-      // Best-effort enumeration for the section-layout overlap check
-      // (src/workflows/section-layout.ts). Live-verified (2026-07-09): the
-      // plain 'X'/'Y' guess used by SCH_PrimitiveComponent/SCH_PrimitiveText
-      // does NOT hold here — a live readback returned width/height/rotation
-      // correctly but x/y were undefined. SCH_PrimitiveRectangle.create()'s
-      // own positional args are named TopLeftX/TopLeftY (see addRectangle
-      // above), and that's the key that actually resolves; X/Y kept as a
-      // fallback in case a future runtime version differs. Still degrades to
-      // "no overlap data" (not a crash) if both guesses are wrong.
-      //
-      // Y-sign note (live-verified 2026-07-09): a rectangle created with
-      // `y: 5000` reads back TopLeftY: -5000 — an exact sign flip, also
-      // observed on SCH_PrimitiveText the same way (created y:6000 -> read
-      // back y:-6000). SCH_PrimitiveComponent (pins) and SCH_PrimitiveWire
-      // (Line) showed no such flip across multiple live checks — this
-      // appears specific to these two annotation-layer primitive types, not
-      // a general coordinate-system quirk. Negate on the way out so callers
-      // (e.g. findOverlappingRectangles, which compares against pin-derived
-      // Y coordinates) see the same sign convention as everything else.
-      const schRectClass = readFirstPath<any>(['SCH_PrimitiveRectangle', 'sch_PrimitiveRectangle']);
-      if (!schRectClass || typeof schRectClass.getAll !== 'function') {
-        return { total: 0, items: [] };
-      }
-      let all: unknown[] = [];
-      try {
-        all = (await schRectClass.getAll()) || [];
-      } catch (e) {
-        logRecoverableError('failed to list rectangles', e);
-        all = [];
-      }
-      const items = all.map((r) => {
-        const rawY = safeGetState(r, 'TopLeftY') ?? safeGetState(r, 'Y');
-        return {
-          primitiveId: extractPrimitiveId(r) || String(safeGetState(r, 'PrimitiveId') ?? ''),
-          x: safeGetState(r, 'TopLeftX') ?? safeGetState(r, 'X'),
-          y: typeof rawY === 'number' ? -rawY : rawY,
-          width: safeGetState(r, 'Width'),
-          height: safeGetState(r, 'Height'),
-          rotation: safeGetState(r, 'Rotation'),
-        };
-      });
-      return { total: items.length, items };
-    }
+    case 'schematic.listRectangles':
+      return schematicInspection.listRectangles();
     case 'schematic.deletePrimitive':
       return deleteSchematicPrimitives(params.primitiveIds);
     case 'schematic.recreatePrimitiveSnapshot':
@@ -4084,6 +3866,13 @@ export function createDispatcher(toolkit: DispatcherToolkit): Dispatcher {
     createBridgeError: newBridgeError,
   });
   projectOperations = createProjectOperations({ callFirst });
+  schematicInspection = createSchematicInspectionOperations({
+    callFirst,
+    readFirstPath,
+    readState: safeGetState,
+    extractPrimitiveId,
+    createBridgeError: newBridgeError,
+  });
   textAlignModeCache.clear();
   log(`dispatcher initialized (build ${BUILD_ID}, ${METHOD_LIST.length} methods)`);
   return {

--- a/easyeda-bridge-extension/src/schematic-inspection.ts
+++ b/easyeda-bridge-extension/src/schematic-inspection.ts
@@ -1,0 +1,251 @@
+import type { ApiRuntime } from './api-runtime.js';
+import { normalizeValue } from './api-introspection.js';
+import { isRecord, logRecoverableError } from './utils.js';
+
+interface RawPrimitiveBBox {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
+type SheetInfoSource = 'current_page' | 'focused_document' | 'current_schematic_page_list';
+
+type SheetInfoAttempt = {
+  stage: string;
+  status: 'value' | 'empty' | 'unavailable';
+  error?: string;
+};
+
+export interface SchematicInspectionOperationDependencies {
+  callFirst: ApiRuntime['callFirst'];
+  readFirstPath<T>(paths: readonly string[]): T | undefined;
+  readState(value: unknown, key: string): unknown;
+  extractPrimitiveId(value: unknown): string;
+  createBridgeError(code: string, message: string, suggestion: string, data?: unknown): Error;
+}
+
+export interface SchematicInspectionOperations {
+  primitiveBounds(primitiveIds: unknown): Promise<unknown>;
+  getSheetInfo(): Promise<unknown>;
+  listRectangles(): Promise<unknown>;
+}
+
+function asNonEmptyRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!isRecord(value) || Object.keys(value).length === 0) return undefined;
+  return value;
+}
+
+function asRecordArray(value: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is Record<string, unknown> => isRecord(item));
+}
+
+export function createSchematicInspectionOperations({
+  callFirst,
+  readFirstPath,
+  readState,
+  extractPrimitiveId,
+  createBridgeError,
+}: SchematicInspectionOperationDependencies): SchematicInspectionOperations {
+  async function primitiveBounds(primitiveIds: unknown): Promise<unknown> {
+    const schematicPrimitiveClass = readFirstPath<{
+      getPrimitivesBBox(ids: string[]): Promise<RawPrimitiveBBox | null | undefined>;
+    }>(['SCH_Primitive', 'sch_Primitive']);
+    if (!schematicPrimitiveClass) {
+      throw new Error('SCH_Primitive class not found in EasyEDA Pro API');
+    }
+    const ids = Array.isArray(primitiveIds)
+      ? primitiveIds.filter((id): id is string => typeof id === 'string' && id.length > 0)
+      : [];
+
+    const items: Array<{ primitiveId: string; bounds: RawPrimitiveBBox | null }> = [];
+    for (const id of ids) {
+      let bounds: RawPrimitiveBBox | null = null;
+      try {
+        bounds = (await schematicPrimitiveClass.getPrimitivesBBox([id])) ?? null;
+      } catch (error) {
+        logRecoverableError(`failed to read bounding box for primitive ${id}`, error);
+      }
+      items.push({ primitiveId: id, bounds });
+    }
+
+    let combined: RawPrimitiveBBox | null = null;
+    if (ids.length > 0) {
+      try {
+        combined = (await schematicPrimitiveClass.getPrimitivesBBox(ids)) ?? null;
+      } catch (error) {
+        logRecoverableError('failed to read combined bounding box', error);
+      }
+    }
+
+    return { items, combined };
+  }
+
+  async function trySheetInfoCall(
+    stage: string,
+    paths: string[],
+    attempts: SheetInfoAttempt[],
+    ...args: unknown[]
+  ): Promise<unknown> {
+    try {
+      const value = normalizeValue(await callFirst(paths, ...args), 5);
+      const meaningful = Array.isArray(value)
+        ? value.length > 0
+        : Boolean(asNonEmptyRecord(value)) || (value !== null && value !== undefined);
+      attempts.push({ stage, status: meaningful ? 'value' : 'empty' });
+      return value;
+    } catch (error) {
+      attempts.push({
+        stage,
+        status: 'unavailable',
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return undefined;
+    }
+  }
+
+  async function getSheetInfo(): Promise<unknown> {
+    const attempts: SheetInfoAttempt[] = [];
+    let source: SheetInfoSource | undefined;
+
+    let currentPage = asNonEmptyRecord(
+      await trySheetInfoCall(
+        'current_page',
+        ['DMT_Schematic.getCurrentSchematicPageInfo'],
+        attempts,
+      ),
+    );
+    if (currentPage) source = 'current_page';
+
+    let pages = asRecordArray(
+      await trySheetInfoCall(
+        'current_page_list',
+        ['DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo'],
+        attempts,
+      ),
+    );
+    if (pages.length === 0) {
+      pages = asRecordArray(
+        await trySheetInfoCall(
+          'all_page_list',
+          ['DMT_Schematic.getAllSchematicPagesInfo'],
+          attempts,
+        ),
+      );
+    }
+
+    const focusedDocument = asNonEmptyRecord(
+      await trySheetInfoCall(
+        'focused_document',
+        ['DMT_SelectControl.getCurrentDocumentInfo'],
+        attempts,
+      ),
+    );
+    const focusedPageUuid =
+      typeof focusedDocument?.uuid === 'string' && focusedDocument.uuid.trim()
+        ? focusedDocument.uuid
+        : undefined;
+
+    let currentSchematic: Record<string, unknown> | undefined;
+    if (!currentPage || pages.length === 0) {
+      currentSchematic = asNonEmptyRecord(
+        await trySheetInfoCall(
+          'current_schematic',
+          ['DMT_Schematic.getCurrentSchematicInfo'],
+          attempts,
+        ),
+      );
+    }
+
+    if (!currentPage && focusedPageUuid) {
+      currentPage = asNonEmptyRecord(
+        await trySheetInfoCall(
+          'focused_document_page',
+          ['DMT_Schematic.getSchematicPageInfo'],
+          attempts,
+          focusedPageUuid,
+        ),
+      );
+      if (currentPage) source = 'focused_document';
+    }
+
+    const schematicPages = asRecordArray(currentSchematic?.page);
+    if (pages.length === 0 && schematicPages.length > 0) pages = schematicPages;
+
+    if (!currentPage && focusedPageUuid && pages.length > 0) {
+      currentPage = pages.find((page) => page.uuid === focusedPageUuid);
+      if (currentPage) source = 'focused_document';
+    }
+
+    if (!currentPage && pages.length === 1 && currentSchematic) {
+      currentPage = pages[0];
+      source = 'current_schematic_page_list';
+    }
+
+    const diagnostics = {
+      stage: 'focused_sheet_resolution',
+      currentPageAvailable: Boolean(currentPage),
+      pageListAvailable: pages.length > 0,
+      focusedDocumentAvailable: Boolean(focusedDocument),
+      attempts,
+    };
+
+    if (!currentPage) {
+      throw createBridgeError(
+        'SHEET_INFO_UNAVAILABLE',
+        'EasyEDA did not expose metadata for the focused schematic page.',
+        'Focus the schematic editor tab and retry. The diagnostics identify which runtime paths were empty or unavailable.',
+        diagnostics,
+      );
+    }
+
+    return {
+      currentPage,
+      pages,
+      source,
+      focusedDocument,
+      diagnostics,
+    };
+  }
+
+  async function listRectangles(): Promise<unknown> {
+    // Best-effort enumeration for section-layout overlap checks. Live verification
+    // showed rectangles expose TopLeftX/TopLeftY rather than X/Y, with X/Y kept
+    // as compatibility fallbacks for future runtimes.
+    //
+    // Live verification also showed annotation-layer rectangle Y values are the
+    // exact sign inverse of creation coordinates. Negate numeric values so callers
+    // receive the same coordinate convention as components, pins, and wires.
+    const schematicRectangleClass = readFirstPath<{
+      getAll(): Promise<unknown[] | null | undefined>;
+    }>(['SCH_PrimitiveRectangle', 'sch_PrimitiveRectangle']);
+    if (!schematicRectangleClass || typeof schematicRectangleClass.getAll !== 'function') {
+      return { total: 0, items: [] };
+    }
+
+    let all: unknown[] = [];
+    try {
+      all = (await schematicRectangleClass.getAll()) || [];
+    } catch (error) {
+      logRecoverableError('failed to list rectangles', error);
+      all = [];
+    }
+
+    const items = all.map((rectangle) => {
+      const rawY = readState(rectangle, 'TopLeftY') ?? readState(rectangle, 'Y');
+      return {
+        primitiveId:
+          extractPrimitiveId(rectangle) || String(readState(rectangle, 'PrimitiveId') ?? ''),
+        x: readState(rectangle, 'TopLeftX') ?? readState(rectangle, 'X'),
+        y: typeof rawY === 'number' ? -rawY : rawY,
+        width: readState(rectangle, 'Width'),
+        height: readState(rectangle, 'Height'),
+        rotation: readState(rectangle, 'Rotation'),
+      };
+    });
+    return { total: items.length, items };
+  }
+
+  return { primitiveBounds, getSheetInfo, listRectangles };
+}

--- a/easyeda-bridge-extension/src/schematic-inspection.ts
+++ b/easyeda-bridge-extension/src/schematic-inspection.ts
@@ -41,6 +41,15 @@ function asRecordArray(value: unknown): Array<Record<string, unknown>> {
   return value.filter((item): item is Record<string, unknown> => isRecord(item));
 }
 
+function nativeScalarString(value: unknown): string {
+  return typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint'
+    ? String(value)
+    : '';
+}
+
 export function createSchematicInspectionOperations({
   callFirst,
   readFirstPath,
@@ -105,36 +114,100 @@ export function createSchematicInspectionOperations({
     }
   }
 
-  async function getSheetInfo(): Promise<unknown> {
-    const attempts: SheetInfoAttempt[] = [];
-    let source: SheetInfoSource | undefined;
-
-    let currentPage = asNonEmptyRecord(
-      await trySheetInfoCall(
-        'current_page',
-        ['DMT_Schematic.getCurrentSchematicPageInfo'],
-        attempts,
-      ),
-    );
-    if (currentPage) source = 'current_page';
-
-    let pages = asRecordArray(
+  async function readSheetPages(
+    attempts: SheetInfoAttempt[],
+  ): Promise<Array<Record<string, unknown>>> {
+    const currentPages = asRecordArray(
       await trySheetInfoCall(
         'current_page_list',
         ['DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo'],
         attempts,
       ),
     );
-    if (pages.length === 0) {
-      pages = asRecordArray(
-        await trySheetInfoCall(
-          'all_page_list',
-          ['DMT_Schematic.getAllSchematicPagesInfo'],
-          attempts,
-        ),
-      );
-    }
+    if (currentPages.length > 0) return currentPages;
+    return asRecordArray(
+      await trySheetInfoCall('all_page_list', ['DMT_Schematic.getAllSchematicPagesInfo'], attempts),
+    );
+  }
 
+  function readFocusedPageUuid(
+    focusedDocument: Record<string, unknown> | undefined,
+  ): string | undefined {
+    const uuid = focusedDocument?.uuid;
+    return typeof uuid === 'string' && uuid.trim() ? uuid : undefined;
+  }
+
+  async function readCurrentSchematicIfNeeded(
+    currentPage: Record<string, unknown> | undefined,
+    pages: Array<Record<string, unknown>>,
+    attempts: SheetInfoAttempt[],
+  ): Promise<Record<string, unknown> | undefined> {
+    if (currentPage && pages.length > 0) return undefined;
+    return asNonEmptyRecord(
+      await trySheetInfoCall(
+        'current_schematic',
+        ['DMT_Schematic.getCurrentSchematicInfo'],
+        attempts,
+      ),
+    );
+  }
+
+  async function readFocusedDocumentPage(
+    currentPage: Record<string, unknown> | undefined,
+    focusedPageUuid: string | undefined,
+    attempts: SheetInfoAttempt[],
+  ): Promise<Record<string, unknown> | undefined> {
+    if (currentPage || !focusedPageUuid) return undefined;
+    return asNonEmptyRecord(
+      await trySheetInfoCall(
+        'focused_document_page',
+        ['DMT_Schematic.getSchematicPageInfo'],
+        attempts,
+        focusedPageUuid,
+      ),
+    );
+  }
+
+  function mergeSchematicPages(
+    pages: Array<Record<string, unknown>>,
+    currentSchematic: Record<string, unknown> | undefined,
+  ): Array<Record<string, unknown>> {
+    if (pages.length > 0) return pages;
+    const schematicPages = asRecordArray(currentSchematic?.page);
+    return schematicPages.length > 0 ? schematicPages : pages;
+  }
+
+  function resolveCurrentPage(
+    currentPage: Record<string, unknown> | undefined,
+    focusedDocumentPage: Record<string, unknown> | undefined,
+    focusedPageUuid: string | undefined,
+    pages: Array<Record<string, unknown>>,
+    currentSchematic: Record<string, unknown> | undefined,
+  ): { currentPage?: Record<string, unknown>; source?: SheetInfoSource } {
+    if (currentPage) return { currentPage, source: 'current_page' };
+    if (focusedDocumentPage) {
+      return { currentPage: focusedDocumentPage, source: 'focused_document' };
+    }
+    const matchedPage = focusedPageUuid
+      ? pages.find((page) => page.uuid === focusedPageUuid)
+      : undefined;
+    if (matchedPage) return { currentPage: matchedPage, source: 'focused_document' };
+    if (pages.length === 1 && currentSchematic) {
+      return { currentPage: pages[0], source: 'current_schematic_page_list' };
+    }
+    return {};
+  }
+
+  async function getSheetInfo(): Promise<unknown> {
+    const attempts: SheetInfoAttempt[] = [];
+    const initialCurrentPage = asNonEmptyRecord(
+      await trySheetInfoCall(
+        'current_page',
+        ['DMT_Schematic.getCurrentSchematicPageInfo'],
+        attempts,
+      ),
+    );
+    const initialPages = await readSheetPages(attempts);
     const focusedDocument = asNonEmptyRecord(
       await trySheetInfoCall(
         'focused_document',
@@ -142,56 +215,34 @@ export function createSchematicInspectionOperations({
         attempts,
       ),
     );
-    const focusedPageUuid =
-      typeof focusedDocument?.uuid === 'string' && focusedDocument.uuid.trim()
-        ? focusedDocument.uuid
-        : undefined;
-
-    let currentSchematic: Record<string, unknown> | undefined;
-    if (!currentPage || pages.length === 0) {
-      currentSchematic = asNonEmptyRecord(
-        await trySheetInfoCall(
-          'current_schematic',
-          ['DMT_Schematic.getCurrentSchematicInfo'],
-          attempts,
-        ),
-      );
-    }
-
-    if (!currentPage && focusedPageUuid) {
-      currentPage = asNonEmptyRecord(
-        await trySheetInfoCall(
-          'focused_document_page',
-          ['DMT_Schematic.getSchematicPageInfo'],
-          attempts,
-          focusedPageUuid,
-        ),
-      );
-      if (currentPage) source = 'focused_document';
-    }
-
-    const schematicPages = asRecordArray(currentSchematic?.page);
-    if (pages.length === 0 && schematicPages.length > 0) pages = schematicPages;
-
-    if (!currentPage && focusedPageUuid && pages.length > 0) {
-      currentPage = pages.find((page) => page.uuid === focusedPageUuid);
-      if (currentPage) source = 'focused_document';
-    }
-
-    if (!currentPage && pages.length === 1 && currentSchematic) {
-      currentPage = pages[0];
-      source = 'current_schematic_page_list';
-    }
-
+    const focusedPageUuid = readFocusedPageUuid(focusedDocument);
+    const currentSchematic = await readCurrentSchematicIfNeeded(
+      initialCurrentPage,
+      initialPages,
+      attempts,
+    );
+    const focusedDocumentPage = await readFocusedDocumentPage(
+      initialCurrentPage,
+      focusedPageUuid,
+      attempts,
+    );
+    const pages = mergeSchematicPages(initialPages, currentSchematic);
+    const resolution = resolveCurrentPage(
+      initialCurrentPage,
+      focusedDocumentPage,
+      focusedPageUuid,
+      pages,
+      currentSchematic,
+    );
     const diagnostics = {
       stage: 'focused_sheet_resolution',
-      currentPageAvailable: Boolean(currentPage),
+      currentPageAvailable: Boolean(resolution.currentPage),
       pageListAvailable: pages.length > 0,
       focusedDocumentAvailable: Boolean(focusedDocument),
       attempts,
     };
 
-    if (!currentPage) {
+    if (!resolution.currentPage) {
       throw createBridgeError(
         'SHEET_INFO_UNAVAILABLE',
         'EasyEDA did not expose metadata for the focused schematic page.',
@@ -201,9 +252,9 @@ export function createSchematicInspectionOperations({
     }
 
     return {
-      currentPage,
+      currentPage: resolution.currentPage,
       pages,
-      source,
+      source: resolution.source,
       focusedDocument,
       diagnostics,
     };
@@ -236,7 +287,7 @@ export function createSchematicInspectionOperations({
       const rawY = readState(rectangle, 'TopLeftY') ?? readState(rectangle, 'Y');
       return {
         primitiveId:
-          extractPrimitiveId(rectangle) || String(readState(rectangle, 'PrimitiveId') ?? ''),
+          extractPrimitiveId(rectangle) || nativeScalarString(readState(rectangle, 'PrimitiveId')),
         x: readState(rectangle, 'TopLeftX') ?? readState(rectangle, 'X'),
         y: typeof rawY === 'number' ? -rawY : rawY,
         width: readState(rectangle, 'Width'),

--- a/easyeda-bridge-extension/src/schematic-inspection.ts
+++ b/easyeda-bridge-extension/src/schematic-inspection.ts
@@ -50,6 +50,43 @@ function nativeScalarString(value: unknown): string {
     : '';
 }
 
+function readFocusedPageUuid(
+  focusedDocument: Record<string, unknown> | undefined,
+): string | undefined {
+  const uuid = focusedDocument?.uuid;
+  return typeof uuid === 'string' && uuid.trim() ? uuid : undefined;
+}
+
+function mergeSchematicPages(
+  pages: Array<Record<string, unknown>>,
+  currentSchematic: Record<string, unknown> | undefined,
+): Array<Record<string, unknown>> {
+  if (pages.length > 0) return pages;
+  const schematicPages = asRecordArray(currentSchematic?.page);
+  return schematicPages.length > 0 ? schematicPages : pages;
+}
+
+function resolveCurrentPage(
+  currentPage: Record<string, unknown> | undefined,
+  focusedDocumentPage: Record<string, unknown> | undefined,
+  focusedPageUuid: string | undefined,
+  pages: Array<Record<string, unknown>>,
+  currentSchematic: Record<string, unknown> | undefined,
+): { currentPage?: Record<string, unknown>; source?: SheetInfoSource } {
+  if (currentPage) return { currentPage, source: 'current_page' };
+  if (focusedDocumentPage) {
+    return { currentPage: focusedDocumentPage, source: 'focused_document' };
+  }
+  const matchedPage = focusedPageUuid
+    ? pages.find((page) => page.uuid === focusedPageUuid)
+    : undefined;
+  if (matchedPage) return { currentPage: matchedPage, source: 'focused_document' };
+  if (pages.length === 1 && currentSchematic) {
+    return { currentPage: pages[0], source: 'current_schematic_page_list' };
+  }
+  return {};
+}
+
 export function createSchematicInspectionOperations({
   callFirst,
   readFirstPath,
@@ -130,13 +167,6 @@ export function createSchematicInspectionOperations({
     );
   }
 
-  function readFocusedPageUuid(
-    focusedDocument: Record<string, unknown> | undefined,
-  ): string | undefined {
-    const uuid = focusedDocument?.uuid;
-    return typeof uuid === 'string' && uuid.trim() ? uuid : undefined;
-  }
-
   async function readCurrentSchematicIfNeeded(
     currentPage: Record<string, unknown> | undefined,
     pages: Array<Record<string, unknown>>,
@@ -166,36 +196,6 @@ export function createSchematicInspectionOperations({
         focusedPageUuid,
       ),
     );
-  }
-
-  function mergeSchematicPages(
-    pages: Array<Record<string, unknown>>,
-    currentSchematic: Record<string, unknown> | undefined,
-  ): Array<Record<string, unknown>> {
-    if (pages.length > 0) return pages;
-    const schematicPages = asRecordArray(currentSchematic?.page);
-    return schematicPages.length > 0 ? schematicPages : pages;
-  }
-
-  function resolveCurrentPage(
-    currentPage: Record<string, unknown> | undefined,
-    focusedDocumentPage: Record<string, unknown> | undefined,
-    focusedPageUuid: string | undefined,
-    pages: Array<Record<string, unknown>>,
-    currentSchematic: Record<string, unknown> | undefined,
-  ): { currentPage?: Record<string, unknown>; source?: SheetInfoSource } {
-    if (currentPage) return { currentPage, source: 'current_page' };
-    if (focusedDocumentPage) {
-      return { currentPage: focusedDocumentPage, source: 'focused_document' };
-    }
-    const matchedPage = focusedPageUuid
-      ? pages.find((page) => page.uuid === focusedPageUuid)
-      : undefined;
-    if (matchedPage) return { currentPage: matchedPage, source: 'focused_document' };
-    if (pages.length === 1 && currentSchematic) {
-      return { currentPage: pages[0], source: 'current_schematic_page_list' };
-    }
-    return {};
   }
 
   async function getSheetInfo(): Promise<unknown> {

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -694,6 +694,25 @@ describe('createDispatcher', () => {
     expect(getSchematicPageInfo).toHaveBeenCalledWith('page-1');
   });
 
+  it('delegates schematic primitive bounds through the extracted inspection domain', async () => {
+    const getPrimitivesBBox = vi.fn(async (ids: string[]) =>
+      ids.length === 1
+        ? { minX: 1, maxX: 2, minY: 3, maxY: 4 }
+        : { minX: 1, maxX: 6, minY: 3, maxY: 8 },
+    );
+    const dispatcher = createDispatcher(makeToolkit({ SCH_Primitive: { getPrimitivesBBox } }));
+
+    await expect(
+      dispatcher.dispatch('schematic.primitiveBounds', { primitiveIds: ['p1', 'p2'] }),
+    ).resolves.toEqual({
+      items: [
+        { primitiveId: 'p1', bounds: { minX: 1, maxX: 2, minY: 3, maxY: 4 } },
+        { primitiveId: 'p2', bounds: { minX: 1, maxX: 2, minY: 3, maxY: 4 } },
+      ],
+      combined: { minX: 1, maxX: 6, minY: 3, maxY: 8 },
+    });
+  });
+
   it('schematic.getSheetInfo rejects an empty focused-sheet response with diagnostics', async () => {
     const dispatcher = createDispatcher(
       makeToolkit({

--- a/easyeda-bridge-extension/tests/schematic-inspection.test.ts
+++ b/easyeda-bridge-extension/tests/schematic-inspection.test.ts
@@ -306,7 +306,7 @@ describe('schematic inspection operations', () => {
         getState_X: () => 50,
         getState_Y: () => 'unknown-y',
       },
-      {},
+      { getState_PrimitiveId: () => ({ unsafe: true }) },
     ];
     const { operations } = makeOperations({
       SCH_PrimitiveRectangle: { getAll: async () => rectangles },

--- a/easyeda-bridge-extension/tests/schematic-inspection.test.ts
+++ b/easyeda-bridge-extension/tests/schematic-inspection.test.ts
@@ -1,0 +1,345 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createSchematicInspectionOperations } from '../src/schematic-inspection.js';
+
+function bridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
+  return Object.assign(new Error(message), { code, suggestion, data });
+}
+
+function makeOperations(runtime: Record<string, unknown> = {}) {
+  const callFirst = vi.fn(async (paths: readonly string[], ...args: unknown[]) => {
+    for (const path of paths) {
+      const value = runtime[path];
+      if (typeof value === 'function') return (value as (...values: unknown[]) => unknown)(...args);
+    }
+    throw new Error(`No API path found: ${paths.join(', ')}`);
+  });
+  const readFirstPath = vi.fn(<T>(paths: readonly string[]): T | undefined => {
+    for (const path of paths) {
+      if (path in runtime) return runtime[path] as T;
+    }
+    return undefined;
+  });
+  const readState = vi.fn((value: unknown, key: string): unknown => {
+    if (!value || typeof value !== 'object') return undefined;
+    const record = value as Record<string, unknown>;
+    const getter = record[`getState_${key}`];
+    if (typeof getter === 'function') return (getter as () => unknown).call(value);
+    return record[key];
+  });
+  const extractPrimitiveId = vi.fn((value: unknown): string => {
+    if (!value || typeof value !== 'object') return '';
+    const id = (value as Record<string, unknown>).primitiveId;
+    return typeof id === 'string' ? id : '';
+  });
+
+  return {
+    callFirst,
+    readFirstPath,
+    readState,
+    extractPrimitiveId,
+    operations: createSchematicInspectionOperations({
+      callFirst,
+      readFirstPath,
+      readState,
+      extractPrimitiveId,
+      createBridgeError: bridgeError,
+    }),
+  };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('schematic inspection operations', () => {
+  it('rejects primitive bounds when the schematic primitive class is unavailable', async () => {
+    await expect(makeOperations().operations.primitiveBounds(['p1'])).rejects.toThrow(
+      'SCH_Primitive class not found in EasyEDA Pro API',
+    );
+  });
+
+  it('filters primitive IDs and returns per-item plus combined native bounds', async () => {
+    const getPrimitivesBBox = vi.fn(async (ids: string[]) =>
+      ids.length === 1
+        ? { minX: ids[0] === 'p1' ? 1 : 2, maxX: 3, minY: 4, maxY: 5 }
+        : { minX: 1, maxX: 8, minY: 4, maxY: 9 },
+    );
+    const { operations } = makeOperations({ SCH_Primitive: { getPrimitivesBBox } });
+
+    await expect(operations.primitiveBounds(['p1', '', 42, 'p2'])).resolves.toEqual({
+      items: [
+        { primitiveId: 'p1', bounds: { minX: 1, maxX: 3, minY: 4, maxY: 5 } },
+        { primitiveId: 'p2', bounds: { minX: 2, maxX: 3, minY: 4, maxY: 5 } },
+      ],
+      combined: { minX: 1, maxX: 8, minY: 4, maxY: 9 },
+    });
+  });
+
+  it('normalizes undefined native item and combined bounds to null', async () => {
+    const getPrimitivesBBox = vi.fn(async () => undefined);
+    const { operations } = makeOperations({ sch_Primitive: { getPrimitivesBBox } });
+
+    await expect(operations.primitiveBounds(['p1'])).resolves.toEqual({
+      items: [{ primitiveId: 'p1', bounds: null }],
+      combined: null,
+    });
+  });
+
+  it('contains item and combined bounding-box failures and accepts non-array input', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const getPrimitivesBBox = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('item failed'))
+      .mockRejectedValueOnce(new Error('combined failed'));
+    const { operations } = makeOperations({ SCH_Primitive: { getPrimitivesBBox } });
+
+    await expect(operations.primitiveBounds(['p1'])).resolves.toEqual({
+      items: [{ primitiveId: 'p1', bounds: null }],
+      combined: null,
+    });
+    await expect(operations.primitiveBounds('not-an-array')).resolves.toEqual({
+      items: [],
+      combined: null,
+    });
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns the current page with non-empty list and focus diagnostics', async () => {
+    const currentPage = { uuid: 'page-1', name: 'Main' };
+    const pages = [currentPage, { uuid: 'page-2', name: 'Power' }];
+    const focusedDocument = { uuid: 'page-1', documentType: 'schematic' };
+    const { operations } = makeOperations({
+      'DMT_Schematic.getCurrentSchematicPageInfo': async () => currentPage,
+      'DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo': async () => pages,
+      'DMT_SelectControl.getCurrentDocumentInfo': async () => focusedDocument,
+    });
+
+    await expect(operations.getSheetInfo()).resolves.toEqual({
+      currentPage,
+      pages,
+      source: 'current_page',
+      focusedDocument,
+      diagnostics: {
+        stage: 'focused_sheet_resolution',
+        currentPageAvailable: true,
+        pageListAvailable: true,
+        focusedDocumentAvailable: true,
+        attempts: [
+          { stage: 'current_page', status: 'value' },
+          { stage: 'current_page_list', status: 'value' },
+          { stage: 'focused_document', status: 'value' },
+        ],
+      },
+    });
+  });
+
+  it('recovers a focused page through the direct UUID lookup', async () => {
+    const page = { uuid: 'focused-page', name: 'Recovered' };
+    const { operations, callFirst } = makeOperations({
+      'DMT_Schematic.getCurrentSchematicPageInfo': async () => ({}),
+      'DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo': async () => [],
+      'DMT_Schematic.getAllSchematicPagesInfo': async () => [page, 'ignored'],
+      'DMT_SelectControl.getCurrentDocumentInfo': async () => ({ uuid: 'focused-page' }),
+      'DMT_Schematic.getCurrentSchematicInfo': async () => ({ page: [page] }),
+      'DMT_Schematic.getSchematicPageInfo': async (uuid: unknown) =>
+        uuid === 'focused-page' ? page : undefined,
+    });
+
+    await expect(operations.getSheetInfo()).resolves.toMatchObject({
+      currentPage: page,
+      pages: [page],
+      source: 'focused_document',
+    });
+    expect(callFirst).toHaveBeenCalledWith(['DMT_Schematic.getSchematicPageInfo'], 'focused-page');
+  });
+
+  it('recovers from a non-Error rejection through a matching focused page list', async () => {
+    const page = { uuid: 'focused-page', name: 'Recovered from list' };
+    const { operations } = makeOperations({
+      'DMT_Schematic.getCurrentSchematicPageInfo': async () => {
+        throw 'page transport failed';
+      },
+      'DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo': async () => [page],
+      'DMT_SelectControl.getCurrentDocumentInfo': async () => ({ uuid: 'focused-page' }),
+      'DMT_Schematic.getCurrentSchematicInfo': async () => ({ page: [page] }),
+      'DMT_Schematic.getSchematicPageInfo': async () => null,
+    });
+
+    await expect(operations.getSheetInfo()).resolves.toMatchObject({
+      currentPage: page,
+      source: 'focused_document',
+      diagnostics: {
+        attempts: expect.arrayContaining([
+          { stage: 'current_page', status: 'unavailable', error: 'page transport failed' },
+          { stage: 'focused_document_page', status: 'empty' },
+        ]),
+      },
+    });
+  });
+
+  it('uses a sole current-schematic page without a focused document', async () => {
+    const page = { uuid: 'only-page', name: 'Only' };
+    const { operations } = makeOperations({
+      'DMT_Schematic.getCurrentSchematicPageInfo': async () => null,
+      'DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo': async () => null,
+      'DMT_Schematic.getAllSchematicPagesInfo': async () => [],
+      'DMT_SelectControl.getCurrentDocumentInfo': async () => 7,
+      'DMT_Schematic.getCurrentSchematicInfo': async () => ({ page: [page] }),
+    });
+
+    await expect(operations.getSheetInfo()).resolves.toMatchObject({
+      currentPage: page,
+      pages: [page],
+      source: 'current_schematic_page_list',
+      focusedDocument: undefined,
+    });
+  });
+
+  it('rejects when a focused UUID is absent from a non-empty page list', async () => {
+    const { operations } = makeOperations({
+      'DMT_Schematic.getCurrentSchematicPageInfo': async () => null,
+      'DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo': async () => [
+        { uuid: 'page-1' },
+        { uuid: 'page-2' },
+      ],
+      'DMT_SelectControl.getCurrentDocumentInfo': async () => ({ uuid: 'missing-page' }),
+      'DMT_Schematic.getCurrentSchematicInfo': async () => ({ page: [] }),
+      'DMT_Schematic.getSchematicPageInfo': async () => null,
+    });
+
+    await expect(operations.getSheetInfo()).rejects.toMatchObject({
+      code: 'SHEET_INFO_UNAVAILABLE',
+      data: {
+        currentPageAvailable: false,
+        pageListAvailable: true,
+        focusedDocumentAvailable: true,
+      },
+    });
+  });
+
+  it('rejects when direct and list-based focused-page recovery are both empty', async () => {
+    const { operations } = makeOperations({
+      'DMT_Schematic.getCurrentSchematicPageInfo': async () => null,
+      'DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo': async () => [],
+      'DMT_Schematic.getAllSchematicPagesInfo': async () => [],
+      'DMT_SelectControl.getCurrentDocumentInfo': async () => ({ uuid: 'missing-page' }),
+      'DMT_Schematic.getCurrentSchematicInfo': async () => ({ page: [] }),
+      'DMT_Schematic.getSchematicPageInfo': async () => null,
+    });
+
+    await expect(operations.getSheetInfo()).rejects.toMatchObject({
+      code: 'SHEET_INFO_UNAVAILABLE',
+      data: {
+        currentPageAvailable: false,
+        pageListAvailable: false,
+        focusedDocumentAvailable: true,
+      },
+    });
+  });
+
+  it('reports stable diagnostics when every sheet path is empty or unavailable', async () => {
+    const { operations } = makeOperations({
+      'DMT_Schematic.getCurrentSchematicPageInfo': async () => {
+        throw new Error('page unavailable');
+      },
+      'DMT_Schematic.getCurrentSchematicAllSchematicPagesInfo': async () => [],
+      'DMT_Schematic.getAllSchematicPagesInfo': async () => [],
+      'DMT_SelectControl.getCurrentDocumentInfo': async () => ({ uuid: '' }),
+      'DMT_Schematic.getCurrentSchematicInfo': async () => ({ page: [] }),
+    });
+
+    await expect(operations.getSheetInfo()).rejects.toMatchObject({
+      code: 'SHEET_INFO_UNAVAILABLE',
+      message: 'EasyEDA did not expose metadata for the focused schematic page.',
+      data: {
+        currentPageAvailable: false,
+        pageListAvailable: false,
+        focusedDocumentAvailable: true,
+        attempts: expect.arrayContaining([
+          { stage: 'current_page', status: 'unavailable', error: 'page unavailable' },
+          { stage: 'current_page_list', status: 'empty' },
+          { stage: 'all_page_list', status: 'empty' },
+          { stage: 'focused_document', status: 'value' },
+          { stage: 'current_schematic', status: 'value' },
+        ]),
+      },
+    });
+  });
+
+  it('degrades rectangle inspection when the class or getAll method is unavailable', async () => {
+    await expect(makeOperations().operations.listRectangles()).resolves.toEqual({
+      total: 0,
+      items: [],
+    });
+    await expect(
+      makeOperations({ SCH_PrimitiveRectangle: {} }).operations.listRectangles(),
+    ).resolves.toEqual({ total: 0, items: [] });
+  });
+
+  it('contains rectangle enumeration failures and null collections as empty results', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const getAll = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('rectangle list failed'))
+      .mockResolvedValueOnce(null);
+    const { operations } = makeOperations({ sch_PrimitiveRectangle: { getAll } });
+
+    await expect(operations.listRectangles()).resolves.toEqual({ total: 0, items: [] });
+    await expect(operations.listRectangles()).resolves.toEqual({ total: 0, items: [] });
+    expect(warn).toHaveBeenCalledWith(
+      '[easyeda-mcp-pro]',
+      'failed to list rectangles',
+      expect.any(Error),
+    );
+  });
+
+  it('maps rectangle IDs, live top-left fields, fallbacks, and the verified Y sign', async () => {
+    const rectangles = [
+      {
+        primitiveId: 'r1',
+        getState_TopLeftX: () => 10,
+        getState_TopLeftY: () => -20,
+        getState_Width: () => 30,
+        getState_Height: () => 40,
+        getState_Rotation: () => 90,
+      },
+      {
+        getState_PrimitiveId: () => 'r2',
+        getState_X: () => 50,
+        getState_Y: () => 'unknown-y',
+      },
+      {},
+    ];
+    const { operations } = makeOperations({
+      SCH_PrimitiveRectangle: { getAll: async () => rectangles },
+    });
+
+    await expect(operations.listRectangles()).resolves.toEqual({
+      total: 3,
+      items: [
+        {
+          primitiveId: 'r1',
+          x: 10,
+          y: 20,
+          width: 30,
+          height: 40,
+          rotation: 90,
+        },
+        {
+          primitiveId: 'r2',
+          x: 50,
+          y: 'unknown-y',
+          width: undefined,
+          height: undefined,
+          rotation: undefined,
+        },
+        {
+          primitiveId: '',
+          x: undefined,
+          y: undefined,
+          width: undefined,
+          height: undefined,
+          rotation: undefined,
+        },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Extract read-only schematic document and geometry inspection from the extension dispatcher into a typed `SchematicInspectionOperations` domain module.

This is the tenth bounded, behavior-preserving delivery slice for #339. It does not add, remove, or rename any public extension method.

## Changes

- add `easyeda-bridge-extension/src/schematic-inspection.ts`
- move the following inspection operations behind `createSchematicInspectionOperations(...)`:
  - `schematic.getSheetInfo`
  - `schematic.primitiveBounds`
  - `schematic.listRectangles`
- inject the existing API router, class resolver, state reader, primitive-ID extractor, and bridge-error factory through an explicit typed interface
- reduce `dispatcher.ts` to routing/delegation for these methods
- add focused tests for sheet-resolution fallbacks, stable diagnostics, per-item/combined bounds, failure containment, rectangle field compatibility, and the live-verified Y-sign convention
- apply Sonar guidance by decomposing sheet resolution into focused helpers and preventing object-valued native IDs from being stringified

## Behavior-parity evidence

The extraction preserves the existing EasyEDA Pro contracts:

- focused-sheet resolution retains the current-page, page-list, document-selector, direct UUID lookup, list-match, and sole-page fallback paths
- `SHEET_INFO_UNAVAILABLE` retains its stable code, message, suggestion, and per-stage diagnostics
- primitive IDs are filtered exactly as before; native per-item and combined bounding boxes normalize missing/failed results to `null`
- missing `SCH_Primitive` still fails with the same explicit error
- rectangle enumeration still degrades safely when the class or `getAll()` is unavailable or fails
- rectangle coordinates retain `TopLeftX`/`TopLeftY` with `X`/`Y` compatibility fallbacks
- numeric rectangle Y values retain the live-verified sign inversion
- only scalar native primitive IDs are accepted; objects are not converted to `[object Object]`
- public extension method list remains byte-for-byte identical at 67 methods

## Maintainability impact

- `dispatcher.ts`: 4,094 → 3,883 lines
- new schematic inspection domain: 100% statement/branch/function/line coverage
  - 77/77 lines
  - 18/18 functions
  - 79/79 branches
- focused module/dispatcher parity: 109 tests

## Verification

- `pnpm verify`
  - 150 server test files / 1,740 tests passed
  - 20 extension test files / 237 tests passed
  - format, typecheck, lint, metadata, build, package, and docs gates passed
- `pnpm security:audit`
  - only the repository-documented temporary `@hono/node-server` advisory allowance remains
- `pnpm peers check`
- extension coverage gates
- extension package/checksum verification
- size budgets:
  - `.eext`: 163,584 / 200,000 bytes
  - extension entry: 221,844 / 260,000 bytes
  - dispatcher bundle: 161,429 / 185,000 bytes

## Scope

This PR intentionally does not include schematic component/BOM inspection; that remains a separate bounded domain candidate. This PR does not close #339.

Refs #339
