### PR TITLE
refactor(extension): extract design rule-check operations

### DIFF
--- a/docs/superpowers/plans/2026-07-23-design-rule-check-boundary.md
+++ b/docs/superpowers/plans/2026-07-23-design-rule-check-boundary.md
@@ -648,4 +648,21 @@ PR body must use `Refs #339`, not a closing keyword, and include test, coverage,
 
 ## Execution Evidence
 
-Populate this section only with command output collected at the exact PR head. Do not estimate values.
+Collected at implementation head `57300ac26b28b4a3a8bcb64a4cdebbca6c436d03` on Node.js 24.18.0 and pnpm 11.5.1:
+
+- Dispatcher source: 3,749 → 3,533 lines (-216).
+- Extracted module: 252 lines.
+- Public extension method list: 67 → 67.
+- Focused rule-check/domain parity: 108 tests passed.
+- Server suite: 150 files / 1,740 tests passed.
+- Extension suite: 22 files / 258 tests passed.
+- `design-rule-check-operations.ts`: 100% statements / branches / functions / lines.
+- `pnpm verify`: passed.
+- `pnpm test:extension:ci`: passed.
+- Extension distribution verification: passed.
+- Packaged extension: 163,723 / 200,000 bytes.
+- Extension entry bundle: 223,192 / 260,000 bytes.
+- Dispatcher bundle: 162,778 / 185,000 bytes.
+- Dependency audit policy: passed with only the existing documented #334 advisory exception.
+- No peer-dependency validation script is defined in the repository package scripts.
+- MSI checksum fixtures were run with a worktree-local `TMPDIR` to avoid the pre-existing shared `/tmp/easyeda-bridge-extension.*` ownership collision; no repository behavior was changed for that environment issue.

--- a/docs/superpowers/plans/2026-07-23-design-rule-check-boundary.md
+++ b/docs/superpowers/plans/2026-07-23-design-rule-check-boundary.md
@@ -220,6 +220,7 @@ git -c user.name='Osman Aslan' -c user.email='info@oaslananka.dev' \
   - `DesignRuleCheckOperations.runDrc()`
   - `DesignRuleCheckOperations.runErc()`
   - `DesignRuleCheckOperations.runRuleCheck()`
+  - `DesignRuleCheckOperations.runSchematicCheck()` for the existing `schematic.validateNetlist` native cross-check
 
 - [ ] **Step 1: Add the complete module implementation**
 
@@ -560,7 +561,7 @@ runPcbDrcCheck;
 runRuleCheckForActiveCanvas;
 ```
 
-Keep `errorMessage`, `findFloatingPinsApi`, `isConfirmedNativeNoConnect`, and connectivity inference in the dispatcher because they remain cross-domain dependencies.
+Keep `errorMessage`, `findFloatingPinsApi`, `isConfirmedNativeNoConnect`, and connectivity inference in the dispatcher because they remain cross-domain dependencies. Route `schematic.validateNetlist` through `designRuleCheckOperations.runSchematicCheck()` so it does not retain a duplicate normalizer.
 
 - [ ] **Step 4: Add dispatcher delegation parity assertions**
 

--- a/docs/superpowers/plans/2026-07-23-design-rule-check-boundary.md
+++ b/docs/superpowers/plans/2026-07-23-design-rule-check-boundary.md
@@ -648,21 +648,22 @@ PR body must use `Refs #339`, not a closing keyword, and include test, coverage,
 
 ## Execution Evidence
 
-Collected at implementation head `57300ac26b28b4a3a8bcb64a4cdebbca6c436d03` on Node.js 24.18.0 and pnpm 11.5.1:
+Collected after the Sonar follow-up at implementation head `010e664be65b028d61d55bc3f4bf3379f36844a3` on Node.js 24.18.0 and pnpm 11.5.1:
 
 - Dispatcher source: 3,749 → 3,533 lines (-216).
-- Extracted module: 252 lines.
+- Extracted module: 272 lines.
 - Public extension method list: 67 → 67.
-- Focused rule-check/domain parity: 108 tests passed.
+- Focused rule-check/domain parity: 110 tests passed.
 - Server suite: 150 files / 1,740 tests passed.
-- Extension suite: 22 files / 258 tests passed.
+- Extension suite: 22 files / 260 tests passed.
 - `design-rule-check-operations.ts`: 100% statements / branches / functions / lines.
 - `pnpm verify`: passed.
 - `pnpm test:extension:ci`: passed.
 - Extension distribution verification: passed.
-- Packaged extension: 163,723 / 200,000 bytes.
-- Extension entry bundle: 223,192 / 260,000 bytes.
-- Dispatcher bundle: 162,778 / 185,000 bytes.
+- Packaged extension: 163,894 / 200,000 bytes.
+- Extension entry bundle: 223,726 / 260,000 bytes.
+- Dispatcher bundle: 163,312 / 185,000 bytes.
 - Dependency audit policy: passed with only the existing documented #334 advisory exception.
+- Sonar review findings were addressed by restricting severity, rule, title, component, and aggregate normalization inputs to native scalar values; object-valued fields no longer leak `[object Object]` into bridge results.
 - No peer-dependency validation script is defined in the repository package scripts.
 - MSI checksum fixtures were run with a worktree-local `TMPDIR` to avoid the pre-existing shared `/tmp/easyeda-bridge-extension.*` ownership collision; no repository behavior was changed for that environment issue.

--- a/docs/superpowers/plans/2026-07-23-design-rule-check-boundary.md
+++ b/docs/superpowers/plans/2026-07-23-design-rule-check-boundary.md
@@ -1,0 +1,650 @@
+# Design Rule-Check Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract `design.drc`, `design.erc`, and `design.ruleCheck` from `dispatcher.ts` into a typed, fully covered design-rule-check domain without changing native calls, normalization, fallback order, errors, or the 67-method public contract.
+
+**Architecture:** Add a factory module that owns DRC/ERC normalization and orchestration. Inject `callFirst`, bridge-error creation, recoverable logging, error-message conversion, and floating-pin discovery; initialize the factory in `createDispatcher()` and leave three thin switch delegates.
+
+**Tech Stack:** TypeScript 6, Vitest 4, Node.js 24.18.0, pnpm 11.5.1, esbuild-based extension packaging.
+
+## Global Constraints
+
+- Canonical base behavior is GitHub `main` commit `18c5217083da7f8a705d8dc246e82fc9ed734caf`.
+- Preserve exactly 67 public bridge methods.
+- Preserve native calls as `check(true, true, true)`.
+- Preserve PCB-first fallback order for `design.ruleCheck`.
+- Preserve existing `CONTEXT_UNAVAILABLE` messages, suggestions, and cause data.
+- Preserve best-effort floating-pin inference semantics for `design.erc`.
+- New module coverage must be 100% statements, branches, functions, and lines.
+- Use `TMPDIR="$PWD/.tmp/test-runtime"` for local verification on MSI to avoid the known shared `/tmp/easyeda-bridge-extension.*` fixture collision.
+
+---
+
+### Task 1: Lock the extracted rule-check contract with RED tests
+
+**Files:**
+
+- Create: `easyeda-bridge-extension/tests/design-rule-check-operations.test.ts`
+
+**Interfaces:**
+
+- Consumes: future `createDesignRuleCheckOperations(dependencies)` factory.
+- Produces: executable contract for `runDrc()`, `runErc()`, and `runRuleCheck()`.
+
+- [ ] **Step 1: Create the focused test file with the factory contract**
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { createDesignRuleCheckOperations } from '../src/design-rule-check-operations.js';
+
+function bridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
+  return Object.assign(new Error(message), { code, suggestion, data });
+}
+
+function createSubject(overrides: Record<string, unknown> = {}) {
+  const callFirst = vi.fn();
+  const findFloatingPins = vi.fn().mockResolvedValue({ floatingPins: [], partRefs: [] });
+  const logRecoverableError = vi.fn();
+  const operations = createDesignRuleCheckOperations({
+    callFirst,
+    createBridgeError: bridgeError,
+    logRecoverableError,
+    errorMessage: (error) => (error instanceof Error ? error.message : String(error)),
+    findFloatingPins,
+    ...overrides,
+  });
+  return { operations, callFirst, findFloatingPins, logRecoverableError };
+}
+
+describe('design rule-check operations', () => {
+  it('normalizes detailed leaves and nested UI trees', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst.mockResolvedValue([
+      {
+        name: 'Netlist mismatch',
+        count: 1,
+        list: [
+          {
+            ruleName: 'Missing connection',
+            message: 'U1.1 is disconnected',
+            severity: 'fatal',
+            position: { x: 10, y: 20 },
+            layer: 'TopLayer',
+          },
+        ],
+      },
+    ]);
+
+    await expect(operations.runDrc()).resolves.toMatchObject({
+      totalViolations: 1,
+      errorCount: 1,
+      warningCount: 0,
+      passed: false,
+      violations: [
+        {
+          rule: 'Missing connection',
+          description: 'U1.1 is disconnected',
+          severity: 'error',
+          location: { x: 10, y: 20, layer: 'TopLayer' },
+        },
+      ],
+    });
+    expect(callFirst).toHaveBeenCalledWith(['PCB_Drc.check'], true, true, true);
+  });
+
+  it('counts flat aggregate groups without inventing leaf detail', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst.mockResolvedValue([
+      { type: 'error', count: 2 },
+      { type: 'warn', count: 3 },
+      { type: 'info', count: 4 },
+    ]);
+
+    await expect(operations.runDrc()).resolves.toMatchObject({
+      totalViolations: 9,
+      errorCount: 2,
+      warningCount: 3,
+      passed: false,
+    });
+  });
+
+  it('translates an inactive PCB context for design.drc', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst.mockRejectedValue(new Error('no PCB canvas'));
+
+    await expect(operations.runDrc()).rejects.toMatchObject({
+      code: 'CONTEXT_UNAVAILABLE',
+      message: 'PCB DRC is unavailable in the current editor context.',
+      suggestion: 'Open and focus a PCB document, then retry design.drc.',
+      data: { cause: 'no PCB canvas' },
+    });
+  });
+
+  it('falls back from PCB to schematic for design.ruleCheck', async () => {
+    const { operations, callFirst, logRecoverableError } = createSubject();
+    callFirst
+      .mockRejectedValueOnce(new Error('no PCB canvas'))
+      .mockResolvedValueOnce([{ type: 'warn', count: 1 }]);
+
+    await expect(operations.runRuleCheck()).resolves.toMatchObject({
+      totalViolations: 1,
+      errorCount: 0,
+      warningCount: 1,
+      passed: true,
+    });
+    expect(callFirst.mock.calls).toEqual([
+      [['PCB_Drc.check'], true, true, true],
+      [['SCH_Drc.check'], true, true, true],
+    ]);
+    expect(logRecoverableError).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports both causes when neither canvas is available', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst
+      .mockRejectedValueOnce(new Error('no PCB canvas'))
+      .mockRejectedValueOnce(new Error('no schematic canvas'));
+
+    await expect(operations.runRuleCheck()).rejects.toMatchObject({
+      code: 'CONTEXT_UNAVAILABLE',
+      data: { pcbCause: 'no PCB canvas', schematicCause: 'no schematic canvas' },
+    });
+  });
+
+  it('supplements ERC with inferred floating pins', async () => {
+    const floatingPins = [{ primitiveId: 'p1', designator: 'U1', pinNumber: '1' }];
+    const { operations, callFirst, findFloatingPins } = createSubject();
+    callFirst.mockResolvedValue([{ type: 'warn', count: 1 }]);
+    findFloatingPins.mockResolvedValue({ floatingPins, partRefs: ['U1'] });
+
+    await expect(operations.runErc()).resolves.toMatchObject({
+      inferredFloatingPins: floatingPins,
+      detailSource: 'inferred_partial',
+    });
+  });
+
+  it('contains ERC inference failures and returns the native aggregate', async () => {
+    const { operations, callFirst, findFloatingPins, logRecoverableError } = createSubject();
+    callFirst.mockResolvedValue([{ type: 'warn', count: 1 }]);
+    findFloatingPins.mockRejectedValue(new Error('inference failed'));
+
+    await expect(operations.runErc()).resolves.toMatchObject({
+      inferredFloatingPins: [],
+      detailSource: 'native_aggregate_only',
+      warningCount: 1,
+    });
+    expect(logRecoverableError).toHaveBeenCalledWith(
+      'design.erc: floating-pin inference failed',
+      expect.any(Error),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the focused test and verify RED**
+
+Run:
+
+```bash
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH \
+TMPDIR="$PWD/.tmp/test-runtime" \
+pnpm --filter @easyeda-mcp-pro/bridge-extension exec vitest run \
+  tests/design-rule-check-operations.test.ts
+```
+
+Expected: FAIL because `../src/design-rule-check-operations.js` does not exist.
+
+- [ ] **Step 3: Commit the RED contract**
+
+```bash
+git add easyeda-bridge-extension/tests/design-rule-check-operations.test.ts
+git -c user.name='Osman Aslan' -c user.email='info@oaslananka.dev' \
+  commit -m 'test(extension): lock design rule-check boundary'
+```
+
+### Task 2: Implement the typed rule-check domain
+
+**Files:**
+
+- Create: `easyeda-bridge-extension/src/design-rule-check-operations.ts`
+- Test: `easyeda-bridge-extension/tests/design-rule-check-operations.test.ts`
+
+**Interfaces:**
+
+- Consumes:
+  - `callFirst(paths: string[], ...args: unknown[]): Promise<unknown>`
+  - `createBridgeError(code, message, suggestion, data?)`
+  - recoverable logger and floating-pin callback
+- Produces:
+  - `DesignRuleCheckOperations.runDrc()`
+  - `DesignRuleCheckOperations.runErc()`
+  - `DesignRuleCheckOperations.runRuleCheck()`
+
+- [ ] **Step 1: Add the complete module implementation**
+
+```ts
+export type DrcSeverity = 'error' | 'warning' | 'info';
+
+export interface DrcResult {
+  violations: Array<Record<string, unknown>>;
+  totalViolations: number;
+  errorCount: number;
+  warningCount: number;
+  passed: boolean;
+}
+
+export interface FloatingPin {
+  primitiveId: string;
+  designator: string;
+  pinNumber: string;
+}
+
+export interface DesignRuleCheckDependencies {
+  callFirst: (paths: string[], ...args: unknown[]) => Promise<unknown>;
+  createBridgeError: (code: string, message: string, suggestion: string, data?: unknown) => Error;
+  logRecoverableError: (message: string, error: unknown) => void;
+  errorMessage: (error: unknown) => string;
+  findFloatingPins: () => Promise<{ floatingPins: FloatingPin[]; partRefs: string[] }>;
+}
+
+export interface DesignRuleCheckOperations {
+  runDrc: () => Promise<DrcResult>;
+  runErc: () => Promise<
+    DrcResult & {
+      inferredFloatingPins: FloatingPin[];
+      detailSource: 'inferred_partial' | 'native_aggregate_only';
+    }
+  >;
+  runRuleCheck: () => Promise<DrcResult>;
+}
+
+function normalizeSeverity(raw: unknown): DrcSeverity {
+  const value = String(raw ?? '').toLowerCase();
+  if (value.includes('fatal') || value.includes('error')) return 'error';
+  if (value.includes('warn')) return 'warning';
+  return 'info';
+}
+
+function normalizeViolation(item: unknown): Record<string, unknown> {
+  const obj: Record<string, unknown> = item && typeof item === 'object' ? { ...item } : {};
+  const explanation =
+    obj.explanation && typeof obj.explanation === 'object'
+      ? (obj.explanation as Record<string, unknown>).str
+      : undefined;
+  const message =
+    obj.message ?? obj.msg ?? obj.description ?? obj.text ?? obj.detail ?? explanation ?? item;
+  const severitySource = [
+    obj.level,
+    obj.severity,
+    obj.type,
+    obj.errorLevel,
+    obj.errorType,
+    obj.errorObjType,
+    obj.name,
+    obj.ruleName,
+  ]
+    .filter((value) => value !== undefined && value !== null)
+    .join(' ');
+  const position =
+    obj.position && typeof obj.position === 'object'
+      ? (obj.position as Record<string, unknown>)
+      : obj.location && typeof obj.location === 'object'
+        ? (obj.location as Record<string, unknown>)
+        : obj;
+  return {
+    rule: String(
+      obj.rule ??
+        obj.ruleName ??
+        obj.ruleTypeName ??
+        obj.errorType ??
+        obj.name ??
+        obj.type ??
+        'unknown',
+    ),
+    description: typeof message === 'string' ? message : JSON.stringify(message),
+    severity: normalizeSeverity(severitySource),
+    net: obj.net ?? obj.netName ?? undefined,
+    component: obj.component ?? obj.ref ?? obj.designator ?? obj.primitiveId ?? undefined,
+    location:
+      typeof position.x === 'number' && typeof position.y === 'number'
+        ? { x: position.x, y: position.y, layer: obj.layer as string | undefined }
+        : undefined,
+  };
+}
+
+function normalizeAggregate(item: unknown): { severity: DrcSeverity; count: number } | null {
+  const obj = item && typeof item === 'object' ? (item as Record<string, unknown>) : null;
+  if (!obj || typeof obj.count !== 'number') return null;
+  const source = [
+    obj.type,
+    obj.severity,
+    obj.level,
+    obj.errorType,
+    obj.errorObjType,
+    obj.name,
+    Array.isArray(obj.title) ? obj.title.join(' ') : obj.title,
+  ]
+    .filter((value) => value !== undefined && value !== null)
+    .join(' ');
+  return { severity: normalizeSeverity(source), count: obj.count };
+}
+
+function hasLeafDetail(obj: Record<string, unknown>): boolean {
+  return [
+    'message',
+    'msg',
+    'description',
+    'text',
+    'detail',
+    'explanation',
+    'errorType',
+    'errorObjType',
+    'rule',
+    'ruleName',
+    'ruleTypeName',
+  ].some((key) => obj[key] !== undefined);
+}
+
+function normalizeNode(item: unknown): {
+  violations: Array<Record<string, unknown>>;
+  aggregates: Array<{ severity: DrcSeverity; count: number }>;
+} {
+  const obj = item && typeof item === 'object' ? (item as Record<string, unknown>) : null;
+  if (!obj) return { violations: [normalizeViolation(item)], aggregates: [] };
+  const children = Array.isArray(obj.list) ? obj.list : [];
+  if (children.length > 0) {
+    const normalized = children.map(normalizeNode);
+    const violations = normalized.flatMap((entry) => entry.violations);
+    const aggregates = normalized.flatMap((entry) => entry.aggregates);
+    if (violations.length > 0 || aggregates.length > 0) return { violations, aggregates };
+  }
+  if (hasLeafDetail(obj)) return { violations: [normalizeViolation(obj)], aggregates: [] };
+  const aggregate = normalizeAggregate(obj);
+  return { violations: [], aggregates: aggregate ? [aggregate] : [] };
+}
+
+export function createDesignRuleCheckOperations(
+  dependencies: DesignRuleCheckDependencies,
+): DesignRuleCheckOperations {
+  const runNative = async (paths: string[]): Promise<DrcResult> => {
+    const raw = await dependencies.callFirst(paths, true, true, true);
+    const normalized = (Array.isArray(raw) ? raw : []).map(normalizeNode);
+    const detailed = normalized.flatMap((entry) => entry.violations);
+    const aggregates = normalized.flatMap((entry) => entry.aggregates);
+    const violations = [
+      ...detailed,
+      ...aggregates
+        .filter((entry) => entry.count > 0)
+        .map((entry) => ({
+          rule: 'aggregate',
+          description:
+            `${entry.count} ${entry.severity}(s) reported by EasyEDA's native design/electrical rule ` +
+            'check. Per-violation detail is only shown in EasyEDA Pro when the API returns aggregate counts.',
+          severity: entry.severity,
+        })),
+    ];
+    const errorCount =
+      detailed.filter((entry) => entry.severity === 'error').length +
+      aggregates
+        .filter((entry) => entry.severity === 'error')
+        .reduce((sum, entry) => sum + entry.count, 0);
+    const warningCount =
+      detailed.filter((entry) => entry.severity === 'warning').length +
+      aggregates
+        .filter((entry) => entry.severity === 'warning')
+        .reduce((sum, entry) => sum + entry.count, 0);
+    return {
+      violations,
+      totalViolations: detailed.length + aggregates.reduce((sum, entry) => sum + entry.count, 0),
+      errorCount,
+      warningCount,
+      passed: errorCount === 0,
+    };
+  };
+
+  const runDrc = async (): Promise<DrcResult> => {
+    try {
+      return await runNative(['PCB_Drc.check']);
+    } catch (error) {
+      throw dependencies.createBridgeError(
+        'CONTEXT_UNAVAILABLE',
+        'PCB DRC is unavailable in the current editor context.',
+        'Open and focus a PCB document, then retry design.drc.',
+        { cause: dependencies.errorMessage(error) },
+      );
+    }
+  };
+
+  const runRuleCheck = async (): Promise<DrcResult> => {
+    let pcbError: unknown;
+    try {
+      return await runNative(['PCB_Drc.check']);
+    } catch (error) {
+      pcbError = error;
+      dependencies.logRecoverableError(
+        'design.ruleCheck: PCB DRC unavailable; trying schematic ERC/DRC',
+        error,
+      );
+    }
+    try {
+      return await runNative(['SCH_Drc.check']);
+    } catch (schematicError) {
+      throw dependencies.createBridgeError(
+        'CONTEXT_UNAVAILABLE',
+        'No active PCB or schematic canvas is available for design.ruleCheck.',
+        'Open and focus a PCB or schematic document, then retry.',
+        {
+          pcbCause: dependencies.errorMessage(pcbError),
+          schematicCause: dependencies.errorMessage(schematicError),
+        },
+      );
+    }
+  };
+
+  const runErc = async () => {
+    const result = await runNative(['SCH_Drc.check']);
+    try {
+      const { floatingPins } = await dependencies.findFloatingPins();
+      return {
+        ...result,
+        inferredFloatingPins: floatingPins,
+        detailSource:
+          floatingPins.length > 0
+            ? ('inferred_partial' as const)
+            : ('native_aggregate_only' as const),
+      };
+    } catch (error) {
+      dependencies.logRecoverableError('design.erc: floating-pin inference failed', error);
+      return {
+        ...result,
+        inferredFloatingPins: [],
+        detailSource: 'native_aggregate_only' as const,
+      };
+    }
+  };
+
+  return { runDrc, runErc, runRuleCheck };
+}
+```
+
+- [ ] **Step 2: Run focused tests and verify GREEN**
+
+```bash
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH \
+TMPDIR="$PWD/.tmp/test-runtime" \
+pnpm --filter @easyeda-mcp-pro/bridge-extension exec vitest run \
+  tests/design-rule-check-operations.test.ts
+```
+
+Expected: all focused tests PASS.
+
+- [ ] **Step 3: Run focused coverage**
+
+```bash
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH \
+TMPDIR="$PWD/.tmp/test-runtime" \
+pnpm --filter @easyeda-mcp-pro/bridge-extension exec vitest run \
+  tests/design-rule-check-operations.test.ts --coverage
+```
+
+Expected: `design-rule-check-operations.ts` reports 100% statements, branches, functions, and lines.
+
+- [ ] **Step 4: Commit the domain implementation**
+
+```bash
+git add easyeda-bridge-extension/src/design-rule-check-operations.ts \
+  easyeda-bridge-extension/tests/design-rule-check-operations.test.ts
+git -c user.name='Osman Aslan' -c user.email='info@oaslananka.dev' \
+  commit -m 'refactor(extension): extract design rule checks'
+```
+
+### Task 3: Delegate the dispatcher and remove duplicate implementation
+
+**Files:**
+
+- Modify: `easyeda-bridge-extension/src/dispatcher.ts:1-3749`
+- Modify: `easyeda-bridge-extension/tests/dispatcher.test.ts:1050-1408`
+
+**Interfaces:**
+
+- Consumes: `createDesignRuleCheckOperations()` from Task 2.
+- Produces: three thin public delegates and one initialized `DesignRuleCheckOperations` instance.
+
+- [ ] **Step 1: Add dispatcher import, field, and factory binding**
+
+```ts
+import {
+  createDesignRuleCheckOperations,
+  type DesignRuleCheckOperations,
+} from './design-rule-check-operations.js';
+
+let designRuleCheckOperations: DesignRuleCheckOperations;
+```
+
+Inside `createDispatcher()` after API runtime creation:
+
+```ts
+designRuleCheckOperations = createDesignRuleCheckOperations({
+  callFirst,
+  createBridgeError: newBridgeError,
+  logRecoverableError,
+  errorMessage,
+  findFloatingPins: findFloatingPinsApi,
+});
+```
+
+- [ ] **Step 2: Replace the three switch bodies with delegates**
+
+```ts
+case 'design.ruleCheck':
+  return designRuleCheckOperations.runRuleCheck();
+case 'design.erc':
+  return designRuleCheckOperations.runErc();
+case 'design.drc':
+  return designRuleCheckOperations.runDrc();
+```
+
+- [ ] **Step 3: Delete only the moved rule-check helpers**
+
+Delete the dispatcher-local definitions of:
+
+```ts
+normalizeDrcSeverity;
+normalizeDrcViolation;
+normalizeDrcAggregate;
+hasDrcLeafDetail;
+normalizeDrcNode;
+runDrcCheck;
+runPcbDrcCheck;
+runRuleCheckForActiveCanvas;
+```
+
+Keep `errorMessage`, `findFloatingPinsApi`, `isConfirmedNativeNoConnect`, and connectivity inference in the dispatcher because they remain cross-domain dependencies.
+
+- [ ] **Step 4: Add dispatcher delegation parity assertions**
+
+In `dispatcher.test.ts`, retain all current behavioral tests and add one call-order test that dispatches all three methods through injected native classes. Assert:
+
+```ts
+expect(dispatcher.methodList).toHaveLength(67);
+expect(dispatcher.methodList).toContain('design.drc');
+expect(dispatcher.methodList).toContain('design.erc');
+expect(dispatcher.methodList).toContain('design.ruleCheck');
+```
+
+- [ ] **Step 5: Run focused parity**
+
+```bash
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH \
+TMPDIR="$PWD/.tmp/test-runtime" \
+pnpm --filter @easyeda-mcp-pro/bridge-extension exec vitest run \
+  tests/design-rule-check-operations.test.ts tests/dispatcher.test.ts
+```
+
+Expected: all rule-check module and dispatcher tests PASS.
+
+- [ ] **Step 6: Commit dispatcher delegation**
+
+```bash
+git add easyeda-bridge-extension/src/dispatcher.ts \
+  easyeda-bridge-extension/tests/dispatcher.test.ts
+git -c user.name='Osman Aslan' -c user.email='info@oaslananka.dev' \
+  commit -m 'refactor(extension): delegate design rule checks'
+```
+
+### Task 4: Verify and prepare Pull Request 1
+
+**Files:**
+
+- Modify: `docs/superpowers/plans/2026-07-23-design-rule-check-boundary.md` only to append measured execution evidence.
+
+**Interfaces:**
+
+- Produces: reviewable PR evidence; issue #339 remains open.
+
+- [ ] **Step 1: Run full verification at exact head**
+
+```bash
+mkdir -p .tmp/test-runtime
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH \
+TMPDIR="$PWD/.tmp/test-runtime" pnpm verify
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH \
+TMPDIR="$PWD/.tmp/test-runtime" pnpm test:extension:ci
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH pnpm verify:extension
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH pnpm check:extension-size
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH pnpm security:audit
+```
+
+Expected: all commands exit 0; server suite remains 1,740 tests; public methods remain 67; new module coverage is 100%.
+
+- [ ] **Step 2: Record objective measurements**
+
+```bash
+wc -l easyeda-bridge-extension/src/dispatcher.ts
+wc -c easyeda-bridge-extension/dist/dispatcher.js
+git diff --stat 18c5217083da7f8a705d8dc246e82fc9ed734caf...HEAD
+```
+
+Append actual counts to this plan under `## Execution Evidence`.
+
+- [ ] **Step 3: Commit evidence and push the PR branch**
+
+```bash
+git add docs/superpowers/plans/2026-07-23-design-rule-check-boundary.md
+git -c user.name='Osman Aslan' -c user.email='info@oaslananka.dev' \
+  commit -m 'docs: record rule-check extraction evidence'
+git push -u origin refactor/issue-339-design-rule-check
+```
+
+PR title:
+
+```text
+refactor(extension): extract design rule-check operations
+```
+
+PR body must use `Refs #339`, not a closing keyword, and include test, coverage, line-count, bundle-size, and security evidence.
+
+## Execution Evidence
+
+Populate this section only with command output collected at the exact PR head. Do not estimate values.

--- a/docs/superpowers/plans/2026-07-23-schematic-transaction-boundary.md
+++ b/docs/superpowers/plans/2026-07-23-schematic-transaction-boundary.md
@@ -1,0 +1,780 @@
+# Schematic Transaction Boundary Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the six schematic transaction bridge methods and their safety machinery from `dispatcher.ts` into a typed, fully covered domain module, then close #339 after exact-head and post-merge acceptance verification.
+
+**Architecture:** Add a factory module that owns snapshot parsing, primitive discovery, ownership-aware deletion, recreation, safe partial modification, text alignment replay protection, and connected-wire following. Keep helpers used by non-transaction schematic paths in the dispatcher and inject them as narrow typed callbacks; replace six switch bodies with delegates.
+
+**Tech Stack:** TypeScript 6, Vitest 4, Node.js 24.18.0, pnpm 11.5.1, EasyEDA Pro bridge runtime.
+
+## Global Constraints
+
+- Start after the design-rule-check PR is merged or rebased into this branch.
+- Preserve exactly 67 public bridge methods.
+- Preserve schema version `schematic-primitive-snapshot/v1` exactly.
+- Preserve error codes, messages, suggestions, and data unless an existing test proves an unsafe ambiguity.
+- Never stringify object-valued primitive IDs.
+- Preserve public text alignment values 1 through 9 and never replay internal `getAll()` encodings.
+- Preserve text and rectangle Y-axis sign conversion during recreation.
+- Preserve ownership-aware deletion and `success: false` when any ID is not found.
+- Preserve component movement wire-following and recoverable wire failures.
+- New module coverage must be 100% statements, branches, functions, and lines.
+- Use `TMPDIR="$PWD/.tmp/test-runtime"` for MSI verification.
+
+---
+
+### Task 1: Define the transaction factory and lock RED behavior
+
+**Files:**
+
+- Create: `easyeda-bridge-extension/tests/schematic-transaction-operations.test.ts`
+
+**Interfaces:**
+
+- Consumes: future `createSchematicTransactionOperations(dependencies)` factory.
+- Produces: focused domain contract independent from the dispatcher switch.
+
+- [ ] **Step 1: Create dependency fixtures and initial failing tests**
+
+```ts
+import { describe, expect, it, vi } from 'vitest';
+import { createSchematicTransactionOperations } from '../src/schematic-transaction-operations.js';
+
+function bridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
+  return Object.assign(new Error(message), { code, suggestion, data });
+}
+
+function state(source: unknown, key: string): unknown {
+  if (!source || typeof source !== 'object') return undefined;
+  const record = source as Record<string, unknown>;
+  const getter = record[`getState_${key}`];
+  if (typeof getter === 'function') return getter.call(source);
+  if (typeof record.getState === 'function') {
+    const value = record.getState.call(source) as Record<string, unknown>;
+    if (value && key in value) return value[key];
+  }
+  const lower = key.charAt(0).toLowerCase() + key.slice(1);
+  return record[key] ?? record[lower];
+}
+
+function createSubject(classes: Record<string, unknown> = {}) {
+  const textAlignCache = new Map<string, 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9>();
+  const callFirst = vi.fn();
+  const logRecoverableError = vi.fn();
+  const operations = createSchematicTransactionOperations({
+    callFirst,
+    readFirstPath: (paths) => paths.map((path) => classes[path]).find(Boolean),
+    readState: state,
+    extractPrimitiveId: (value) => {
+      if (!value || typeof value !== 'object') return '';
+      const record = value as Record<string, unknown>;
+      const raw = record.primitiveId ?? record.uuid ?? state(value, 'PrimitiveId');
+      return typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'bigint'
+        ? String(raw)
+        : '';
+    },
+    readComponentType: (value) => String(state(value, 'ComponentType') ?? '').toLowerCase(),
+    readPinPoint: (value) => ({
+      x: state(value, 'X') as number | undefined,
+      y: state(value, 'Y') as number | undefined,
+      rotation: state(value, 'Rotation') as number | undefined,
+    }),
+    createBridgeError: bridgeError,
+    logRecoverableError,
+    asPublicTextAlignMode: (value) =>
+      typeof value === 'number' && Number.isInteger(value) && value >= 1 && value <= 9
+        ? (value as 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9)
+        : undefined,
+    requirePublicTextAlignMode: (value, field = 'alignMode') => {
+      if (typeof value !== 'number' || !Number.isInteger(value) || value < 1 || value > 9) {
+        throw bridgeError(
+          'INVALID_PARAMS',
+          `${field} must be an integer from 1 through 9`,
+          'Use the documented ESCH_PrimitiveTextAlignMode values: LEFT_TOP=1 through RIGHT_BOTTOM=9.',
+        );
+      }
+      return value as 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+    },
+    getCachedTextAlignMode: (primitiveId) => textAlignCache.get(primitiveId),
+    setCachedTextAlignMode: (primitiveId, alignMode) => textAlignCache.set(primitiveId, alignMode),
+    deleteCachedTextAlignMode: (primitiveId) => textAlignCache.delete(primitiveId),
+  });
+  return { operations, callFirst, logRecoverableError, textAlignCache };
+}
+
+describe('schematic transaction operations', () => {
+  it('captures a scalar-safe component snapshot', async () => {
+    const component = {
+      getState_PrimitiveId: () => 'cmp-1',
+      getState_ComponentType: () => 'component',
+      getState_X: () => 10,
+      getState_Y: () => 20,
+      getState_Designator: () => 'U1',
+      getState_OtherProperty: () => ({ value: 'MCU' }),
+    };
+    const { operations } = createSubject({
+      SCH_PrimitiveComponent: { get: vi.fn().mockResolvedValue(component) },
+    });
+
+    await expect(operations.getPrimitiveSnapshot('cmp-1')).resolves.toMatchObject({
+      schemaVersion: 'schematic-primitive-snapshot/v1',
+      primitiveId: 'cmp-1',
+      primitiveKind: 'component',
+      property: { x: 10, y: 20, designator: 'U1', otherProperty: { value: 'MCU' } },
+    });
+  });
+
+  it('rejects malformed restore input before mutation', async () => {
+    const { operations, callFirst } = createSubject();
+    await expect(
+      operations.restorePrimitiveSnapshot({ schemaVersion: 'wrong' }),
+    ).rejects.toMatchObject({
+      code: 'INVALID_PARAMS',
+      message: 'snapshot does not match schematic-primitive-snapshot/v1',
+    });
+    expect(callFirst).not.toHaveBeenCalled();
+  });
+
+  it('does not stringify object-valued primitive IDs', async () => {
+    const { operations } = createSubject({
+      SCH_PrimitiveWire: {
+        getAll: vi.fn().mockResolvedValue([{ primitiveId: { unsafe: true } }]),
+      },
+    });
+    await expect(operations.listPrimitiveIds('wire')).resolves.toEqual({
+      primitiveKind: 'wire',
+      primitiveIds: [],
+    });
+  });
+
+  it('routes deletion to the owning class and reports missing IDs', async () => {
+    const componentDelete = vi.fn().mockResolvedValue(true);
+    const wireDelete = vi.fn().mockResolvedValue(true);
+    const { operations } = createSubject({
+      SCH_PrimitiveComponent: {
+        get: vi.fn(async (id) => (id === 'cmp-1' ? { primitiveId: id } : undefined)),
+        delete: componentDelete,
+      },
+      SCH_PrimitiveWire: {
+        get: vi.fn(async (id) => (id === 'wire-1' ? { primitiveId: id } : undefined)),
+        delete: wireDelete,
+      },
+    });
+
+    await expect(operations.deletePrimitives(['cmp-1', 'wire-1', 'missing'])).resolves.toEqual({
+      success: false,
+      deleted: ['cmp-1', 'wire-1'],
+      notFound: ['missing'],
+    });
+    expect(componentDelete).toHaveBeenCalledWith(['cmp-1']);
+    expect(wireDelete).toHaveBeenCalledWith(['wire-1']);
+  });
+
+  it('rejects component recreation without a complete creation descriptor', async () => {
+    const { operations } = createSubject();
+    await expect(
+      operations.recreatePrimitiveSnapshot({
+        schemaVersion: 'schematic-primitive-snapshot/v1',
+        primitiveId: 'cmp-1',
+        primitiveKind: 'component',
+        property: {},
+      }),
+    ).rejects.toMatchObject({ code: 'UNSUPPORTED_RUNTIME' });
+  });
+});
+```
+
+- [ ] **Step 2: Run focused tests and verify RED**
+
+```bash
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH \
+TMPDIR="$PWD/.tmp/test-runtime" \
+pnpm --filter @easyeda-mcp-pro/bridge-extension exec vitest run \
+  tests/schematic-transaction-operations.test.ts
+```
+
+Expected: FAIL because `schematic-transaction-operations.ts` does not exist.
+
+- [ ] **Step 3: Commit the RED contract**
+
+```bash
+git add easyeda-bridge-extension/tests/schematic-transaction-operations.test.ts
+git -c user.name='Osman Aslan' -c user.email='info@oaslananka.dev' \
+  commit -m 'test(extension): lock schematic transaction boundary'
+```
+
+### Task 2: Implement snapshot, inventory, deletion, and recreation
+
+**Files:**
+
+- Create: `easyeda-bridge-extension/src/schematic-transaction-operations.ts`
+- Modify: `easyeda-bridge-extension/tests/schematic-transaction-operations.test.ts`
+
+**Interfaces:**
+
+- Consumes the exact dependency callbacks shown below.
+- Produces the six public transaction operations plus no new bridge methods.
+
+- [ ] **Step 1: Add the factory interfaces and snapshot schema**
+
+```ts
+import { isRecord } from './utils.js';
+
+export type PublicTextAlignMode = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+export type SchematicPrimitiveSnapshotKind =
+  'component' | 'netflag' | 'netport' | 'wire' | 'text' | 'rectangle' | 'circle' | 'polygon';
+
+export interface SchematicPrimitiveSnapshot {
+  schemaVersion: 'schematic-primitive-snapshot/v1';
+  primitiveId: string;
+  primitiveKind: SchematicPrimitiveSnapshotKind;
+  componentType?: string;
+  property: Record<string, unknown>;
+}
+
+export interface SchematicTransactionDependencies {
+  callFirst: (paths: string[], ...args: unknown[]) => Promise<unknown>;
+  readFirstPath: <T>(paths: string[]) => T | undefined;
+  readState: (source: unknown, key: string) => unknown;
+  extractPrimitiveId: (source: unknown) => string;
+  readComponentType: (source: unknown) => string;
+  readPinPoint: (source: unknown) => { x?: number; y?: number; rotation?: number };
+  createBridgeError: (code: string, message: string, suggestion: string, data?: unknown) => Error;
+  logRecoverableError: (message: string, error: unknown) => void;
+  asPublicTextAlignMode: (value: unknown) => PublicTextAlignMode | undefined;
+  requirePublicTextAlignMode: (value: unknown, field?: string) => PublicTextAlignMode;
+  getCachedTextAlignMode: (primitiveId: string) => PublicTextAlignMode | undefined;
+  setCachedTextAlignMode: (primitiveId: string, alignMode: PublicTextAlignMode) => void;
+  deleteCachedTextAlignMode: (primitiveId: string) => void;
+}
+
+export interface SchematicTransactionOperations {
+  getPrimitiveSnapshot: (
+    primitiveId: string,
+    expectedPrimitiveKind?: SchematicPrimitiveSnapshotKind,
+  ) => Promise<SchematicPrimitiveSnapshot>;
+  listPrimitiveIds: (
+    primitiveKind: unknown,
+  ) => Promise<{ primitiveKind: SchematicPrimitiveSnapshotKind; primitiveIds: string[] }>;
+  deletePrimitives: (
+    primitiveIds: unknown,
+  ) => Promise<{ success: boolean; deleted: string[]; notFound: string[] }>;
+  recreatePrimitiveSnapshot: (
+    snapshot: unknown,
+  ) => Promise<{ primitiveId: string; snapshot: SchematicPrimitiveSnapshot }>;
+  restorePrimitiveSnapshot: (
+    snapshot: unknown,
+  ) => Promise<{ restored: true; snapshot: SchematicPrimitiveSnapshot }>;
+  modifyPrimitive: (primitiveId: string, property: Record<string, unknown>) => Promise<unknown>;
+}
+```
+
+- [ ] **Step 2: Move the exact transaction-only helper set into the factory closure**
+
+Move these dispatcher definitions without changing messages, fallback order, property names, or native argument order:
+
+```text
+compactDefinedRecord
+readPrimitiveFromClass
+readPublicTextPrimitive
+readPersistentTextPrimitive
+validatedPublicTextPrimitive
+readTextPrimitiveFromClass
+componentSnapshotProperty
+COMPONENT_CLASS_PATHS
+WIRE_CLASS_PATHS
+TEXT_CLASS_PATHS
+RECTANGLE_CLASS_PATHS
+CIRCLE_CLASS_PATHS
+POLYGON_CLASS_PATHS
+componentKindFromType
+componentSnapshot
+wireSnapshot
+textSnapshot
+rectangleSnapshot
+circleSnapshot
+polygonSnapshot
+readComponentSnapshot
+readClassSnapshot
+readTextSnapshot
+throwUnsupportedTextSnapshot
+readSnapshotByKind
+readUnconstrainedSnapshot
+getSchematicPrimitiveSnapshot
+parseSchematicPrimitiveSnapshot
+RECREATABLE_SCHEMATIC_KINDS
+schematicPrimitiveClassPaths
+parseSchematicPrimitiveKind
+primitiveIdFromValue
+listSchematicPrimitiveIds
+primitiveExistsInClass
+deleteSchematicPrimitives
+requiredSnapshotNumber
+recreateSchematicPrimitiveSnapshot
+```
+
+Every former global access must use the injected dependency object. For example:
+
+```ts
+const primitiveClass = dependencies.readFirstPath<any>(paths);
+const value = dependencies.readState(current, 'Line');
+const primitiveId = dependencies.extractPrimitiveId(result);
+throw dependencies.createBridgeError('INVALID_PARAMS', message, suggestion, data);
+dependencies.logRecoverableError(context, error);
+```
+
+- [ ] **Step 3: Preserve text alignment resolution exactly**
+
+```ts
+interface TextPrimitiveRead {
+  publicCurrent?: unknown;
+  persistentCurrent?: unknown;
+  className: string;
+}
+
+function readTextState(text: TextPrimitiveRead, key: string): unknown {
+  const publicValue = dependencies.readState(text.publicCurrent, key);
+  if (publicValue !== undefined) return publicValue;
+  return dependencies.readState(text.persistentCurrent, key);
+}
+
+function resolvePublicTextAlignMode(
+  text: TextPrimitiveRead,
+  primitiveId: string,
+): PublicTextAlignMode | undefined {
+  const publicAlignMode = dependencies.asPublicTextAlignMode(
+    dependencies.readState(text.publicCurrent, 'AlignMode'),
+  );
+  if (publicAlignMode !== undefined) {
+    dependencies.setCachedTextAlignMode(primitiveId, publicAlignMode);
+    return publicAlignMode;
+  }
+  return dependencies.getCachedTextAlignMode(primitiveId);
+}
+```
+
+- [ ] **Step 4: Add recreation tests for every supported kind and ID path**
+
+Extend the focused test file with table-driven cases for wire, text, rectangle, circle, and polygon. Assert exact `callFirst` path and arguments. Include:
+
+```ts
+it('recovers a recreated ID from an exact one-item inventory diff', async () => {
+  const wireClass = {
+    getAll: vi
+      .fn()
+      .mockResolvedValueOnce([{ primitiveId: 'before' }])
+      .mockResolvedValueOnce([{ primitiveId: 'before' }, { primitiveId: 'after' }]),
+    get: vi.fn(async (id) => ({ primitiveId: id, getState_Line: () => [0, 0, 10, 0] })),
+  };
+  const { operations, callFirst } = createSubject({ SCH_PrimitiveWire: wireClass });
+  callFirst.mockResolvedValue({});
+
+  await expect(
+    operations.recreatePrimitiveSnapshot({
+      schemaVersion: 'schematic-primitive-snapshot/v1',
+      primitiveId: 'old',
+      primitiveKind: 'wire',
+      property: { line: [0, 0, 10, 0], net: 'GND' },
+    }),
+  ).resolves.toMatchObject({ primitiveId: 'after' });
+});
+```
+
+Add an ambiguity case where two IDs appear and expect `CREATE_UNCONFIRMED`.
+
+- [ ] **Step 5: Run focused tests and coverage**
+
+```bash
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH \
+TMPDIR="$PWD/.tmp/test-runtime" \
+pnpm --filter @easyeda-mcp-pro/bridge-extension exec vitest run \
+  tests/schematic-transaction-operations.test.ts --coverage
+```
+
+Expected: snapshot/inventory/delete/recreate tests pass. Coverage may remain below 100% until Task 3 adds modification branches.
+
+- [ ] **Step 6: Commit the read/delete/recreate boundary**
+
+```bash
+git add easyeda-bridge-extension/src/schematic-transaction-operations.ts \
+  easyeda-bridge-extension/tests/schematic-transaction-operations.test.ts
+git -c user.name='Osman Aslan' -c user.email='info@oaslananka.dev' \
+  commit -m 'refactor(extension): extract schematic transaction snapshots'
+```
+
+### Task 3: Implement safe modification and connected-wire following
+
+**Files:**
+
+- Modify: `easyeda-bridge-extension/src/schematic-transaction-operations.ts`
+- Modify: `easyeda-bridge-extension/tests/schematic-transaction-operations.test.ts`
+
+**Interfaces:**
+
+- Consumes snapshot/read helpers from Task 2.
+- Produces complete `modifyPrimitive()` and `restorePrimitiveSnapshot()` behavior.
+
+- [ ] **Step 1: Move the exact modification helper set into the module**
+
+Move these definitions and replace dispatcher globals with dependencies:
+
+```text
+applyNetFlagState
+getComponentPinCoordinates
+shiftWireLine
+followConnectedWires
+```
+
+Use this local point key implementation to preserve coordinate rounding:
+
+```ts
+function pointKey(point: { x: number; y: number }): string {
+  return `${Math.round(point.x * 1000) / 1000},${Math.round(point.y * 1000) / 1000}`;
+}
+```
+
+`getComponentPinCoordinates()` must call:
+
+```ts
+await dependencies.callFirst(
+  [
+    'SCH_PrimitiveComponent.getAllPinsByPrimitiveId',
+    'sch_PrimitiveComponent.getAllPinsByPrimitiveId',
+  ],
+  primitiveId,
+);
+```
+
+and use `dependencies.readPinPoint(pin)` so connect-pin behavior outside this module remains untouched.
+
+- [ ] **Step 2: Implement `modifyPrimitive()` with the existing class order**
+
+The class ownership order must remain:
+
+```text
+component/netflag/netport
+wire
+text
+circle
+polygon
+generic component/wire fallback
+```
+
+For components, preserve this merged shape:
+
+```ts
+const merged: Record<string, unknown> = {
+  x: oldX,
+  y: oldY,
+  rotation: dependencies.readState(current, 'Rotation'),
+  mirror: dependencies.readState(current, 'Mirror'),
+  addIntoBom: dependencies.readState(current, 'AddIntoBom'),
+  addIntoPcb: dependencies.readState(current, 'AddIntoPcb'),
+  designator: dependencies.readState(current, 'Designator'),
+  name: dependencies.readState(current, 'Name'),
+  uniqueId: dependencies.readState(current, 'UniqueId'),
+  manufacturer: dependencies.readState(current, 'Manufacturer'),
+  manufacturerId: dependencies.readState(current, 'ManufacturerId'),
+  supplier: dependencies.readState(current, 'Supplier'),
+  supplierId: dependencies.readState(current, 'SupplierId'),
+  ...property,
+  otherProperty: incomingOther ? { ...existingOther, ...incomingOther } : existingOther,
+};
+```
+
+For text, preserve alias normalization and public alignment:
+
+```ts
+if (incoming.color !== undefined) incoming.textColor = incoming.color;
+if (incoming.underline !== undefined) incoming.underLine = incoming.underline;
+delete incoming.color;
+delete incoming.underline;
+incoming.alignMode = alignMode;
+```
+
+After a component position change, call `followConnectedWires()` and return:
+
+```ts
+return { result: modifyResult, followedWireIds, wireFollowFailures };
+```
+
+- [ ] **Step 3: Implement restore through the local safe modify operation**
+
+```ts
+const restorePrimitiveSnapshot = async (input: unknown) => {
+  const snapshot = parseSchematicPrimitiveSnapshot(input);
+  await modifyPrimitive(snapshot.primitiveId, snapshot.property);
+  return {
+    restored: true as const,
+    snapshot: await getPrimitiveSnapshot(snapshot.primitiveId),
+  };
+};
+```
+
+This replaces the dispatcher-recursive call but preserves the same safe modification path and result contract.
+
+- [ ] **Step 4: Add focused modification tests**
+
+Add tests covering:
+
+```text
+component partial merge and first-level otherProperty merge
+netflag low-level setters + done()
+wire full-state merge
+text public get() alignment and cache fallback
+invalid text alignment
+circle and polygon ownership
+component movement wire endpoint translation
+recoverable wire modification failure
+no wire scan when x/y do not change
+primitive fallback path
+```
+
+The wire-follow failure test must assert that component modification resolves and includes the failed wire ID instead of throwing.
+
+- [ ] **Step 5: Reach focused 100% coverage**
+
+```bash
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH \
+TMPDIR="$PWD/.tmp/test-runtime" \
+pnpm --filter @easyeda-mcp-pro/bridge-extension exec vitest run \
+  tests/schematic-transaction-operations.test.ts --coverage
+```
+
+Expected: `schematic-transaction-operations.ts` reports 100% statements, branches, functions, and lines.
+
+- [ ] **Step 6: Commit safe mutation behavior**
+
+```bash
+git add easyeda-bridge-extension/src/schematic-transaction-operations.ts \
+  easyeda-bridge-extension/tests/schematic-transaction-operations.test.ts
+git -c user.name='Osman Aslan' -c user.email='info@oaslananka.dev' \
+  commit -m 'refactor(extension): extract schematic transaction mutations'
+```
+
+### Task 4: Wire six dispatcher delegates and remove duplicate helpers
+
+**Files:**
+
+- Modify: `easyeda-bridge-extension/src/dispatcher.ts:1-3749`
+- Modify: `easyeda-bridge-extension/tests/dispatcher.test.ts:1974-2725`
+
+**Interfaces:**
+
+- Consumes: complete factory from Tasks 2 and 3.
+- Produces: six thin switch delegates and one initialized domain instance.
+
+- [ ] **Step 1: Import and initialize the domain**
+
+```ts
+import {
+  createSchematicTransactionOperations,
+  type SchematicPrimitiveSnapshotKind,
+  type SchematicTransactionOperations,
+} from './schematic-transaction-operations.js';
+
+let schematicTransactionOperations: SchematicTransactionOperations;
+```
+
+Inside `createDispatcher()`:
+
+```ts
+schematicTransactionOperations = createSchematicTransactionOperations({
+  callFirst,
+  readFirstPath,
+  readState: safeGetState,
+  extractPrimitiveId,
+  readComponentType,
+  readPinPoint,
+  createBridgeError: newBridgeError,
+  logRecoverableError,
+  asPublicTextAlignMode,
+  requirePublicTextAlignMode,
+  getCachedTextAlignMode: (primitiveId) => textAlignModeCache.get(primitiveId),
+  setCachedTextAlignMode: (primitiveId, alignMode) =>
+    textAlignModeCache.set(primitiveId, alignMode),
+  deleteCachedTextAlignMode: (primitiveId) => textAlignModeCache.delete(primitiveId),
+});
+```
+
+Keep `textAlignModeCache.clear()` in dispatcher initialization so cache lifetime remains one dispatcher instance.
+
+- [ ] **Step 2: Replace six switch implementations**
+
+```ts
+case 'schematic.getPrimitiveSnapshot':
+  return schematicTransactionOperations.getPrimitiveSnapshot(
+    params.primitiveId as string,
+    typeof params.expectedPrimitiveKind === 'string'
+      ? (params.expectedPrimitiveKind as SchematicPrimitiveSnapshotKind)
+      : undefined,
+  );
+case 'schematic.listPrimitiveIds':
+  return schematicTransactionOperations.listPrimitiveIds(params.primitiveKind);
+case 'schematic.deletePrimitive':
+  return schematicTransactionOperations.deletePrimitives(params.primitiveIds);
+case 'schematic.recreatePrimitiveSnapshot':
+  return schematicTransactionOperations.recreatePrimitiveSnapshot(params.snapshot);
+case 'schematic.restorePrimitiveSnapshot':
+  return schematicTransactionOperations.restorePrimitiveSnapshot(params.snapshot);
+case 'schematic.modifyPrimitive':
+  return schematicTransactionOperations.modifyPrimitive(
+    params.primitiveId as string,
+    (params.property as Record<string, unknown>) || {},
+  );
+```
+
+- [ ] **Step 3: Delete only helpers now owned exclusively by the transaction module**
+
+Delete the exact helper set listed in Tasks 2 and 3. Keep shared dispatcher helpers:
+
+```text
+safeGetState
+readComponentType
+readPinPoint
+extractPrimitiveId
+asPublicTextAlignMode
+requirePublicTextAlignMode
+textAlignModeCache
+```
+
+because non-transaction paths still consume them.
+
+- [ ] **Step 4: Retain and extend dispatcher parity tests**
+
+Do not delete existing transaction behavior tests until every assertion has an equivalent focused-module test. Keep a compact dispatcher integration for all six method names and assert:
+
+```ts
+expect(dispatcher.methodList).toHaveLength(67);
+expect(dispatcher.methodList.filter((method) => method.startsWith('schematic.'))).toContain(
+  'schematic.getPrimitiveSnapshot',
+);
+```
+
+- [ ] **Step 5: Run focused parity and typecheck**
+
+```bash
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH \
+TMPDIR="$PWD/.tmp/test-runtime" \
+pnpm --filter @easyeda-mcp-pro/bridge-extension exec vitest run \
+  tests/schematic-transaction-operations.test.ts tests/dispatcher.test.ts
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH pnpm typecheck:extension
+```
+
+Expected: all tests and typecheck pass; public methods remain 67.
+
+- [ ] **Step 6: Commit dispatcher delegation**
+
+```bash
+git add easyeda-bridge-extension/src/dispatcher.ts \
+  easyeda-bridge-extension/tests/dispatcher.test.ts
+git -c user.name='Osman Aslan' -c user.email='info@oaslananka.dev' \
+  commit -m 'refactor(extension): delegate schematic transactions'
+```
+
+### Task 5: Final acceptance, PR, merge, and issue closure
+
+**Files:**
+
+- Modify: `docs/superpowers/plans/2026-07-23-schematic-transaction-boundary.md` to append measured evidence.
+- GitHub: final PR and issue #339 comment/state.
+
+**Interfaces:**
+
+- Produces: completed issue acceptance evidence and closure.
+
+- [ ] **Step 1: Run all exact-head local gates**
+
+```bash
+mkdir -p .tmp/test-runtime
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH \
+TMPDIR="$PWD/.tmp/test-runtime" pnpm verify
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH \
+TMPDIR="$PWD/.tmp/test-runtime" pnpm test:extension:ci
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH pnpm verify:extension
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH pnpm check:extension-size
+PATH=/home/msi/.local/share/node-v24.18.0-linux-x64/bin:$PATH pnpm security:audit
+```
+
+Expected: all exit 0; server suite remains 1,740 tests or higher; extension suite passes; both new modules have 100% coverage; method count remains 67.
+
+- [ ] **Step 2: Record measured acceptance data**
+
+```bash
+wc -l easyeda-bridge-extension/src/dispatcher.ts
+wc -c easyeda-bridge-extension/dist/dispatcher.js easyeda-bridge-extension/easyeda-bridge-extension.eext
+git diff --stat 18c5217083da7f8a705d8dc246e82fc9ed734caf...HEAD
+```
+
+Append only actual results under `## Execution Evidence`.
+
+- [ ] **Step 3: Commit evidence and push final branch**
+
+```bash
+git add docs/superpowers/plans/2026-07-23-schematic-transaction-boundary.md
+git -c user.name='Osman Aslan' -c user.email='info@oaslananka.dev' \
+  commit -m 'docs: record issue 339 completion evidence'
+git push -u origin refactor/issue-339-schematic-transactions
+```
+
+PR title:
+
+```text
+refactor(extension): extract schematic transaction operations
+```
+
+PR body may use `Closes #339` only after the rule-check extraction is on `main` and every local gate above passes.
+
+- [ ] **Step 4: Verify all remote checks and review threads**
+
+Required successful checks:
+
+```text
+CI Ubuntu/macOS/Windows
+Codecov patch checks
+Sonar: 0 new issues, 0 accepted issues, 0 hotspots
+CodeQL
+Semgrep OSS/Cloud
+Socket
+Trivy
+DeepScan
+dependency review
+container/workflow security
+```
+
+Resolve every bot, agent, and human review thread before merge.
+
+- [ ] **Step 5: Merge and verify post-merge main**
+
+After squash merge, verify the exact merge SHA has successful:
+
+```text
+CI
+Static Security Analysis
+Scorecard
+Golden Benchmark
+Release Please
+```
+
+- [ ] **Step 6: Publish final #339 evidence and close only after verification**
+
+The final issue comment must state:
+
+```text
+rule-check PR number and merge SHA
+transaction PR number and merge SHA
+final dispatcher line count and reduction from 5,041 and 3,749 baselines
+server and extension test totals
+100% coverage evidence for both new modules
+67-method parity
+bundle/package size results
+Sonar/Codecov/security results
+post-merge main workflow status
+```
+
+If the PR did not close #339 automatically, close it explicitly only after the comment is posted and all acceptance criteria are true.
+
+## Execution Evidence
+
+Populate this section only with command output collected at the exact final PR head and post-merge `main`. Do not estimate values.

--- a/docs/superpowers/specs/2026-07-23-issue-339-completion-design.md
+++ b/docs/superpowers/specs/2026-07-23-issue-339-completion-design.md
@@ -1,0 +1,224 @@
+# Issue #339 Completion Design
+
+## Goal
+
+Complete the remaining dispatcher decomposition work tracked by GitHub issue #339 by extracting the design rule-check and schematic transaction boundaries into typed domain modules, preserving all public bridge behavior, and closing the issue only after post-merge acceptance evidence is complete.
+
+## Starting Point
+
+- Repository: `oaslananka/easyeda-mcp-pro`
+- Canonical base: GitHub `main` at `18c5217083da7f8a705d8dc246e82fc9ed734caf`
+- Public extension method list: exactly 67 methods, unchanged throughout this work
+- Dispatcher size at the base commit: 3,749 lines
+- Runtime: Node.js 24.18.0 and pnpm 11.5.1
+- Work location: isolated branch and worktree; the existing MSI checkout and its uncommitted `.mcp.json` deletion remain untouched
+
+The work is delivered as two sequential pull requests. The first pull request references #339 without closing it. The second pull request closes #339 only after all acceptance criteria in this document pass.
+
+## Scope
+
+### Pull Request 1: Design Rule-Check Boundary
+
+Create `easyeda-bridge-extension/src/design-rule-check-operations.ts` and move the dispatcher-owned implementation of these public methods behind a typed factory:
+
+- `design.drc`
+- `design.erc`
+- `design.ruleCheck`
+
+The extracted module owns:
+
+- DRC/ERC severity normalization
+- leaf violation normalization
+- aggregate count normalization
+- recursive flattening of nested EasyEDA UI result trees
+- normalized summary counts and pass/fail calculation
+- PCB-only DRC context error translation
+- generic active-canvas fallback from PCB DRC to schematic ERC/DRC
+- stable `CONTEXT_UNAVAILABLE` errors with existing messages, suggestions, and cause data
+- `design.erc` orchestration for best-effort inferred floating-pin detail
+
+The extracted module does not own schematic net inference or floating-pin discovery. The dispatcher injects the existing `findFloatingPinsApi` behavior as a typed dependency so this pull request changes ownership, not connectivity semantics.
+
+### Pull Request 2: Schematic Transaction Boundary
+
+Create `easyeda-bridge-extension/src/schematic-transaction-operations.ts` and move these public methods behind a typed factory:
+
+- `schematic.getPrimitiveSnapshot`
+- `schematic.listPrimitiveIds`
+- `schematic.deletePrimitive`
+- `schematic.recreatePrimitiveSnapshot`
+- `schematic.restorePrimitiveSnapshot`
+- `schematic.modifyPrimitive`
+
+The extracted module owns the `schematic-primitive-snapshot/v1` contract and transaction-safe behavior for:
+
+- component
+- net flag
+- net port
+- wire
+- text
+- rectangle
+- circle
+- polygon
+
+It also owns the supporting transaction behavior currently embedded in `dispatcher.ts`, including primitive class resolution, snapshot parsing and validation, scalar-safe primitive IDs, ownership-aware deletion, recreation confirmation, partial-update state merging, text alignment safety, and connected-wire following after component movement.
+
+## Required Behavioral Parity
+
+### Rule-Check Behavior
+
+The rule-check module must preserve all observed native result shapes:
+
+- detailed leaf objects
+- flat aggregate objects such as `{ type, count }`
+- nested UI trees such as `{ name, count, list: [...] }`
+
+Severity mapping remains:
+
+- values containing `fatal` or `error` become `error`
+- values containing `warn` become `warning`
+- all other values become `info`
+
+`passed` remains true when and only when `errorCount` is zero. Aggregate counts contribute their full count to `totalViolations`, `errorCount`, and `warningCount`; the public `violations` array contains one explanatory aggregate entry per non-zero aggregate group.
+
+`design.drc` remains PCB-only. A missing or unfocused PCB context becomes `CONTEXT_UNAVAILABLE` with the existing actionable suggestion.
+
+`design.ruleCheck` continues to attempt PCB first, then schematic. It returns the first successful native check and emits a single stable `CONTEXT_UNAVAILABLE` error only when neither canvas is available, including both causes in error data.
+
+`design.erc` continues to run native schematic DRC/ERC and then best-effort floating-pin inference. Inference failure must not fail the native ERC result. `detailSource` remains `inferred_partial` when inferred pins exist and `native_aggregate_only` otherwise.
+
+### Transaction Behavior
+
+The snapshot schema version remains exactly `schematic-primitive-snapshot/v1`. Existing error codes, messages, suggestions, and error data are preserved unless a test demonstrates an unsafe or ambiguous contract that must be made stricter.
+
+Primitive IDs must remain scalar-safe. Object values must never become `[object Object]` identifiers.
+
+Text behavior must preserve the public `ESCH_PrimitiveTextAlignMode` range of 1 through 9. Internal `getAll()` encodings must never be written back to public create or modify APIs. The dispatcher-instance cache remains short-lived and is cleared when a dispatcher is created.
+
+Snapshot recreation remains supported only for wire, text, rectangle, circle, and polygon. Component, net flag, and net port recreation remains rejected because the current snapshot does not contain a complete creation descriptor.
+
+Text and rectangle recreation must preserve the current Y-axis conversion. The extraction must not “simplify” or remove the sign inversion already validated against the live runtime.
+
+Partial modification must continue to snapshot and merge all native fields because EasyEDA resets omitted fields. Component `otherProperty` remains deep-merged at its first level. Text aliases remain normalized from `color` to `textColor` and `underline` to `underLine`.
+
+Moving a component continues to capture its original pin coordinates before modification and move matching wire points by the same delta afterward. The result continues to report `followedWireIds` and `wireFollowFailures`; wire-follow failures remain recoverable and do not roll back the component modification.
+
+Deletion remains ownership-aware: the implementation must identify the owning primitive class before invoking its delete operation. Missing IDs remain reported in `notFound`, and the response `success` remains false when any requested ID was not found.
+
+When native create results do not expose an ID, recreation continues to compare the before/after inventory. Exactly one new ID confirms creation; zero or multiple candidates produce `CREATE_UNCONFIRMED`.
+
+## Architecture
+
+Both new modules use factory functions matching the established extracted-domain pattern in the repository. Dependencies are injected as narrow typed callbacks rather than importing dispatcher globals.
+
+The dispatcher remains responsible for:
+
+- constructing the shared EasyEDA API runtime
+- constructing extracted domain modules
+- routing public method names to domain methods
+- owning cross-domain callbacks that are not part of the extracted boundary
+- clearing dispatcher-instance caches during initialization
+
+The rule-check module receives callbacks for native API calls, bridge-error creation, recoverable logging, error-message normalization, and floating-pin discovery.
+
+The transaction module receives callbacks for API path resolution, native calls, bridge-error creation, recoverable logging, primitive state reads, primitive ID extraction, and the connected-wire helper dependencies required to preserve current behavior. Helpers should move with the domain when they have no remaining non-transaction consumers. Helpers shared with non-transaction schematic operations remain in the dispatcher and are injected.
+
+No new public bridge method is introduced. No server schema or MCP tool name changes are required.
+
+## Testing Strategy
+
+Implementation follows test-driven development.
+
+### Rule-Check Tests
+
+Add `easyeda-bridge-extension/tests/design-rule-check-operations.test.ts` covering:
+
+- detailed leaf normalization
+- nested UI tree flattening
+- flat aggregate normalization
+- count and pass/fail calculation
+- PCB DRC success
+- PCB context translation
+- PCB-first generic rule check
+- schematic fallback
+- both-contexts-unavailable error data
+- ERC inferred floating pins
+- ERC inference failure containment
+
+Update dispatcher parity tests to prove all three public methods delegate through the new module and the public method list remains byte-for-byte unchanged.
+
+### Transaction Tests
+
+Add `easyeda-bridge-extension/tests/schematic-transaction-operations.test.ts` covering every supported primitive kind and the critical safety branches:
+
+- snapshot validation and expected-kind mismatch
+- text public align mode and cache fallback
+- object-valued ID rejection
+- class ownership during deletion
+- unsupported component-like recreation
+- create-result ID extraction
+- inventory-diff ID recovery
+- ambiguous/unconfirmed recreation
+- text and rectangle Y conversion
+- partial component, wire, text, circle, and polygon modifications
+- net flag and net port low-level state mutation
+- connected-wire movement and recoverable failures
+- primitive-not-found and unsupported-runtime errors
+
+Update dispatcher parity tests for all six delegated transaction methods and verify the method list remains exactly 67 entries.
+
+New extracted modules must reach 100% statement, branch, function, and line coverage. Existing test coverage must not be reduced.
+
+## Verification Gates
+
+Each pull request must pass locally at its exact head with Node.js 24.18.0 and pnpm 11.5.1:
+
+- focused red/green tests for the new module
+- complete extension test suite
+- complete server test suite
+- `pnpm verify`
+- extension build and distribution verification
+- extension package and bundle size budgets
+- dependency audit policy, including only the documented temporary Hono exception tracked by #334
+- peer dependency validation
+- public method-list parity
+
+Remote required checks must pass before merge:
+
+- CI on Ubuntu, macOS, and Windows
+- Codecov patch checks with all changed coverable lines tested
+- Sonar with zero new issues, zero accepted issues, and zero security hotspots
+- CodeQL
+- Semgrep OSS and Cloud
+- Socket
+- Trivy
+- DeepScan
+- dependency review
+- container and workflow security checks
+
+All bot, agent, review, and inline suggestion threads must be resolved or explicitly documented before merge.
+
+## Delivery and Issue Closure
+
+Pull Request 1 uses `Refs #339` and leaves the issue open.
+
+Pull Request 2 may use `Closes #339` only when:
+
+- both extracted boundaries are merged or included in the final pull request
+- all required local and remote checks pass
+- public method count remains 67
+- dispatcher behavior parity is demonstrated by tests
+- no unresolved bot, agent, or reviewer feedback remains
+- final dispatcher line-count and coverage evidence are recorded
+
+After the final merge, verify the post-merge `main` workflow set, including CI, static security, Scorecard, Release Please, and benchmark jobs. Add a final issue comment summarizing both pull requests, merge commits, dispatcher reduction, test totals, coverage, quality/security results, and acceptance-criteria completion. Close #339 only after that evidence is public.
+
+## Explicit Non-Goals
+
+- changing public MCP tool names or schemas
+- changing native DRC/ERC semantics
+- rewriting schematic connectivity or floating-pin inference
+- adding component/net flag/net port delete recreation
+- changing title-block, synchronization, BOM, PCB, export, canvas, or API-runtime domains
+- unrelated cleanup in the dispatcher
+- modifying the user’s existing MSI checkout or `.mcp.json` deletion

--- a/docs/superpowers/specs/2026-07-23-issue-339-completion-design.md
+++ b/docs/superpowers/specs/2026-07-23-issue-339-completion-design.md
@@ -36,6 +36,7 @@ The extracted module owns:
 - generic active-canvas fallback from PCB DRC to schematic ERC/DRC
 - stable `CONTEXT_UNAVAILABLE` errors with existing messages, suggestions, and cause data
 - `design.erc` orchestration for best-effort inferred floating-pin detail
+- a typed native schematic-check operation reused by `schematic.validateNetlist` without duplicating normalization logic
 
 The extracted module does not own schematic net inference or floating-pin discovery. The dispatcher injects the existing `findFloatingPinsApi` behavior as a typed dependency so this pull request changes ownership, not connectivity semantics.
 
@@ -119,7 +120,7 @@ The dispatcher remains responsible for:
 - owning cross-domain callbacks that are not part of the extracted boundary
 - clearing dispatcher-instance caches during initialization
 
-The rule-check module receives callbacks for native API calls, bridge-error creation, recoverable logging, error-message normalization, and floating-pin discovery.
+The rule-check module receives callbacks for native API calls, bridge-error creation, recoverable logging, error-message normalization, and floating-pin discovery. Besides the three public delegates, it exposes an internal `runSchematicCheck()` operation so `schematic.validateNetlist` can preserve its native ERC cross-check through the same normalization boundary.
 
 The transaction module receives callbacks for API path resolution, native calls, bridge-error creation, recoverable logging, primitive state reads, primitive ID extraction, and the connected-wire helper dependencies required to preserve current behavior. Helpers should move with the domain when they have no remaining non-transaction consumers. Helpers shared with non-transaction schematic operations remain in the dispatcher and are injected.
 

--- a/easyeda-bridge-extension/src/design-rule-check-operations.ts
+++ b/easyeda-bridge-extension/src/design-rule-check-operations.ts
@@ -1,0 +1,252 @@
+import type { ApiRuntime } from './api-runtime.js';
+
+export type DrcSeverity = 'error' | 'warning' | 'info';
+
+export interface DrcResult {
+  violations: Array<Record<string, unknown>>;
+  totalViolations: number;
+  errorCount: number;
+  warningCount: number;
+  passed: boolean;
+}
+
+export interface FloatingPin {
+  primitiveId: string;
+  designator: string;
+  pinNumber: string;
+}
+
+export interface DesignRuleCheckDependencies {
+  callFirst: ApiRuntime['callFirst'];
+  createBridgeError(code: string, message: string, suggestion: string, data?: unknown): Error;
+  logRecoverableError(message: string, error: unknown): void;
+  errorMessage(error: unknown): string;
+  findFloatingPins(): Promise<{ floatingPins: FloatingPin[]; partRefs: string[] }>;
+}
+
+export interface DesignRuleCheckOperations {
+  runDrc(): Promise<DrcResult>;
+  runErc(): Promise<
+    DrcResult & {
+      inferredFloatingPins: FloatingPin[];
+      detailSource: 'inferred_partial' | 'native_aggregate_only';
+    }
+  >;
+  runRuleCheck(): Promise<DrcResult>;
+  runSchematicCheck(): Promise<DrcResult>;
+}
+
+function normalizeSeverity(raw: string): DrcSeverity {
+  const value = raw.toLowerCase();
+  if (value.includes('fatal') || value.includes('error')) return 'error';
+  if (value.includes('warn')) return 'warning';
+  return 'info';
+}
+
+function normalizeViolation(item: unknown): Record<string, unknown> {
+  const obj: Record<string, unknown> = item && typeof item === 'object' ? { ...item } : {};
+  const explanation =
+    obj.explanation && typeof obj.explanation === 'object'
+      ? (obj.explanation as Record<string, unknown>).str
+      : undefined;
+  const message =
+    obj.message ?? obj.msg ?? obj.description ?? obj.text ?? obj.detail ?? explanation ?? item;
+  const severitySource = [
+    obj.level,
+    obj.severity,
+    obj.type,
+    obj.errorLevel,
+    obj.errorType,
+    obj.errorObjType,
+    obj.name,
+    obj.ruleName,
+  ]
+    .filter((value) => value !== undefined && value !== null)
+    .join(' ');
+  const position =
+    obj.position && typeof obj.position === 'object'
+      ? (obj.position as Record<string, unknown>)
+      : obj.location && typeof obj.location === 'object'
+        ? (obj.location as Record<string, unknown>)
+        : obj;
+  return {
+    rule: String(
+      obj.rule ??
+        obj.ruleName ??
+        obj.ruleTypeName ??
+        obj.errorType ??
+        obj.name ??
+        obj.type ??
+        'unknown',
+    ),
+    description: typeof message === 'string' ? message : JSON.stringify(message),
+    severity: normalizeSeverity(severitySource),
+    net: obj.net ?? obj.netName ?? undefined,
+    component: obj.component ?? obj.ref ?? obj.designator ?? obj.primitiveId ?? undefined,
+    location:
+      typeof position.x === 'number' && typeof position.y === 'number'
+        ? { x: position.x, y: position.y, layer: obj.layer as string | undefined }
+        : undefined,
+  };
+}
+
+function normalizeAggregate(
+  obj: Record<string, unknown>,
+): { severity: DrcSeverity; count: number } | null {
+  if (typeof obj.count !== 'number') return null;
+  const source = [
+    obj.type,
+    obj.severity,
+    obj.level,
+    obj.errorType,
+    obj.errorObjType,
+    obj.name,
+    Array.isArray(obj.title) ? obj.title.join(' ') : obj.title,
+  ]
+    .filter((value) => value !== undefined && value !== null)
+    .join(' ');
+  return { severity: normalizeSeverity(source), count: obj.count };
+}
+
+function hasLeafDetail(obj: Record<string, unknown>): boolean {
+  return [
+    'message',
+    'msg',
+    'description',
+    'text',
+    'detail',
+    'explanation',
+    'errorType',
+    'errorObjType',
+    'rule',
+    'ruleName',
+    'ruleTypeName',
+  ].some((key) => obj[key] !== undefined);
+}
+
+function normalizeNode(item: unknown): {
+  violations: Array<Record<string, unknown>>;
+  aggregates: Array<{ severity: DrcSeverity; count: number }>;
+} {
+  const obj = item && typeof item === 'object' ? (item as Record<string, unknown>) : null;
+  if (!obj) return { violations: [normalizeViolation(item)], aggregates: [] };
+
+  const children = Array.isArray(obj.list) ? obj.list : [];
+  if (children.length > 0) {
+    const normalized = children.map(normalizeNode);
+    const violations = normalized.flatMap((entry) => entry.violations);
+    const aggregates = normalized.flatMap((entry) => entry.aggregates);
+    if (violations.length > 0 || aggregates.length > 0) return { violations, aggregates };
+  }
+
+  if (hasLeafDetail(obj)) return { violations: [normalizeViolation(obj)], aggregates: [] };
+  const aggregate = normalizeAggregate(obj);
+  return { violations: [], aggregates: aggregate ? [aggregate] : [] };
+}
+
+export function createDesignRuleCheckOperations(
+  dependencies: DesignRuleCheckDependencies,
+): DesignRuleCheckOperations {
+  async function runNative(paths: string[]): Promise<DrcResult> {
+    const raw = await dependencies.callFirst(paths, true, true, true);
+    const normalized = (Array.isArray(raw) ? raw : []).map(normalizeNode);
+    const detailed = normalized.flatMap((entry) => entry.violations);
+    const aggregates = normalized.flatMap((entry) => entry.aggregates);
+    const violations = [
+      ...detailed,
+      ...aggregates
+        .filter((entry) => entry.count > 0)
+        .map((entry) => ({
+          rule: 'aggregate',
+          description:
+            `${entry.count} ${entry.severity}(s) reported by EasyEDA's native design/electrical rule ` +
+            'check. Per-violation detail is only shown in EasyEDA Pro when the API returns aggregate counts.',
+          severity: entry.severity,
+        })),
+    ];
+    const errorCount =
+      detailed.filter((entry) => entry.severity === 'error').length +
+      aggregates
+        .filter((entry) => entry.severity === 'error')
+        .reduce((sum, entry) => sum + entry.count, 0);
+    const warningCount =
+      detailed.filter((entry) => entry.severity === 'warning').length +
+      aggregates
+        .filter((entry) => entry.severity === 'warning')
+        .reduce((sum, entry) => sum + entry.count, 0);
+    return {
+      violations,
+      totalViolations: detailed.length + aggregates.reduce((sum, entry) => sum + entry.count, 0),
+      errorCount,
+      warningCount,
+      passed: errorCount === 0,
+    };
+  }
+
+  async function runSchematicCheck(): Promise<DrcResult> {
+    return runNative(['SCH_Drc.check']);
+  }
+
+  async function runDrc(): Promise<DrcResult> {
+    try {
+      return await runNative(['PCB_Drc.check']);
+    } catch (error) {
+      throw dependencies.createBridgeError(
+        'CONTEXT_UNAVAILABLE',
+        'PCB DRC is unavailable in the current editor context.',
+        'Open and focus a PCB document, then retry design.drc.',
+        { cause: dependencies.errorMessage(error) },
+      );
+    }
+  }
+
+  async function runRuleCheck(): Promise<DrcResult> {
+    let pcbError: unknown;
+    try {
+      return await runNative(['PCB_Drc.check']);
+    } catch (error) {
+      pcbError = error;
+      dependencies.logRecoverableError(
+        'design.ruleCheck: PCB DRC unavailable; trying schematic ERC/DRC',
+        error,
+      );
+    }
+    try {
+      return await runNative(['SCH_Drc.check']);
+    } catch (schematicError) {
+      throw dependencies.createBridgeError(
+        'CONTEXT_UNAVAILABLE',
+        'No active PCB or schematic canvas is available for design.ruleCheck.',
+        'Open and focus a PCB or schematic document, then retry.',
+        {
+          pcbCause: dependencies.errorMessage(pcbError),
+          schematicCause: dependencies.errorMessage(schematicError),
+        },
+      );
+    }
+  }
+
+  async function runErc(): ReturnType<DesignRuleCheckOperations['runErc']> {
+    const result = await runNative(['SCH_Drc.check']);
+    try {
+      const { floatingPins } = await dependencies.findFloatingPins();
+      return {
+        ...result,
+        inferredFloatingPins: floatingPins,
+        detailSource:
+          floatingPins.length > 0
+            ? ('inferred_partial' as const)
+            : ('native_aggregate_only' as const),
+      };
+    } catch (error) {
+      dependencies.logRecoverableError('design.erc: floating-pin inference failed', error);
+      return {
+        ...result,
+        inferredFloatingPins: [],
+        detailSource: 'native_aggregate_only' as const,
+      };
+    }
+  }
+
+  return { runDrc, runErc, runRuleCheck, runSchematicCheck };
+}

--- a/easyeda-bridge-extension/src/design-rule-check-operations.ts
+++ b/easyeda-bridge-extension/src/design-rule-check-operations.ts
@@ -43,6 +43,30 @@ function normalizeSeverity(raw: string): DrcSeverity {
   return 'info';
 }
 
+function scalarString(value: unknown): string | undefined {
+  return typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean' ||
+    typeof value === 'bigint'
+    ? String(value)
+    : undefined;
+}
+
+function joinScalarValues(values: unknown[]): string {
+  return values
+    .map(scalarString)
+    .filter((value): value is string => value !== undefined)
+    .join(' ');
+}
+
+function firstScalarValue(values: unknown[]): string {
+  for (const value of values) {
+    const scalar = scalarString(value);
+    if (scalar !== undefined) return scalar;
+  }
+  return 'unknown';
+}
+
 function normalizeViolation(item: unknown): Record<string, unknown> {
   const obj: Record<string, unknown> = item && typeof item === 'object' ? { ...item } : {};
   const explanation =
@@ -51,7 +75,7 @@ function normalizeViolation(item: unknown): Record<string, unknown> {
       : undefined;
   const message =
     obj.message ?? obj.msg ?? obj.description ?? obj.text ?? obj.detail ?? explanation ?? item;
-  const severitySource = [
+  const severitySource = joinScalarValues([
     obj.level,
     obj.severity,
     obj.type,
@@ -60,25 +84,22 @@ function normalizeViolation(item: unknown): Record<string, unknown> {
     obj.errorObjType,
     obj.name,
     obj.ruleName,
-  ]
-    .filter((value) => value !== undefined && value !== null)
-    .join(' ');
-  const position =
-    obj.position && typeof obj.position === 'object'
-      ? (obj.position as Record<string, unknown>)
-      : obj.location && typeof obj.location === 'object'
-        ? (obj.location as Record<string, unknown>)
-        : obj;
+  ]);
+  let position = obj;
+  if (obj.position && typeof obj.position === 'object') {
+    position = obj.position as Record<string, unknown>;
+  } else if (obj.location && typeof obj.location === 'object') {
+    position = obj.location as Record<string, unknown>;
+  }
   return {
-    rule: String(
-      obj.rule ??
-        obj.ruleName ??
-        obj.ruleTypeName ??
-        obj.errorType ??
-        obj.name ??
-        obj.type ??
-        'unknown',
-    ),
+    rule: firstScalarValue([
+      obj.rule,
+      obj.ruleName,
+      obj.ruleTypeName,
+      obj.errorType,
+      obj.name,
+      obj.type,
+    ]),
     description: typeof message === 'string' ? message : JSON.stringify(message),
     severity: normalizeSeverity(severitySource),
     net: obj.net ?? obj.netName ?? undefined,
@@ -94,17 +115,16 @@ function normalizeAggregate(
   obj: Record<string, unknown>,
 ): { severity: DrcSeverity; count: number } | null {
   if (typeof obj.count !== 'number') return null;
-  const source = [
+  const title = Array.isArray(obj.title) ? joinScalarValues(obj.title) : obj.title;
+  const source = joinScalarValues([
     obj.type,
     obj.severity,
     obj.level,
     obj.errorType,
     obj.errorObjType,
     obj.name,
-    Array.isArray(obj.title) ? obj.title.join(' ') : obj.title,
-  ]
-    .filter((value) => value !== undefined && value !== null)
-    .join(' ');
+    title,
+  ]);
   return { severity: normalizeSeverity(source), count: obj.count };
 }
 

--- a/easyeda-bridge-extension/src/dispatcher.ts
+++ b/easyeda-bridge-extension/src/dispatcher.ts
@@ -20,6 +20,10 @@ import {
   type BoardInspectionOperations,
 } from './board-inspection.js';
 import { createCanvasOperations, type CanvasOperations } from './canvas-operations.js';
+import {
+  createDesignRuleCheckOperations,
+  type DesignRuleCheckOperations,
+} from './design-rule-check-operations.js';
 import { createExportOperations, type ExportOperations } from './export-operations.js';
 import {
   createPcbMutationOperations,
@@ -128,6 +132,7 @@ let inspectApiInventory: ApiRuntime['inspectApiInventory'];
 let callAllowedApi: ApiRuntime['callAllowedApi'];
 let boardInspection: BoardInspectionOperations;
 let canvasOperations: CanvasOperations;
+let designRuleCheckOperations: DesignRuleCheckOperations;
 let exportOperations: ExportOperations;
 let pcbMutationOperations: PcbMutationOperations;
 let pcbReadOperations: PcbReadOperations;
@@ -2316,212 +2321,8 @@ async function connectPinToNetImpl(
   return { primitiveId: createdId, endpoint };
 }
 
-function normalizeDrcSeverity(raw: unknown): 'error' | 'warning' | 'info' {
-  const s = String(raw ?? '').toLowerCase();
-  if (s.includes('fatal') || s.includes('error')) return 'error';
-  if (s.includes('warn')) return 'warning';
-  return 'info';
-}
-
-function normalizeDrcViolation(item: unknown): Record<string, unknown> {
-  const obj: Record<string, unknown> = item && typeof item === 'object' ? { ...item } : {};
-  const explanation =
-    obj.explanation && typeof obj.explanation === 'object'
-      ? (obj.explanation as Record<string, unknown>).str
-      : undefined;
-  const message =
-    obj.message ?? obj.msg ?? obj.description ?? obj.text ?? obj.detail ?? explanation ?? item;
-  const severitySource = [
-    obj.level,
-    obj.severity,
-    obj.type,
-    obj.errorLevel,
-    obj.errorType,
-    obj.errorObjType,
-    obj.name,
-    obj.ruleName,
-  ]
-    .filter((value) => value !== undefined && value !== null)
-    .join(' ');
-  const posSource =
-    obj.position && typeof obj.position === 'object'
-      ? (obj.position as Record<string, unknown>)
-      : obj.location && typeof obj.location === 'object'
-        ? (obj.location as Record<string, unknown>)
-        : obj;
-  const x = posSource.x;
-  const y = posSource.y;
-  return {
-    rule: String(
-      obj.rule ??
-        obj.ruleName ??
-        obj.ruleTypeName ??
-        obj.errorType ??
-        obj.name ??
-        obj.type ??
-        'unknown',
-    ),
-    description: typeof message === 'string' ? message : JSON.stringify(message),
-    severity: normalizeDrcSeverity(severitySource),
-    net: obj.net ?? obj.netName ?? undefined,
-    component: obj.component ?? obj.ref ?? obj.designator ?? obj.primitiveId ?? undefined,
-    location:
-      typeof x === 'number' && typeof y === 'number'
-        ? { x, y, layer: obj.layer as string | undefined }
-        : undefined,
-  };
-}
-
-function normalizeDrcAggregate(
-  item: unknown,
-): { severity: 'error' | 'warning' | 'info'; count: number } | null {
-  const obj = item && typeof item === 'object' ? (item as Record<string, unknown>) : null;
-  if (!obj || typeof obj.count !== 'number') return null;
-  const severitySource = [
-    obj.type,
-    obj.severity,
-    obj.level,
-    obj.errorType,
-    obj.errorObjType,
-    obj.name,
-    Array.isArray(obj.title) ? obj.title.join(' ') : obj.title,
-  ]
-    .filter((value) => value !== undefined && value !== null)
-    .join(' ');
-  return { severity: normalizeDrcSeverity(severitySource), count: obj.count };
-}
-
-function hasDrcLeafDetail(obj: Record<string, unknown>): boolean {
-  return [
-    'message',
-    'msg',
-    'description',
-    'text',
-    'detail',
-    'explanation',
-    'errorType',
-    'errorObjType',
-    'rule',
-    'ruleName',
-    'ruleTypeName',
-  ].some((key) => obj[key] !== undefined);
-}
-
-function normalizeDrcNode(item: unknown): {
-  violations: Array<Record<string, unknown>>;
-  aggregates: Array<{ severity: 'error' | 'warning' | 'info'; count: number }>;
-} {
-  const obj = item && typeof item === 'object' ? (item as Record<string, unknown>) : null;
-  if (!obj) return { violations: [normalizeDrcViolation(item)], aggregates: [] };
-
-  const children = Array.isArray(obj.list) ? obj.list : [];
-  if (children.length > 0) {
-    const normalizedChildren = children.map(normalizeDrcNode);
-    const violations = normalizedChildren.flatMap((entry) => entry.violations);
-    const aggregates = normalizedChildren.flatMap((entry) => entry.aggregates);
-    if (violations.length > 0 || aggregates.length > 0) return { violations, aggregates };
-  }
-
-  if (hasDrcLeafDetail(obj)) {
-    return { violations: [normalizeDrcViolation(obj)], aggregates: [] };
-  }
-  const aggregate = normalizeDrcAggregate(obj);
-  return { violations: [], aggregates: aggregate ? [aggregate] : [] };
-}
-
-/**
- * Runs the native SCH_Drc.check/PCB_Drc.check API correctly. EasyEDA has two
- * observed verbose return shapes: flat aggregates (`{type,count}`) and nested
- * UI trees (`{name,count,list:[...]}`). The latter is used by PCB netlist
- * mismatch checks, so the tree must be recursively flattened rather than
- * stringified as one informational item.
- */
-async function runDrcCheck(classPaths: string[]): Promise<{
-  violations: Array<Record<string, unknown>>;
-  totalViolations: number;
-  errorCount: number;
-  warningCount: number;
-  passed: boolean;
-}> {
-  const raw = await callFirst(classPaths, true, true, true);
-  const items = Array.isArray(raw) ? raw : [];
-  const normalized = items.map(normalizeDrcNode);
-  const detailedViolations = normalized.flatMap((entry) => entry.violations);
-  const aggregates = normalized.flatMap((entry) => entry.aggregates);
-  const aggregateViolations = aggregates
-    .filter((entry) => entry.count > 0)
-    .map((entry) => ({
-      rule: 'aggregate',
-      description:
-        `${entry.count} ${entry.severity}(s) reported by EasyEDA's native design/electrical rule ` +
-        'check. Per-violation detail is only shown in EasyEDA Pro when the API returns aggregate counts.',
-      severity: entry.severity,
-    }));
-  const violations = [...detailedViolations, ...aggregateViolations];
-  const errorCount =
-    detailedViolations.filter((entry) => entry.severity === 'error').length +
-    aggregates
-      .filter((entry) => entry.severity === 'error')
-      .reduce((sum, entry) => sum + entry.count, 0);
-  const warningCount =
-    detailedViolations.filter((entry) => entry.severity === 'warning').length +
-    aggregates
-      .filter((entry) => entry.severity === 'warning')
-      .reduce((sum, entry) => sum + entry.count, 0);
-  const totalViolations =
-    detailedViolations.length + aggregates.reduce((sum, entry) => sum + entry.count, 0);
-  return {
-    violations,
-    totalViolations,
-    errorCount,
-    warningCount,
-    passed: errorCount === 0,
-  };
-}
-
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-/** Run PCB DRC only when a PCB canvas is available, translating EasyEDA's
- * opaque message-bus failure into a stable bridge error. The public MCP tool
- * already maps this error to `not_available: true`; callers of the bridge API
- * now receive an actionable code/suggestion instead of a localized runtime
- * string. */
-async function runPcbDrcCheck(): ReturnType<typeof runDrcCheck> {
-  try {
-    return await runDrcCheck(['PCB_Drc.check']);
-  } catch (error) {
-    throw newBridgeError(
-      'CONTEXT_UNAVAILABLE',
-      'PCB DRC is unavailable in the current editor context.',
-      'Open and focus a PCB document, then retry design.drc.',
-      { cause: errorMessage(error) },
-    );
-  }
-}
-
-/** Generic rule-check chooses the active canvas by trying PCB first and then
- * schematic. EasyEDA exposes both classes globally even when their canvas is
- * not active, so class presence alone is not a reliable context signal. */
-async function runRuleCheckForActiveCanvas(): ReturnType<typeof runDrcCheck> {
-  let pcbError: unknown;
-  try {
-    return await runDrcCheck(['PCB_Drc.check']);
-  } catch (error) {
-    pcbError = error;
-    logRecoverableError('design.ruleCheck: PCB DRC unavailable; trying schematic ERC/DRC', error);
-  }
-  try {
-    return await runDrcCheck(['SCH_Drc.check']);
-  } catch (schematicError) {
-    throw newBridgeError(
-      'CONTEXT_UNAVAILABLE',
-      'No active PCB or schematic canvas is available for design.ruleCheck.',
-      'Open and focus a PCB or schematic document, then retry.',
-      { pcbCause: errorMessage(pcbError), schematicCause: errorMessage(schematicError) },
-    );
-  }
 }
 
 /**
@@ -3360,7 +3161,7 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
       // cannot be a false positive (this is the authoritative source).
       let nativeErc: { errorCount: number; warningCount: number; passed: boolean } | undefined;
       try {
-        const drc = await runDrcCheck(['SCH_Drc.check']);
+        const drc = await designRuleCheckOperations.runSchematicCheck();
         nativeErc = {
           errorCount: drc.errorCount,
           warningCount: drc.warningCount,
@@ -3608,35 +3409,11 @@ async function dispatch(method: string, params: Record<string, unknown> = {}): P
     case 'inventory.getPrice':
       return null;
     case 'design.ruleCheck':
-      return runRuleCheckForActiveCanvas();
-    case 'design.erc': {
-      const result = await runDrcCheck(['SCH_Drc.check']);
-      // SCH_Drc.check()'s verbose mode only ever returns per-severity
-      // aggregates (confirmed live twice: a schematic with exactly one
-      // floating-pin part produced exactly [{type:"warn",count:1}], no
-      // location/net/component fields at any depth). Floating pins are the
-      // one ERC category our own connectivity inference can locate
-      // independently, so surface them as a best-effort supplement —
-      // clearly not a full decomposition of the native count, since other
-      // ERC categories (short circuits, conflicting pin types, etc.) have
-      // no inference-based equivalent.
-      try {
-        const { floatingPins } = await findFloatingPinsApi();
-        return {
-          ...result,
-          inferredFloatingPins: floatingPins,
-          detailSource:
-            floatingPins.length > 0
-              ? ('inferred_partial' as const)
-              : ('native_aggregate_only' as const),
-        };
-      } catch (e) {
-        logRecoverableError('design.erc: floating-pin inference failed', e);
-        return { ...result, inferredFloatingPins: [], detailSource: 'native_aggregate_only' };
-      }
-    }
+      return designRuleCheckOperations.runRuleCheck();
+    case 'design.erc':
+      return designRuleCheckOperations.runErc();
     case 'design.drc':
-      return runPcbDrcCheck();
+      return designRuleCheckOperations.runDrc();
     case 'export.pickPlace':
       return exportOperations.exportPickPlace(params);
     case 'export.pdf':
@@ -3711,6 +3488,13 @@ export function createDispatcher(toolkit: DispatcherToolkit): Dispatcher {
     callFirst,
     normalizeBinaryResult,
     createBridgeError: newBridgeError,
+  });
+  designRuleCheckOperations = createDesignRuleCheckOperations({
+    callFirst,
+    createBridgeError: newBridgeError,
+    logRecoverableError,
+    errorMessage,
+    findFloatingPins: findFloatingPinsApi,
   });
   exportOperations = createExportOperations({ callFirst, normalizeBinaryResult });
   pcbReadOperations = createPcbReadOperations({

--- a/easyeda-bridge-extension/tests/design-rule-check-operations.test.ts
+++ b/easyeda-bridge-extension/tests/design-rule-check-operations.test.ts
@@ -1,0 +1,255 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createDesignRuleCheckOperations } from '../src/design-rule-check-operations.js';
+
+function bridgeError(code: string, message: string, suggestion: string, data?: unknown): Error {
+  return Object.assign(new Error(message), { code, suggestion, data });
+}
+
+function createSubject() {
+  const callFirst = vi.fn();
+  const findFloatingPins = vi.fn().mockResolvedValue({ floatingPins: [], partRefs: [] });
+  const logRecoverableError = vi.fn();
+  const operations = createDesignRuleCheckOperations({
+    callFirst,
+    createBridgeError: bridgeError,
+    logRecoverableError,
+    errorMessage: (error) => (error instanceof Error ? error.message : String(error)),
+    findFloatingPins,
+  });
+  return { operations, callFirst, findFloatingPins, logRecoverableError };
+}
+
+describe('design rule-check operations', () => {
+  it('normalizes detailed leaves and nested UI trees', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst.mockResolvedValue([
+      {
+        name: 'Netlist mismatch',
+        count: 1,
+        list: [
+          {
+            ruleName: 'Missing connection',
+            message: 'U1.1 is disconnected',
+            severity: 'fatal',
+            position: { x: 10, y: 20 },
+            layer: 'TopLayer',
+          },
+        ],
+      },
+    ]);
+
+    await expect(operations.runDrc()).resolves.toMatchObject({
+      totalViolations: 1,
+      errorCount: 1,
+      warningCount: 0,
+      passed: false,
+      violations: [
+        {
+          rule: 'Missing connection',
+          description: 'U1.1 is disconnected',
+          severity: 'error',
+          location: { x: 10, y: 20, layer: 'TopLayer' },
+        },
+      ],
+    });
+    expect(callFirst).toHaveBeenCalledWith(['PCB_Drc.check'], true, true, true);
+  });
+
+  it('counts flat aggregate groups without inventing leaf detail', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst.mockResolvedValue([
+      { type: 'error', count: 2 },
+      { type: 'warn', count: 3 },
+      { type: 'info', count: 4 },
+    ]);
+
+    await expect(operations.runDrc()).resolves.toMatchObject({
+      totalViolations: 9,
+      errorCount: 2,
+      warningCount: 3,
+      passed: false,
+    });
+  });
+
+  it('normalizes primitive leaves and every supported message, rule, component, and location fallback', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst.mockResolvedValue([
+      'raw violation',
+      null,
+      { msg: 'from msg', rule: 'rule-direct', netName: 'N1', ref: 'R1', location: { x: 1, y: 2 } },
+      { description: 'from description', ruleTypeName: 'rule-type', component: 'U1' },
+      { text: 'from text', errorType: 'error-type', designator: 'D1' },
+      { detail: 'from detail', name: 'named-rule', primitiveId: 'primitive-1' },
+      { explanation: { str: 'from explanation' }, type: 'typed-rule', x: 5, y: 6 },
+      { message: { nested: true }, ruleName: 'json-message' },
+    ]);
+
+    const result = await operations.runDrc();
+
+    expect(result).toMatchObject({ totalViolations: 8, errorCount: 1, passed: false });
+    expect(result.violations).toEqual([
+      expect.objectContaining({ rule: 'unknown', description: 'raw violation', severity: 'info' }),
+      expect.objectContaining({ rule: 'unknown', description: 'null', severity: 'info' }),
+      expect.objectContaining({
+        rule: 'rule-direct',
+        description: 'from msg',
+        net: 'N1',
+        component: 'R1',
+        location: { x: 1, y: 2, layer: undefined },
+      }),
+      expect.objectContaining({
+        rule: 'rule-type',
+        description: 'from description',
+        component: 'U1',
+      }),
+      expect.objectContaining({
+        rule: 'error-type',
+        description: 'from text',
+        severity: 'error',
+        component: 'D1',
+      }),
+      expect.objectContaining({
+        rule: 'named-rule',
+        description: 'from detail',
+        component: 'primitive-1',
+      }),
+      expect.objectContaining({
+        rule: 'typed-rule',
+        description: 'from explanation',
+        location: { x: 5, y: 6, layer: undefined },
+      }),
+      expect.objectContaining({ rule: 'json-message', description: '{"nested":true}' }),
+    ]);
+  });
+
+  it('handles nested aggregate-only and empty trees, zero counts, and title variants', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst.mockResolvedValue([
+      { list: [{ type: 'warn', count: 2 }] },
+      { list: [{}], type: 'info', count: 0 },
+      { title: ['WARN', 'group'], count: 1 },
+      { title: 'error group', count: 1 },
+      { count: 'not-numeric' },
+    ]);
+
+    const result = await operations.runDrc();
+
+    expect(result).toMatchObject({
+      totalViolations: 4,
+      errorCount: 1,
+      warningCount: 3,
+      passed: false,
+    });
+    expect(result.violations).toHaveLength(3);
+  });
+
+  it('treats a non-array native response as an empty successful check', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst.mockResolvedValue({ unexpected: true });
+
+    await expect(operations.runDrc()).resolves.toEqual({
+      violations: [],
+      totalViolations: 0,
+      errorCount: 0,
+      warningCount: 0,
+      passed: true,
+    });
+  });
+
+  it('returns the PCB result without attempting schematic fallback when ruleCheck succeeds', async () => {
+    const { operations, callFirst, logRecoverableError } = createSubject();
+    callFirst.mockResolvedValue([{ type: 'info', count: 1 }]);
+
+    await expect(operations.runRuleCheck()).resolves.toMatchObject({
+      totalViolations: 1,
+      passed: true,
+    });
+    expect(callFirst).toHaveBeenCalledTimes(1);
+    expect(callFirst).toHaveBeenCalledWith(['PCB_Drc.check'], true, true, true);
+    expect(logRecoverableError).not.toHaveBeenCalled();
+  });
+
+  it('runs a native schematic check for cross-domain validation consumers', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst.mockResolvedValue([{ type: 'warn', count: 2 }]);
+
+    await expect(operations.runSchematicCheck()).resolves.toMatchObject({
+      totalViolations: 2,
+      errorCount: 0,
+      warningCount: 2,
+      passed: true,
+    });
+    expect(callFirst).toHaveBeenCalledWith(['SCH_Drc.check'], true, true, true);
+  });
+
+  it('translates an inactive PCB context for design.drc', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst.mockRejectedValue(new Error('no PCB canvas'));
+
+    await expect(operations.runDrc()).rejects.toMatchObject({
+      code: 'CONTEXT_UNAVAILABLE',
+      message: 'PCB DRC is unavailable in the current editor context.',
+      suggestion: 'Open and focus a PCB document, then retry design.drc.',
+      data: { cause: 'no PCB canvas' },
+    });
+  });
+
+  it('falls back from PCB to schematic for design.ruleCheck', async () => {
+    const { operations, callFirst, logRecoverableError } = createSubject();
+    callFirst
+      .mockRejectedValueOnce(new Error('no PCB canvas'))
+      .mockResolvedValueOnce([{ type: 'warn', count: 1 }]);
+
+    await expect(operations.runRuleCheck()).resolves.toMatchObject({
+      totalViolations: 1,
+      errorCount: 0,
+      warningCount: 1,
+      passed: true,
+    });
+    expect(callFirst.mock.calls).toEqual([
+      [['PCB_Drc.check'], true, true, true],
+      [['SCH_Drc.check'], true, true, true],
+    ]);
+    expect(logRecoverableError).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports both causes when neither canvas is available', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst
+      .mockRejectedValueOnce(new Error('no PCB canvas'))
+      .mockRejectedValueOnce(new Error('no schematic canvas'));
+
+    await expect(operations.runRuleCheck()).rejects.toMatchObject({
+      code: 'CONTEXT_UNAVAILABLE',
+      data: { pcbCause: 'no PCB canvas', schematicCause: 'no schematic canvas' },
+    });
+  });
+
+  it('supplements ERC with inferred floating pins', async () => {
+    const floatingPins = [{ primitiveId: 'p1', designator: 'U1', pinNumber: '1' }];
+    const { operations, callFirst, findFloatingPins } = createSubject();
+    callFirst.mockResolvedValue([{ type: 'warn', count: 1 }]);
+    findFloatingPins.mockResolvedValue({ floatingPins, partRefs: ['U1'] });
+
+    await expect(operations.runErc()).resolves.toMatchObject({
+      inferredFloatingPins: floatingPins,
+      detailSource: 'inferred_partial',
+    });
+  });
+
+  it('contains ERC inference failures and returns the native aggregate', async () => {
+    const { operations, callFirst, findFloatingPins, logRecoverableError } = createSubject();
+    callFirst.mockResolvedValue([{ type: 'warn', count: 1 }]);
+    findFloatingPins.mockRejectedValue(new Error('inference failed'));
+
+    await expect(operations.runErc()).resolves.toMatchObject({
+      inferredFloatingPins: [],
+      detailSource: 'native_aggregate_only',
+      warningCount: 1,
+    });
+    expect(logRecoverableError).toHaveBeenCalledWith(
+      'design.erc: floating-pin inference failed',
+      expect.any(Error),
+    );
+  });
+});

--- a/easyeda-bridge-extension/tests/design-rule-check-operations.test.ts
+++ b/easyeda-bridge-extension/tests/design-rule-check-operations.test.ts
@@ -122,6 +122,49 @@ describe('design rule-check operations', () => {
     ]);
   });
 
+  it('ignores object-valued severity and rule fields instead of leaking object stringification', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst.mockResolvedValue([
+      {
+        message: 'safe leaf',
+        level: { unsafe: true },
+        severity: { unsafe: true },
+        rule: { unsafe: true },
+        ruleName: { unsafe: true },
+        ruleTypeName: 'safe-rule',
+      },
+    ]);
+
+    await expect(operations.runDrc()).resolves.toMatchObject({
+      violations: [
+        expect.objectContaining({
+          rule: 'safe-rule',
+          description: 'safe leaf',
+          severity: 'info',
+        }),
+      ],
+    });
+  });
+
+  it('uses only scalar aggregate title values for severity classification', async () => {
+    const { operations, callFirst } = createSubject();
+    callFirst.mockResolvedValue([
+      {
+        type: { unsafe: true },
+        severity: { unsafe: true },
+        title: [{ unsafe: true }, 'WARN', 42],
+        count: 2,
+      },
+    ]);
+
+    await expect(operations.runDrc()).resolves.toMatchObject({
+      totalViolations: 2,
+      warningCount: 2,
+      passed: true,
+      violations: [expect.objectContaining({ severity: 'warning' })],
+    });
+  });
+
   it('handles nested aggregate-only and empty trees, zero counts, and title variants', async () => {
     const { operations, callFirst } = createSubject();
     callFirst.mockResolvedValue([


### PR DESCRIPTION
## Summary

Extracts `design.drc`, `design.erc`, and `design.ruleCheck` from the extension dispatcher into a typed design-rule-check domain module.

This is the twelfth bounded, behavior-preserving delivery slice for #339. It intentionally does **not** close the parent issue; the schematic transaction boundary remains.

## Scope

- Adds `design-rule-check-operations.ts` with narrow native-call, bridge-error, recoverable-log, error-message, and floating-pin dependencies.
- Delegates `design.drc`, `design.erc`, and `design.ruleCheck` from the dispatcher.
- Reuses the same typed schematic check from `schematic.validateNetlist` instead of retaining duplicate normalization logic.
- Preserves native `check(true, true, true)` calls.
- Preserves nested UI-tree and flat aggregate normalization.
- Preserves PCB-first active-canvas fallback for `design.ruleCheck`.
- Preserves stable `CONTEXT_UNAVAILABLE` contracts and cause data.
- Preserves best-effort ERC floating-pin enrichment and failure containment.
- Restricts native severity, rule, title, component, and aggregate fields to scalar values so object-valued runtime data cannot leak `[object Object]` strings.

## Compatibility evidence

- Public extension methods: **67 → 67**.
- Dispatcher source: **3,749 → 3,533 lines** (-216).
- Extracted module: **272 lines**.
- Extracted module coverage: **100% statements / branches / functions / lines**.
- Focused rule-check/domain parity: **110 tests passed**.
- Server suite: **150 files / 1,740 tests passed**.
- Extension suite: **22 files / 260 tests passed**.
- Packaged extension: **163,894 / 200,000 bytes**.
- Extension entry bundle: **223,726 / 260,000 bytes**.
- Dispatcher bundle: **163,312 / 185,000 bytes**.

## Verification

- `pnpm verify`
- `pnpm test:extension:ci`
- extension distribution verification
- extension size budgets
- dependency audit policy

All completed successfully on Node.js 24.18.0 and pnpm 11.5.1. The dependency audit contains only the existing documented #334 advisory exception.

Refs #339
