### PR TITLE
ci(security): expose Scorecard CI evidence

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -19,6 +19,9 @@ jobs:
       id-token: write
       contents: read
       actions: read
+      checks: read
+      pull-requests: read
+      issues: read
 
     steps:
       # actions/checkout v6.0.3

--- a/docs/development/security-tooling.md
+++ b/docs/development/security-tooling.md
@@ -19,6 +19,11 @@ OCI image pinned to its manifest SHA-256 digest, and pre-commit is installed fro
 `pip-compile --generate-hashes`; review both the resolved versions and hashes in the same pull
 request.
 
+The Scorecard job grants read-only access to actions, checks, pull requests, issues, and repository
+contents so the scanner can verify pre-merge test execution and maintenance evidence. Its only write
+permissions are `security-events: write` for SARIF publication and `id-token: write` for signed
+Scorecard result publication.
+
 GitHub secret scanning and push protection are enabled for the public repository. Validity checks,
 non-provider patterns, and repository custom patterns are not available for the current user-owned
 public repository; the verified state and compensating controls are documented in

--- a/tests/unit/repository/security-tooling-policy.test.ts
+++ b/tests/unit/repository/security-tooling-policy.test.ts
@@ -217,6 +217,21 @@ describe('repository security tooling policy', () => {
     expect(guide).toContain('dependency-audit-report');
   });
 
+  it('gives Scorecard the read permissions needed to verify CI and repository activity', () => {
+    const workflow = readText('.github/workflows/scorecard.yml');
+
+    expect(workflow).toContain('checks: read');
+    expect(workflow).toContain('pull-requests: read');
+    expect(workflow).toContain('issues: read');
+    expect(workflow).toContain('actions: read');
+    expect(workflow).toContain('contents: read');
+    expect(workflow).toContain('security-events: write');
+    expect(workflow).toContain('id-token: write');
+    expect(workflow).not.toContain('contents: write');
+    expect(workflow).not.toContain('pull-requests: write');
+    expect(workflow).not.toContain('checks: write');
+  });
+
   it('hardens CI, release, documentation, and container dependency installation', () => {
     const ciWorkflow = readText('.github/workflows/ci.yml');
     const docsWorkflow = readText('.github/workflows/deploy-docs.yml');


### PR DESCRIPTION
## Summary

Gives the OpenSSF Scorecard job the read-only GitHub permissions needed to inspect check runs, pull requests, issues, actions, and repository contents. This addresses the current CI-Tests evidence blind spot without granting additional mutation authority.

## Changes

- add `checks: read`, `pull-requests: read`, and `issues: read` to the Scorecard job;
- preserve the existing least-privilege write permissions (`security-events: write`, `id-token: write`);
- add repository-policy tests preventing broader write access;
- document the permission rationale and boundary.

## Validation

- `pnpm verify`: passed;
- server: 155 files / 1,765 tests passed;
- extension: 23 files / 313 tests passed;
- dependency audit: no advisories;
- pre-commit all files, Actionlint, and Zizmor: passed.

## Risk

Low. The workflow gains only read permissions. Rollback is a direct revert of this PR.

Closes #386