### PR TITLE
security(deps): remove @hono/node-server advisories

### DIFF
--- a/.github/dependency-audit-allowlist.json
+++ b/.github/dependency-audit-allowlist.json
@@ -1,17 +1,4 @@
 {
   "schemaVersion": 1,
-  "exceptions": [
-    {
-      "advisory": "GHSA-frvp-7c67-39w9",
-      "package": "@hono/node-server",
-      "versions": ["1.19.14"],
-      "severity": "moderate",
-      "owner": "@oaslananka",
-      "reason": "The advisory affects the optional serve-static subpath on Windows. easyeda-mcp-pro does not serve files through @hono/node-server.",
-      "reachability": "@modelcontextprotocol/sdk@1.29.0 imports getRequestListener from the package root for Node.js/Web Standard request conversion. The vulnerable serveStatic implementation is published as the separate @hono/node-server/serve-static export and is not imported by the SDK transport or this repository.",
-      "trackingIssue": 334,
-      "reviewBy": "2026-08-10",
-      "expiresOn": "2026-08-15"
-    }
-  ]
+  "exceptions": []
 }

--- a/docs/adr/0002-dependency-management.md
+++ b/docs/adr/0002-dependency-management.md
@@ -56,8 +56,9 @@ Exceptions are deliberately narrow and fail closed:
 - new, changed, escalated, expired, or stale exceptions fail CI;
 - broad audit suppression flags are not permitted.
 
-The initial exception tracks `GHSA-frvp-7c67-39w9` in #334. The affected Windows path-traversal
-logic belongs to the separate `@hono/node-server/serve-static` export. This repository and
-`@modelcontextprotocol/sdk@1.29.0` use the package-root `getRequestListener` export for HTTP request
-conversion and do not import or configure `serveStatic`. The exception is therefore temporary,
-reviewed on 2026-08-10, and expires on 2026-08-15 while the upstream SDK migration path is tracked.
+The first exception tracked `GHSA-frvp-7c67-39w9` in #334 because the affected Windows
+path-traversal logic was isolated to the separate `@hono/node-server/serve-static` export and the
+repository used only the package-root `getRequestListener` path through
+`@modelcontextprotocol/sdk@1.29.0`. Issue #382 removed that exception after pinning the transitive
+adapter to patched `@hono/node-server@2.0.10` and proving MCP HTTP and Remote Relay compatibility.
+There are currently no active dependency-audit exceptions.

--- a/docs/development/security-tooling.md
+++ b/docs/development/security-tooling.md
@@ -121,12 +121,11 @@ must name the affected package and resolved version, document reachability, link
 and include both review and expiry dates. Unexpected, changed, escalated, expired, or stale entries
 fail closed.
 
-The current `GHSA-frvp-7c67-39w9` exception is limited to
-`@hono/node-server@1.19.14`. The advisory affects the separate
-`@hono/node-server/serve-static` Windows file-serving implementation. The MCP SDK imports only
-`getRequestListener` from the package root, and easyeda-mcp-pro does not expose static file serving
-through Hono. Issue #334 owns upstream remediation; the exception must be reviewed by 2026-08-10
-and is automatically rejected after 2026-08-15.
+There are currently no active dependency-audit exceptions. The former
+`GHSA-frvp-7c67-39w9` exception for `@hono/node-server@1.19.14` was removed in #382 after the
+workspace pinned the transitive adapter to patched `@hono/node-server@2.0.10` and the complete MCP
+HTTP, Remote Relay, platform, and security verification matrix passed. The exact override remains
+in `pnpm-workspace.yaml` until the production MCP SDK v1 line publishes a patched dependency range.
 
 ### Scheduled advisory monitoring
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   fast-uri: 3.1.4
   hono: 4.12.31
+  '@hono/node-server': 2.0.10
   body-parser: 2.3.0
   vite: 7.3.5
   '@vitejs/plugin-vue': 6.0.7
@@ -444,9 +445,9 @@ packages:
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.10':
+    resolution: {integrity: sha512-ZcnNVhKTmyDJeg0UlnZjvM73JBsTAuhrH/J4fjwGOw59PwOW51r4J+p6CsKZWXdKSme4MFqU62CZMOsdDrU4CA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: 4.12.31
 
@@ -2690,7 +2691,7 @@ snapshots:
       '@eslint/core': 1.2.1
       levn: 0.4.1
 
-  '@hono/node-server@1.19.14(hono@4.12.31)':
+  '@hono/node-server@2.0.10(hono@4.12.31)':
     dependencies:
       hono: 4.12.31
 
@@ -2729,7 +2730,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.31)
+      '@hono/node-server': 2.0.10(hono@4.12.31)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,7 +5,7 @@ packages:
 allowBuilds:
   esbuild: true
 minimumReleaseAge: 10080
-# Exact-version exceptions for the reviewed security overrides from #333/#334.
+# Exact-version release-age exceptions for reviewed security overrides from #333.
 minimumReleaseAgeExclude:
   - fast-uri@3.1.4
   - hono@4.12.31
@@ -18,6 +18,7 @@ blockExoticSubdeps: true
 overrides:
   fast-uri: 3.1.4
   hono: 4.12.31
+  '@hono/node-server': 2.0.10
   body-parser: 2.3.0
   vite: 7.3.5
   '@vitejs/plugin-vue': 6.0.7

--- a/tests/unit/repository/security-tooling-policy.test.ts
+++ b/tests/unit/repository/security-tooling-policy.test.ts
@@ -84,12 +84,16 @@ describe('repository security tooling policy', () => {
     expect(workspace).toContain('minimumReleaseAgeExclude:');
     expect(workspace).toContain('fast-uri@3.1.4');
     expect(workspace).toContain('hono@4.12.31');
+    expect(workspace).toContain("'@hono/node-server': 2.0.10");
     expect(workspace).toContain('minimumReleaseAgeStrict: true');
     expect(workspace).toContain('minimumReleaseAgeIgnoreMissingTime: false');
     expect(workspace).toContain('trustPolicy: no-downgrade');
     expect(workspace).toContain('trustLockfile: false');
     expect(workspace).toContain('blockExoticSubdeps: true');
     expect(workspace).toContain('body-parser: 2.3.0');
+    const lockfile = readText('pnpm-lock.yaml');
+    expect(lockfile).toContain("'@hono/node-server@2.0.10':");
+    expect(lockfile).not.toContain("'@hono/node-server@1.19.14':");
     expect(readText('.npmrc')).toContain('min-release-age=7');
   });
 
@@ -155,17 +159,7 @@ describe('repository security tooling policy', () => {
       exceptions?: Array<Record<string, unknown>>;
     };
     expect(dependencyAuditAllowlist.schemaVersion).toBe(1);
-    expect(dependencyAuditAllowlist.exceptions).toHaveLength(1);
-    expect(dependencyAuditAllowlist.exceptions?.[0]).toMatchObject({
-      advisory: 'GHSA-frvp-7c67-39w9',
-      package: '@hono/node-server',
-      versions: ['1.19.14'],
-      severity: 'moderate',
-      owner: '@oaslananka',
-      trackingIssue: 334,
-      reviewBy: '2026-08-10',
-      expiresOn: '2026-08-15',
-    });
+    expect(dependencyAuditAllowlist.exceptions).toEqual([]);
   });
 
   it('runs a least-privilege scheduled dependency advisory monitor', () => {


### PR DESCRIPTION
## Summary

- pin the MCP SDK's transitive `@hono/node-server` dependency to patched `2.0.10`;
- remove the temporary `GHSA-frvp-7c67-39w9` audit exception;
- update repository policy tests and dependency-security documentation.

## Security rationale

The initially advertised path-traversal fix begins at `2.0.5`, but versions `2.0.0` through `2.0.9` are affected by `GHSA-9mqv-5hh9-4cgg`, an aborted-WebSocket-handshake memory-leak DoS. `2.0.10` is the first release that clears both advisories while satisfying the repository's seven-day minimum release-age policy.

`@modelcontextprotocol/sdk@1.29.0` still declares `@hono/node-server@^1.19.9`, so the remediation uses the existing exact pnpm override mechanism. Compatibility is demonstrated rather than assumed across the package-root HTTP adapter, Streamable HTTP transport, Remote Relay, and full repository test suites.

## Dependency diff

- `@hono/node-server`: `1.19.14` → `2.0.10`
- active dependency-audit exceptions: `1` → `0`
- unrelated dependency records: unchanged

## Verification

Executed with Node.js `24.18.0` and pnpm `11.5.1`:

- dependency policy tests: 2 files / 18 tests passed;
- HTTP and Remote Relay regression suite: 13 files / 118 tests passed;
- direct MCP Streamable HTTP transport import: passed;
- `pnpm security:audit`: passed with no advisories;
- `pnpm verify`:
  - server: 155 files / 1,764 tests passed;
  - extension: 23 files / 313 tests passed;
  - formatting, type checking, linting, builds, packaging, metadata, secret hygiene, and docs passed;
- `pnpm pack --dry-run`: passed;
- `git diff --check`: passed.

## Risk and rollback

This crosses a transitive dependency major-version boundary. The focused and full transport suites cover the consumed adapter path, while the GitHub platform matrix will repeat verification on Linux, macOS, and Windows. Rollback is a revert of this PR plus restoration of the exact time-bounded exception only if a verified compatibility regression is discovered.

Closes #382