### PR TITLE
refactor(extension): extract schematic component inspection

### DIFF
--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -29,6 +29,10 @@ import { createPcbReadOperations, type PcbReadOperations } from './pcb-read-oper
 import { createPcbWriteOperations, type PcbWriteOperations } from './pcb-write-operations.js';
 import { createProjectOperations, type ProjectOperations } from './project-operations.js';
 import {
+  createSchematicComponentInspectionOperations,
+  type SchematicComponentInspectionOperations,
+} from './schematic-component-inspection.js';
+import {
   createSchematicInspectionOperations,
   type SchematicInspectionOperations,
 } from './schematic-inspection.js';
@@ -129,6 +133,7 @@ let pcbMutationOperations: PcbMutationOperations;
 let pcbReadOperations: PcbReadOperations;
 let pcbWriteOperations: PcbWriteOperations;
 let projectOperations: ProjectOperations;
+let schematicComponentInspection: SchematicComponentInspectionOperations;
 let schematicInspection: SchematicInspectionOperations;
 
 function newBridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
@@ -886,150 +891,6 @@ async function addCoordinateFallbackNets(
       logRecoverableError('failed to inspect schematic component pins for coordinate nets', error);
     }
   }
-}
-
-function readOtherPropertyValue(
-  otherProperty: Record<string, unknown> | undefined,
-  key: string,
-): string | undefined {
-  if (!otherProperty) return undefined;
-  const exact = otherProperty[key];
-  if (exact !== undefined && exact !== null && String(exact).trim()) return String(exact);
-  const normalizedKey = key.trim().toLowerCase();
-  for (const [candidateKey, candidateValue] of Object.entries(otherProperty)) {
-    if (
-      candidateKey.trim().toLowerCase() === normalizedKey &&
-      candidateValue !== undefined &&
-      candidateValue !== null &&
-      String(candidateValue).trim()
-    ) {
-      return String(candidateValue);
-    }
-  }
-  return undefined;
-}
-
-/** Resolve EasyEDA display expressions such as `={Value}` to their actual
- * component metadata. Library-created parts commonly store the expression in
- * Name while the concrete value lives in OtherProperty or ManufacturerId. */
-function resolveComponentDisplayValue(
-  rawName: unknown,
-  otherProperty: Record<string, unknown> | undefined,
-  manufacturerId: string,
-  deviceName: string,
-): string {
-  const name = typeof rawName === 'string' ? rawName.trim() : '';
-  const expression = /^=\{(.+)\}$/.exec(name);
-  if (expression) {
-    const propertyName = expression[1].trim();
-    const propertyValue = readOtherPropertyValue(otherProperty, propertyName);
-    if (propertyValue) return propertyValue;
-    if (propertyName.toLowerCase() === 'manufacturer part' && manufacturerId) {
-      return manufacturerId;
-    }
-    return manufacturerId || deviceName || name;
-  }
-  if (name) return name;
-  return readOtherPropertyValue(otherProperty, 'Value') || manufacturerId || deviceName || '';
-}
-
-function isSchematicBomComponent(component: unknown): boolean {
-  const componentType = readComponentType(component);
-  if (componentType === 'sheet' || componentType === 'netflag' || componentType === 'netport') {
-    return false;
-  }
-  const device = safeGetState(component, 'Component');
-  const deviceName = isRecord(device) ? String(device.name ?? '') : '';
-  return !deviceName.startsWith('Drawing-Symbol_');
-}
-
-async function listComponentsApi(limit?: number, offset = 0): Promise<unknown> {
-  const schCompClass = readFirstPath<any>([
-    'SCH_PrimitiveComponent',
-    'SCH_PrimitiveComponent3',
-    'sch_PrimitiveComponent',
-  ]);
-  const libFpClass = readFirstPath<any>(['LIB_Footprint', 'lib_Footprint']);
-
-  if (!schCompClass) {
-    throw new Error('SCH_PrimitiveComponent class not found in EasyEDA Pro API');
-  }
-
-  const allComps = (await schCompClass.getAll(undefined, true)) || [];
-  const bomComps = allComps.filter((component: unknown) => isSchematicBomComponent(component));
-  const total = bomComps.length;
-  const start = Math.max(0, offset);
-  const end = typeof limit === 'number' ? start + Math.max(1, limit) : undefined;
-  const comps = bomComps.slice(start, end);
-  const result: any[] = [];
-
-  for (const c of comps || []) {
-    const ref = typeof c.getState_Designator === 'function' ? c.getState_Designator() : '';
-    const lcsc = typeof c.getState_SupplierId === 'function' ? c.getState_SupplierId() : '';
-    const mfr = typeof c.getState_Manufacturer === 'function' ? c.getState_Manufacturer() : '';
-    const mfrId =
-      typeof c.getState_ManufacturerId === 'function' ? c.getState_ManufacturerId() : '';
-    const comp = typeof c.getState_Component === 'function' ? c.getState_Component() : undefined;
-    const sym = typeof c.getState_Symbol === 'function' ? c.getState_Symbol() : undefined;
-    const other =
-      typeof c.getState_OtherProperty === 'function' && isRecord(c.getState_OtherProperty())
-        ? (c.getState_OtherProperty() as Record<string, unknown>)
-        : undefined;
-    const rawName = typeof c.getState_Name === 'function' ? c.getState_Name() : '';
-    const val = resolveComponentDisplayValue(rawName, other, String(mfrId || ''), comp?.name ?? '');
-
-    let fp = '';
-    if (typeof c.getState_Footprint === 'function') {
-      const fpInfo = c.getState_Footprint();
-      if (isRecord(fpInfo)) {
-        // The live runtime already exposes the resolved footprint name here;
-        // prefer it and avoid a redundant library lookup that may fail offline.
-        if (typeof fpInfo.name === 'string' && fpInfo.name.trim()) fp = fpInfo.name;
-        if (!fp && fpInfo.uuid && libFpClass) {
-          try {
-            const fpObj = await libFpClass.get(fpInfo.uuid, fpInfo.libraryUuid);
-            if (fpObj) fp = fpObj.name || '';
-          } catch (e) {
-            logRecoverableError('failed to resolve component footprint', e);
-          }
-        }
-      }
-    }
-
-    if (!fp) {
-      fp =
-        readOtherPropertyValue(other, 'Footprint') ||
-        readOtherPropertyValue(other, 'Supplier Footprint') ||
-        '';
-    }
-    const ds =
-      readOtherPropertyValue(other, 'Datasheet') ||
-      readOtherPropertyValue(other, 'datasheet') ||
-      '';
-
-    // Device identity — needed to re-place / clone a part. `Component` holds the
-    // device uuid+libraryUuid (a valid place_component deviceItem within THIS
-    // project; for a clean project, re-resolve via lcsc/manufacturerId/name).
-    // `Symbol` names the schematic symbol used.
-    result.push({
-      primitiveId: safeGetState(c, 'PrimitiveId') ?? '',
-      reference: ref,
-      value: val,
-      footprint: fp,
-      lcsc: lcsc,
-      manufacturer: mfr,
-      manufacturerId: mfrId,
-      datasheet: ds,
-      deviceUuid: comp?.uuid ?? '',
-      deviceLibraryUuid: comp?.libraryUuid ?? '',
-      deviceName: comp?.name ?? '',
-      symbolName: sym?.name ?? '',
-      x: safeGetState(c, 'X'),
-      y: safeGetState(c, 'Y'),
-      rotation: safeGetState(c, 'Rotation'),
-    });
-  }
-  return { total, items: result };
 }
 
 async function listNetsApi(budget?: NetDetailBudget): Promise<unknown> {
@@ -2023,7 +1884,7 @@ async function inspectWiresApi(limit = 10, offset = 0): Promise<unknown> {
 }
 
 async function generateBomApi(params: any): Promise<unknown> {
-  const comps = ((await listComponentsApi()) as { items: any[] }).items;
+  const comps = ((await schematicComponentInspection.listComponents()) as { items: any[] }).items;
   const groupBy = params.groupBy || 'value';
   const groups = new Map<string, any>();
 
@@ -2781,7 +2642,7 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
     case 'schematic.listPrimitiveIds':
       return listSchematicPrimitiveIds(params.primitiveKind);
     case 'schematic.listComponents':
-      return listComponentsApi(
+      return schematicComponentInspection.listComponents(
         typeof params.limit === 'number' ? params.limit : undefined,
         typeof params.offset === 'number' ? params.offset : 0,
       );
@@ -3738,7 +3599,8 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
     case 'bom.generate':
       return generateBomApi(params);
     case 'bom.validate': {
-      const comps = ((await listComponentsApi()) as { items: any[] }).items;
+      const comps = ((await schematicComponentInspection.listComponents()) as { items: any[] })
+        .items;
       return { totalParts: comps.length, missing: [], obsolete: [], alternates: [] };
     }
     case 'inventory.search':
@@ -3866,6 +3728,10 @@ export function createDispatcher(toolkit: DispatcherToolkit): Dispatcher {
     createBridgeError: newBridgeError,
   });
   projectOperations = createProjectOperations({ callFirst });
+  schematicComponentInspection = createSchematicComponentInspectionOperations({
+    readFirstPath,
+    readState: safeGetState,
+  });
   schematicInspection = createSchematicInspectionOperations({
     callFirst,
     readFirstPath,

--- a/easyeda-bridge-extension/src/schematic-component-inspection.ts
+++ b/easyeda-bridge-extension/src/schematic-component-inspection.ts
@@ -41,7 +41,7 @@ function resolveComponentDisplayValue(
   deviceName: string,
 ): string {
   const name = nativeScalarString(rawName).trim();
-  const expression = name.match(/^=\{(.+)\}$/);
+  const expression = /^=\{(.+)\}$/.exec(name);
   if (expression) {
     const propertyName = expression[1].trim();
     const propertyValue = readOtherPropertyValue(otherProperty, propertyName);

--- a/easyeda-bridge-extension/src/schematic-component-inspection.ts
+++ b/easyeda-bridge-extension/src/schematic-component-inspection.ts
@@ -1,0 +1,166 @@
+import { isRecord, logRecoverableError } from './utils.js';
+
+export interface SchematicComponentInspectionOperationDependencies {
+  readFirstPath<T>(paths: readonly string[]): T | undefined;
+  readState(value: unknown, key: string): unknown;
+}
+
+export interface SchematicComponentInspectionOperations {
+  listComponents(limit?: number, offset?: number): Promise<unknown>;
+}
+
+function nativeScalarString(value: unknown): string {
+  return typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint'
+    ? String(value)
+    : '';
+}
+
+function readOtherPropertyValue(
+  otherProperty: Record<string, unknown> | undefined,
+  key: string,
+): string | undefined {
+  if (!otherProperty) return undefined;
+  const exact = nativeScalarString(otherProperty[key]).trim();
+  if (exact) return exact;
+
+  const normalizedKey = key.trim().toLowerCase();
+  for (const [candidateKey, candidateValue] of Object.entries(otherProperty)) {
+    const value = nativeScalarString(candidateValue).trim();
+    if (candidateKey.trim().toLowerCase() === normalizedKey && value) return value;
+  }
+  return undefined;
+}
+
+function resolveComponentDisplayValue(
+  rawName: unknown,
+  otherProperty: Record<string, unknown> | undefined,
+  manufacturerId: string,
+  deviceName: string,
+): string {
+  const name = nativeScalarString(rawName).trim();
+  const expression = name.match(/^=\{(.+)\}$/);
+  if (expression) {
+    const propertyName = expression[1].trim();
+    const propertyValue = readOtherPropertyValue(otherProperty, propertyName);
+    if (propertyValue) return propertyValue;
+    if (propertyName.toLowerCase() === 'manufacturer part' && manufacturerId) {
+      return manufacturerId;
+    }
+    return manufacturerId || deviceName || name;
+  }
+  if (name) return name;
+  return readOtherPropertyValue(otherProperty, 'Value') || manufacturerId || deviceName || '';
+}
+
+function readRecordState(
+  component: unknown,
+  key: string,
+  readState: SchematicComponentInspectionOperationDependencies['readState'],
+): Record<string, unknown> | undefined {
+  const value = readState(component, key);
+  return isRecord(value) ? value : undefined;
+}
+
+export function createSchematicComponentInspectionOperations({
+  readFirstPath,
+  readState,
+}: SchematicComponentInspectionOperationDependencies): SchematicComponentInspectionOperations {
+  function isBomComponent(component: unknown): boolean {
+    const componentType = nativeScalarString(readState(component, 'ComponentType')).toLowerCase();
+    if (componentType === 'sheet' || componentType === 'netflag' || componentType === 'netport') {
+      return false;
+    }
+    const deviceName = nativeScalarString(readRecordState(component, 'Component', readState)?.name);
+    return !deviceName.startsWith('Drawing-Symbol_');
+  }
+
+  async function resolveFootprint(
+    component: unknown,
+    otherProperty: Record<string, unknown> | undefined,
+    footprintClass: { get(uuid: unknown, libraryUuid: unknown): Promise<unknown> } | undefined,
+  ): Promise<string> {
+    const footprintInfo = readRecordState(component, 'Footprint', readState);
+    let footprint = nativeScalarString(footprintInfo?.name).trim();
+    if (!footprint && footprintInfo?.uuid && footprintClass) {
+      try {
+        const resolved = await footprintClass.get(footprintInfo.uuid, footprintInfo.libraryUuid);
+        footprint = nativeScalarString(isRecord(resolved) ? resolved.name : undefined).trim();
+      } catch (error) {
+        logRecoverableError('failed to resolve component footprint', error);
+      }
+    }
+    return (
+      footprint ||
+      readOtherPropertyValue(otherProperty, 'Footprint') ||
+      readOtherPropertyValue(otherProperty, 'Supplier Footprint') ||
+      ''
+    );
+  }
+
+  async function mapComponent(
+    component: unknown,
+    footprintClass: { get(uuid: unknown, libraryUuid: unknown): Promise<unknown> } | undefined,
+  ): Promise<Record<string, unknown>> {
+    const device = readRecordState(component, 'Component', readState);
+    const symbol = readRecordState(component, 'Symbol', readState);
+    const otherProperty = readRecordState(component, 'OtherProperty', readState);
+    const manufacturerId = nativeScalarString(readState(component, 'ManufacturerId'));
+    const deviceName = nativeScalarString(device?.name);
+
+    return {
+      primitiveId: nativeScalarString(readState(component, 'PrimitiveId')),
+      reference: nativeScalarString(readState(component, 'Designator')),
+      value: resolveComponentDisplayValue(
+        readState(component, 'Name'),
+        otherProperty,
+        manufacturerId,
+        deviceName,
+      ),
+      footprint: await resolveFootprint(component, otherProperty, footprintClass),
+      lcsc: nativeScalarString(readState(component, 'SupplierId')),
+      manufacturer: nativeScalarString(readState(component, 'Manufacturer')),
+      manufacturerId,
+      datasheet:
+        readOtherPropertyValue(otherProperty, 'Datasheet') ||
+        readOtherPropertyValue(otherProperty, 'datasheet') ||
+        '',
+      deviceUuid: nativeScalarString(device?.uuid),
+      deviceLibraryUuid: nativeScalarString(device?.libraryUuid),
+      deviceName,
+      symbolName: nativeScalarString(symbol?.name),
+      x: readState(component, 'X'),
+      y: readState(component, 'Y'),
+      rotation: readState(component, 'Rotation'),
+    };
+  }
+
+  async function listComponents(limit?: number, offset = 0): Promise<unknown> {
+    const componentClass = readFirstPath<{
+      getAll(include?: unknown, recursive?: boolean): Promise<unknown[] | null | undefined>;
+    }>(['SCH_PrimitiveComponent', 'SCH_PrimitiveComponent3', 'sch_PrimitiveComponent']);
+    const footprintClass = readFirstPath<{
+      get(uuid: unknown, libraryUuid: unknown): Promise<unknown>;
+    }>(['LIB_Footprint', 'lib_Footprint']);
+
+    if (!componentClass) {
+      throw new Error('SCH_PrimitiveComponent class not found in EasyEDA Pro API');
+    }
+
+    const allComponents = (await componentClass.getAll(undefined, true)) || [];
+    const bomComponents = allComponents.filter(isBomComponent);
+    const total = bomComponents.length;
+    const start = Math.max(0, offset);
+    const end = typeof limit === 'number' ? start + Math.max(1, limit) : undefined;
+    const selected = bomComponents.slice(start, end);
+    const items: Array<Record<string, unknown>> = [];
+    for (const component of selected) {
+      items.push(await mapComponent(component, footprintClass));
+    }
+    return { total, items };
+  }
+
+  return { listComponents };
+}

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -1763,9 +1763,7 @@ describe('createDispatcher', () => {
       getState_OtherProperty: () => ({}),
     });
     const getAll = vi.fn(async () => [makeBomPart('r1', 'R1'), makeBomPart('r2', 'R2')]);
-    const dispatcher = createDispatcher(
-      makeToolkit({ SCH_PrimitiveComponent: { getAll } }),
-    );
+    const dispatcher = createDispatcher(makeToolkit({ SCH_PrimitiveComponent: { getAll } }));
 
     await expect(dispatcher.dispatch('bom.generate', { groupBy: 'value' })).resolves.toEqual([
       {

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -1749,6 +1749,44 @@ describe('createDispatcher', () => {
     });
   });
 
+  it('routes BOM generation and validation through schematic component inspection', async () => {
+    const makeBomPart = (primitiveId: string, reference: string) => ({
+      getState_PrimitiveId: () => primitiveId,
+      getState_ComponentType: () => 'part',
+      getState_Component: () => ({ uuid: `${primitiveId}-dev`, libraryUuid: 'lib', name: 'RES' }),
+      getState_Designator: () => reference,
+      getState_Name: () => '1k',
+      getState_Footprint: () => ({ name: 'R0805' }),
+      getState_SupplierId: () => 'C17513',
+      getState_Manufacturer: () => 'Example',
+      getState_ManufacturerId: () => 'RES-1K',
+      getState_OtherProperty: () => ({}),
+    });
+    const getAll = vi.fn(async () => [makeBomPart('r1', 'R1'), makeBomPart('r2', 'R2')]);
+    const dispatcher = createDispatcher(
+      makeToolkit({ SCH_PrimitiveComponent: { getAll } }),
+    );
+
+    await expect(dispatcher.dispatch('bom.generate', { groupBy: 'value' })).resolves.toEqual([
+      {
+        reference: 'R1, R2',
+        value: '1k',
+        footprint: 'R0805',
+        lcsc: 'C17513',
+        quantity: 2,
+        manufacturer: 'Example',
+      },
+    ]);
+    await expect(dispatcher.dispatch('bom.validate', {})).resolves.toEqual({
+      totalParts: 2,
+      missing: [],
+      obsolete: [],
+      alternates: [],
+    });
+    expect(getAll).toHaveBeenNthCalledWith(1, undefined, true);
+    expect(getAll).toHaveBeenNthCalledWith(2, undefined, true);
+  });
+
   // PCB readback: field names below are the getState_* getters observed live
   // on real primitives created via the fixed pcb.addVia/pcb.addTrack and a
   // manually-placed footprint (2026-07-07), not guessed.

--- a/easyeda-bridge-extension/tests/schematic-component-inspection.test.ts
+++ b/easyeda-bridge-extension/tests/schematic-component-inspection.test.ts
@@ -275,4 +275,49 @@ describe('schematic component inspection operations', () => {
 
     await expect(operations.listComponents()).resolves.toEqual({ total: 0, items: [] });
   });
+
+  it('covers empty metadata and non-record footprint lookup fallbacks without inventing values', async () => {
+    const part = (state: Record<string, unknown>) =>
+      makeStateful({ ComponentType: 'part', ...state });
+    const { operations } = makeOperations({
+      SCH_PrimitiveComponent: {
+        getAll: async () => [
+          part({
+            PrimitiveId: 'device-fallback',
+            Component: { name: 'DEV-FALLBACK' },
+            Name: '={Unknown}',
+          }),
+          part({
+            PrimitiveId: 'expression-fallback',
+            Component: { name: '' },
+            Name: '={Unknown}',
+            OtherProperty: {},
+          }),
+          part({
+            PrimitiveId: 'empty-value',
+            Component: { name: '' },
+            Name: '',
+            OtherProperty: {},
+          }),
+          part({
+            PrimitiveId: 'non-record-footprint',
+            Component: { name: 'Device' },
+            Name: 'Device',
+            Footprint: { uuid: 'fp', libraryUuid: 'lib' },
+            OtherProperty: { 'Supplier Footprint': 'FALLBACK-FP' },
+          }),
+        ],
+      },
+      LIB_Footprint: { get: async () => 'not-a-record' },
+    });
+
+    await expect(operations.listComponents()).resolves.toMatchObject({
+      items: [
+        { primitiveId: 'device-fallback', value: 'DEV-FALLBACK' },
+        { primitiveId: 'expression-fallback', value: '={Unknown}' },
+        { primitiveId: 'empty-value', value: '' },
+        { primitiveId: 'non-record-footprint', footprint: 'FALLBACK-FP' },
+      ],
+    });
+  });
 });

--- a/easyeda-bridge-extension/tests/schematic-component-inspection.test.ts
+++ b/easyeda-bridge-extension/tests/schematic-component-inspection.test.ts
@@ -326,5 +326,4 @@ describe('schematic component inspection operations', () => {
 
     await expect(operations.listComponents()).resolves.toEqual({ total: 0, items: [] });
   });
-
 });

--- a/easyeda-bridge-extension/tests/schematic-component-inspection.test.ts
+++ b/easyeda-bridge-extension/tests/schematic-component-inspection.test.ts
@@ -268,6 +268,57 @@ describe('schematic component inspection operations', () => {
     });
   });
 
+  it('keeps sparse and malformed native metadata within scalar compatibility fallbacks', async () => {
+    const part = (state: Record<string, unknown>) =>
+      makeStateful({ ComponentType: 'part', ...state });
+    const footprintGet = vi.fn(async () => 'not-a-record');
+    const { operations } = makeOperations({
+      SCH_PrimitiveComponent: {
+        getAll: async () => [
+          part({
+            PrimitiveId: 'device-only',
+            Component: { name: 'DEVICE' },
+            Name: '={Unknown}',
+            ManufacturerId: '',
+            OtherProperty: {},
+          }),
+          part({
+            PrimitiveId: 'expression-only',
+            Component: {},
+            Name: '={Unknown}',
+            ManufacturerId: '',
+            OtherProperty: {},
+          }),
+          part({
+            PrimitiveId: 'empty',
+            Component: {},
+            Name: '',
+            ManufacturerId: '',
+          }),
+          part({
+            PrimitiveId: 'malformed-footprint',
+            Component: { name: 'F' },
+            Name: 'F',
+            Footprint: { uuid: 'fp', libraryUuid: 'lib' },
+            OtherProperty: { 'Supplier Footprint': 'SOIC-8' },
+          }),
+        ],
+      },
+      LIB_Footprint: { get: footprintGet },
+    });
+
+    await expect(operations.listComponents()).resolves.toMatchObject({
+      total: 4,
+      items: [
+        { primitiveId: 'device-only', value: 'DEVICE' },
+        { primitiveId: 'expression-only', value: '={Unknown}' },
+        { primitiveId: 'empty', value: '', footprint: '' },
+        { primitiveId: 'malformed-footprint', footprint: 'SOIC-8' },
+      ],
+    });
+    expect(footprintGet).toHaveBeenCalledWith('fp', 'lib');
+  });
+
   it('normalizes a null native collection to an empty result', async () => {
     const { operations } = makeOperations({
       SCH_PrimitiveComponent: { getAll: async () => null },

--- a/easyeda-bridge-extension/tests/schematic-component-inspection.test.ts
+++ b/easyeda-bridge-extension/tests/schematic-component-inspection.test.ts
@@ -1,0 +1,278 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createSchematicComponentInspectionOperations } from '../src/schematic-component-inspection.js';
+
+function makeStateful(state: Record<string, unknown>): Record<string, unknown> {
+  const value: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(state)) value[`getState_${key}`] = () => entry;
+  return value;
+}
+
+function makeOperations(runtime: Record<string, unknown> = {}) {
+  const readFirstPath = vi.fn(<T>(paths: readonly string[]): T | undefined => {
+    for (const path of paths) {
+      if (path in runtime) return runtime[path] as T;
+    }
+    return undefined;
+  });
+  const readState = vi.fn((value: unknown, key: string): unknown => {
+    if (!value || typeof value !== 'object') return undefined;
+    const record = value as Record<string, unknown>;
+    const getter = record[`getState_${key}`];
+    if (typeof getter === 'function') return (getter as () => unknown).call(value);
+    const lowerCamelKey = key.charAt(0).toLowerCase() + key.slice(1);
+    return record[key] ?? record[lowerCamelKey];
+  });
+  return {
+    readFirstPath,
+    readState,
+    operations: createSchematicComponentInspectionOperations({ readFirstPath, readState }),
+  };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('schematic component inspection operations', () => {
+  it('rejects inspection when the schematic component class is unavailable', async () => {
+    await expect(makeOperations().operations.listComponents()).rejects.toThrow(
+      'SCH_PrimitiveComponent class not found in EasyEDA Pro API',
+    );
+  });
+
+  it('filters non-BOM primitives and maps live component metadata', async () => {
+    const frame = makeStateful({
+      PrimitiveId: 'frame1',
+      ComponentType: 'sheet',
+      Component: { name: 'Drawing-Symbol_A4' },
+    });
+    const netflag = makeStateful({
+      PrimitiveId: 'flag1',
+      ComponentType: 'netflag',
+      Component: { name: 'Power-Flag' },
+    });
+    const netport = makeStateful({
+      PrimitiveId: 'port1',
+      ComponentType: 'netport',
+      Component: { name: 'Net-Port' },
+    });
+    const drawingPart = makeStateful({
+      PrimitiveId: 'drawing1',
+      ComponentType: 'part',
+      Component: { name: 'Drawing-Symbol_Custom' },
+    });
+    const resistor = makeStateful({
+      PrimitiveId: 'r1',
+      ComponentType: 'part',
+      Component: { uuid: 'res-dev', libraryUuid: 'lib', name: 'RES_1K' },
+      Symbol: { name: 'RES' },
+      Footprint: { uuid: 'fp-r', libraryUuid: 'lib', name: 'R0805' },
+      Designator: 'R1',
+      Name: '={Value}',
+      Manufacturer: 'Example',
+      ManufacturerId: 'RES-1K',
+      SupplierId: 'C1',
+      OtherProperty: { Value: '1kΩ', Datasheet: 'https://example.invalid/r1' },
+      X: 100,
+      Y: 200,
+      Rotation: 90,
+    });
+    const timer = makeStateful({
+      PrimitiveId: 'u1',
+      ComponentType: 'part',
+      Component: { uuid: 'timer-dev', libraryUuid: 'lib', name: 'NE555P' },
+      Symbol: { name: 'NE555P' },
+      Footprint: null,
+      Designator: 'U1',
+      Name: '={Manufacturer Part}',
+      Manufacturer: 'TI',
+      ManufacturerId: 'NE555P',
+      SupplierId: 'C2',
+      OtherProperty: { 'Supplier Footprint': 'DIP-8' },
+      X: 300,
+      Y: 400,
+      Rotation: 0,
+    });
+    const getAll = vi.fn(async () => [frame, netflag, netport, drawingPart, resistor, timer]);
+    const { operations } = makeOperations({ SCH_PrimitiveComponent: { getAll } });
+
+    await expect(operations.listComponents()).resolves.toEqual({
+      total: 2,
+      items: [
+        {
+          primitiveId: 'r1',
+          reference: 'R1',
+          value: '1kΩ',
+          footprint: 'R0805',
+          lcsc: 'C1',
+          manufacturer: 'Example',
+          manufacturerId: 'RES-1K',
+          datasheet: 'https://example.invalid/r1',
+          deviceUuid: 'res-dev',
+          deviceLibraryUuid: 'lib',
+          deviceName: 'RES_1K',
+          symbolName: 'RES',
+          x: 100,
+          y: 200,
+          rotation: 90,
+        },
+        {
+          primitiveId: 'u1',
+          reference: 'U1',
+          value: 'NE555P',
+          footprint: 'DIP-8',
+          lcsc: 'C2',
+          manufacturer: 'TI',
+          manufacturerId: 'NE555P',
+          datasheet: '',
+          deviceUuid: 'timer-dev',
+          deviceLibraryUuid: 'lib',
+          deviceName: 'NE555P',
+          symbolName: 'NE555P',
+          x: 300,
+          y: 400,
+          rotation: 0,
+        },
+      ],
+    });
+    expect(getAll).toHaveBeenCalledWith(undefined, true);
+  });
+
+  it('resolves an unnamed footprint from the library and prefers native names', async () => {
+    const footprintGet = vi.fn(async () => ({ name: 'SOT-23' }));
+    const direct = makeStateful({
+      PrimitiveId: 'q1',
+      ComponentType: 'part',
+      Component: { name: 'Q' },
+      Designator: 'Q1',
+      Name: 'Q',
+      Footprint: { uuid: 'native-fp', libraryUuid: 'lib', name: 'SOT-223' },
+      OtherProperty: {},
+    });
+    const lookup = makeStateful({
+      PrimitiveId: 'q2',
+      ComponentType: 'part',
+      Component: { name: 'Q' },
+      Designator: 'Q2',
+      Name: 'Q',
+      Footprint: { uuid: 'lookup-fp', libraryUuid: 'lib' },
+      OtherProperty: {},
+    });
+    const { operations } = makeOperations({
+      SCH_PrimitiveComponent: { getAll: async () => [direct, lookup] },
+      LIB_Footprint: { get: footprintGet },
+    });
+
+    await expect(operations.listComponents()).resolves.toMatchObject({
+      items: [
+        { primitiveId: 'q1', footprint: 'SOT-223' },
+        { primitiveId: 'q2', footprint: 'SOT-23' },
+      ],
+    });
+    expect(footprintGet).toHaveBeenCalledOnce();
+    expect(footprintGet).toHaveBeenCalledWith('lookup-fp', 'lib');
+  });
+
+  it('contains library lookup failures and uses case-insensitive property fallbacks', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const footprintGet = vi.fn(async () => Promise.reject(new Error('offline')));
+    const part = makeStateful({
+      PrimitiveId: 'q1',
+      ComponentType: 'part',
+      Component: { name: 'Q' },
+      Designator: 'Q1',
+      Name: '',
+      ManufacturerId: 'Q-MFR',
+      Footprint: { uuid: 'fp', libraryUuid: 'lib' },
+      OtherProperty: {
+        footprint: 'QFN-16',
+        datasheet: 'https://example.invalid/q1',
+        value: 'MOSFET',
+      },
+    });
+    const { operations } = makeOperations({
+      SCH_PrimitiveComponent: { getAll: async () => [part] },
+      lib_Footprint: { get: footprintGet },
+    });
+
+    await expect(operations.listComponents()).resolves.toMatchObject({
+      items: [
+        {
+          primitiveId: 'q1',
+          value: 'MOSFET',
+          footprint: 'QFN-16',
+          datasheet: 'https://example.invalid/q1',
+        },
+      ],
+    });
+    expect(warn).toHaveBeenCalledWith(
+      '[easyeda-mcp-pro]',
+      'failed to resolve component footprint',
+      expect.any(Error),
+    );
+  });
+
+  it('falls back through display expressions without inventing metadata', async () => {
+    const part = (id: string, name: unknown, manufacturerId: string, deviceName: string) =>
+      makeStateful({
+        PrimitiveId: id,
+        ComponentType: 'part',
+        Component: { name: deviceName },
+        Designator: id.toUpperCase(),
+        Name: name,
+        ManufacturerId: manufacturerId,
+        OtherProperty: {},
+      });
+    const { operations } = makeOperations({
+      SCH_PrimitiveComponent3: {
+        getAll: async () => [
+          part('a', '={Unknown}', 'MFR-A', 'DEV-A'),
+          part('b', '={Manufacturer Part}', 'MFR-B', 'DEV-B'),
+          part('c', '', '', 'DEV-C'),
+        ],
+      },
+    });
+
+    await expect(operations.listComponents()).resolves.toMatchObject({
+      items: [
+        { primitiveId: 'a', value: 'MFR-A' },
+        { primitiveId: 'b', value: 'MFR-B' },
+        { primitiveId: 'c', value: 'DEV-C' },
+      ],
+    });
+  });
+
+  it('paginates only after filtering and clamps offset and limit', async () => {
+    const part = (id: string) =>
+      makeStateful({
+        PrimitiveId: id,
+        ComponentType: 'part',
+        Component: { name: id },
+        Designator: id.toUpperCase(),
+        Name: id,
+        OtherProperty: {},
+      });
+    const frame = makeStateful({
+      ComponentType: 'sheet',
+      Component: { name: 'Drawing-Symbol_A4' },
+    });
+    const { operations } = makeOperations({
+      sch_PrimitiveComponent: { getAll: async () => [frame, part('a'), part('b')] },
+    });
+
+    await expect(operations.listComponents(0, 1)).resolves.toMatchObject({
+      total: 2,
+      items: [{ primitiveId: 'b' }],
+    });
+    await expect(operations.listComponents(1, -10)).resolves.toMatchObject({
+      total: 2,
+      items: [{ primitiveId: 'a' }],
+    });
+  });
+
+  it('normalizes a null native collection to an empty result', async () => {
+    const { operations } = makeOperations({
+      SCH_PrimitiveComponent: { getAll: async () => null },
+    });
+
+    await expect(operations.listComponents()).resolves.toEqual({ total: 0, items: [] });
+  });
+});

--- a/easyeda-bridge-extension/tests/schematic-component-inspection.test.ts
+++ b/easyeda-bridge-extension/tests/schematic-component-inspection.test.ts
@@ -327,48 +327,4 @@ describe('schematic component inspection operations', () => {
     await expect(operations.listComponents()).resolves.toEqual({ total: 0, items: [] });
   });
 
-  it('covers empty metadata and non-record footprint lookup fallbacks without inventing values', async () => {
-    const part = (state: Record<string, unknown>) =>
-      makeStateful({ ComponentType: 'part', ...state });
-    const { operations } = makeOperations({
-      SCH_PrimitiveComponent: {
-        getAll: async () => [
-          part({
-            PrimitiveId: 'device-fallback',
-            Component: { name: 'DEV-FALLBACK' },
-            Name: '={Unknown}',
-          }),
-          part({
-            PrimitiveId: 'expression-fallback',
-            Component: { name: '' },
-            Name: '={Unknown}',
-            OtherProperty: {},
-          }),
-          part({
-            PrimitiveId: 'empty-value',
-            Component: { name: '' },
-            Name: '',
-            OtherProperty: {},
-          }),
-          part({
-            PrimitiveId: 'non-record-footprint',
-            Component: { name: 'Device' },
-            Name: 'Device',
-            Footprint: { uuid: 'fp', libraryUuid: 'lib' },
-            OtherProperty: { 'Supplier Footprint': 'FALLBACK-FP' },
-          }),
-        ],
-      },
-      LIB_Footprint: { get: async () => 'not-a-record' },
-    });
-
-    await expect(operations.listComponents()).resolves.toMatchObject({
-      items: [
-        { primitiveId: 'device-fallback', value: 'DEV-FALLBACK' },
-        { primitiveId: 'expression-fallback', value: '={Unknown}' },
-        { primitiveId: 'empty-value', value: '' },
-        { primitiveId: 'non-record-footprint', footprint: 'FALLBACK-FP' },
-      ],
-    });
-  });
 });


### PR DESCRIPTION
## Summary

Extracts the `schematic.listComponents` read path from the extension dispatcher into a typed schematic-component inspection domain module.

This is the eleventh bounded, behavior-preserving delivery slice for #339. It intentionally does **not** close the parent issue.

## Scope

- Adds `schematic-component-inspection.ts` with a narrow `readFirstPath` + `readState` dependency boundary.
- Delegates `schematic.listComponents` from the dispatcher to the extracted domain.
- Preserves the current EasyEDA runtime aliases and `getAll(undefined, true)` call contract.
- Preserves BOM filtering for sheet, net-flag, net-port, and `Drawing-Symbol_*` primitives.
- Preserves display-expression, manufacturer-part, footprint-library, property, pagination, and failure-containment behavior.
- Keeps footprint lookups sequential to preserve the existing native call ordering.
- Rejects object-valued native metadata instead of leaking `[object Object]` strings.

## Compatibility evidence

- Public extension method list: **67 → 67**, byte-for-byte unchanged.
- Dispatcher size: **3,883 → 3,749 lines**.
- New module coverage: **100% statements / branches / functions / lines**.
- New module LCOV: **56/56 lines**, **59/59 branches**, **9/9 functions**.
- Component inspection tests: **8 passed**.
- Dispatcher BOM consumer coverage: `bom.generate` and `bom.validate` exercised through the extracted domain.
- Extension suite: **246 passed**.
- Server suite: **1,740 passed**.
- Extension package: **163,619 / 200,000 bytes**.
- Extension entry bundle: **222,579 / 260,000 bytes**.
- Dispatcher bundle: **162,165 / 185,000 bytes**.

## Verification

- `pnpm verify`
- `pnpm test:extension:ci`
- `pnpm build:extension`
- extension distribution verification
- extension size budgets
- dependency audit policy
- peer dependency check

All completed successfully on Node.js 24.18.0 and pnpm 11.5.1.

Refs #339
