### PR TITLE
fix(pcb): fail closed for unverified zone creation

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -46,7 +46,7 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_pcb_add_text`                             | `full`  | `medium` | Place a text primitive on a PCB layer (typically Top/Bottom Silkscreen) — reference labels, section titles, assembly notes. Signature recovered from PCB_PrimitiveString: fontFamily must be a name the runtime's font list actually contains — "NotoSansMonoCJKsc-Regular" (the default) is live-verified to work.              |
 | `easyeda_pcb_add_track`                            | `full`  | `high`   | Draw a copper track/trace on the PCB board. A multi-point path is written as one line segment per consecutive point pair (all sharing netName, so they form one electrical track — same coordinate/name merge model as schematic wires).                                                                                         |
 | `easyeda_pcb_add_via`                              | `full`  | `high`   | Place a via to connect different copper layers on the PCB board. outerDiameter/holeSize are passed through to the native API unconverted (same native unit as x/y) — their real-world scale was not independently verified against a known physical dimension, so confirm the resulting via size visually before trusting it.    |
-| `easyeda_pcb_add_zone`                             | `full`  | `high`   | Create a copper pour zone on a layer with clearance settings. CAUTION: the native create() call needs 9 args but this tool sends only 4 (points, layer, netName, clearance) — live-confirmed mismatch, not yet resolved. Verify visually before trusting it.                                                                     |
+| `easyeda_pcb_add_zone`                             | `full`  | `high`   | PCB copper-zone creation is unavailable because the verified EasyEDA Pro runtime requires a complete native argument contract that this integration has not yet recovered. This tool fails closed and does not call the bridge.                                                                                                  |
 | `easyeda_pcb_autoroute`                            | `pro`   | `high`   | Drive EasyEDA Pro's native autorouter (PCB_Document.autoRouting, a @beta API) after a pre-flight constraint check, then run DRC and a constraint report before reporting success. Never reports success without that evidence attached (confirmWrite required).                                                                  |
 | `easyeda_pcb_components`                           | `core`  | `low`    | List components placed on the active PCB layout: primitiveId, designator, footprint identity, position/rotation/layer. Requires a focused PCB tab in EasyEDA Pro — returns an empty list (not an error) if none is active.                                                                                                       |
 | `easyeda_pcb_constraint_check`                     | `core`  | `low`    | Run PCB constraint validation against the board design. Checks board outline, layer stackup, net classes, clearance rules, keepout areas, placement zones, mounting holes, fiducials, and manufacturing constraints.                                                                                                             |
@@ -1366,7 +1366,7 @@ Returns a JSON object matching the schema:
 
 **Profile:** `full` | **Risk Level:** `high`
 
-> Create a copper pour zone on a layer with clearance settings. CAUTION: the native create() call needs 9 args but this tool sends only 4 (points, layer, netName, clearance) — live-confirmed mismatch, not yet resolved. Verify visually before trusting it.
+> PCB copper-zone creation is unavailable because the verified EasyEDA Pro runtime requires a complete native argument contract that this integration has not yet recovered. This tool fails closed and does not call the bridge.
 
 ### Input Parameters
 
@@ -1385,8 +1385,9 @@ Returns a JSON object matching the schema:
 ```ts
 {
   success: boolean;
-  primitiveId: string(optional);
+  not_available: boolean(optional);
   error: string(optional);
+  remediation: string(optional);
 }
 ```
 

--- a/easyeda-bridge-extension/src/pcb-mutation-operations.ts
+++ b/easyeda-bridge-extension/src/pcb-mutation-operations.ts
@@ -16,16 +16,16 @@ export interface PcbMutationOperations {
   }>;
 }
 
+async function rejectUnverifiedZoneCreation(_params: Record<string, unknown>): Promise<unknown> {
+  throw new Error(
+    'PCB copper-zone creation is unavailable until the complete native contract is verified.',
+  );
+}
+
 export function createPcbMutationOperations({
   callFirst,
   deletePrimitives,
 }: PcbMutationOperationDependencies): PcbMutationOperations {
-  async function addZone(_params: Record<string, unknown>): Promise<unknown> {
-    throw new Error(
-      'PCB copper-zone creation is unavailable until the complete native contract is verified.',
-    );
-  }
-
   async function modifyComponent(params: Record<string, unknown>): Promise<unknown> {
     return callFirst(
       ['PCB_PrimitiveComponent.modify', 'pcb_PrimitiveComponent.modify'],
@@ -50,5 +50,5 @@ export function createPcbMutationOperations({
     };
   }
 
-  return { addZone, modifyComponent, deleteComponents };
+  return { addZone: rejectUnverifiedZoneCreation, modifyComponent, deleteComponents };
 }

--- a/easyeda-bridge-extension/src/pcb-mutation-operations.ts
+++ b/easyeda-bridge-extension/src/pcb-mutation-operations.ts
@@ -20,13 +20,9 @@ export function createPcbMutationOperations({
   callFirst,
   deletePrimitives,
 }: PcbMutationOperationDependencies): PcbMutationOperations {
-  async function addZone(params: Record<string, unknown>): Promise<unknown> {
-    return callFirst(
-      ['PCB_PrimitivePour.create', 'PCB_ComplexPolygon.create', 'pcb_PrimitivePour.create'],
-      params.points,
-      params.layer,
-      params.netName,
-      params.clearance,
+  async function addZone(_params: Record<string, unknown>): Promise<unknown> {
+    throw new Error(
+      'PCB copper-zone creation is unavailable until the complete native contract is verified.',
     );
   }
 

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -1487,7 +1487,7 @@ describe('createDispatcher', () => {
     ).rejects.toMatchObject({ code: 'INVALID_PARAMS' });
   });
 
-  it('routes PCB zone creation and component modification through the extracted mutation domain', async () => {
+  it('fails closed for PCB zone creation while preserving component modification', async () => {
     const create = vi.fn(async () => ({ primitiveId: 'zone1' }));
     const modify = vi.fn(async () => ({ primitiveId: 'component1' }));
     const dispatcher = createDispatcher(
@@ -1496,24 +1496,27 @@ describe('createDispatcher', () => {
         PCB_PrimitiveComponent: { modify },
       }),
     );
-    const points = [
-      { x: 10, y: 20 },
-      { x: 30, y: 40 },
-    ];
     const property = { x: 50, y: 60, rotation: 90 };
 
-    await dispatcher.dispatch('pcb.addZone', {
-      points,
-      layer: 1,
-      netName: 'GND',
-      clearance: 0.2,
-    });
+    await expect(
+      dispatcher.dispatch('pcb.addZone', {
+        points: [
+          { x: 10, y: 20 },
+          { x: 30, y: 40 },
+        ],
+        layer: 1,
+        netName: 'GND',
+        clearance: 0.2,
+      }),
+    ).rejects.toThrow(
+      'PCB copper-zone creation is unavailable until the complete native contract is verified.',
+    );
     await dispatcher.dispatch('pcb.modifyComponent', {
       primitiveId: 'component1',
       property,
     });
 
-    expect(create).toHaveBeenCalledWith(points, 1, 'GND', 0.2);
+    expect(create).not.toHaveBeenCalled();
     expect(modify).toHaveBeenCalledWith('component1', property);
   });
 

--- a/easyeda-bridge-extension/tests/pcb-mutation-operations.test.ts
+++ b/easyeda-bridge-extension/tests/pcb-mutation-operations.test.ts
@@ -17,24 +17,20 @@ function createOperations() {
 }
 
 describe('createPcbMutationOperations', () => {
-  it('creates zones with the existing EasyEDA path order and arguments', async () => {
+  it('fails closed for zone creation without invoking a native method', async () => {
     const { callFirst, operations } = createOperations();
-    const params = {
-      points: [0, 0, 10, 0, 10, 10],
-      layer: 1,
-      netName: 'GND',
-      clearance: 0.2,
-    };
 
-    await operations.addZone(params);
-
-    expect(callFirst).toHaveBeenCalledWith(
-      ['PCB_PrimitivePour.create', 'PCB_ComplexPolygon.create', 'pcb_PrimitivePour.create'],
-      params.points,
-      params.layer,
-      params.netName,
-      params.clearance,
+    await expect(
+      operations.addZone({
+        points: [0, 0, 10, 0, 10, 10],
+        layer: 1,
+        netName: 'GND',
+        clearance: 0.2,
+      }),
+    ).rejects.toThrow(
+      'PCB copper-zone creation is unavailable until the complete native contract is verified.',
     );
+    expect(callFirst).not.toHaveBeenCalled();
   });
 
   it('modifies components with the existing primitive id and property order', async () => {

--- a/src/tools/L1_pcb_write.ts
+++ b/src/tools/L1_pcb_write.ts
@@ -476,17 +476,17 @@ function registerPcbWriteTools(
 
   registry.register({
     name: 'easyeda_pcb_add_zone',
-    title: 'Add PCB copper zone/pour',
+    title: 'Add PCB copper zone/pour (unavailable)',
     description:
-      'Create a copper pour zone on a layer with clearance settings. CAUTION: the native ' +
-      'create() call needs 9 args but this tool sends only 4 (points, layer, netName, ' +
-      'clearance) — live-confirmed mismatch, not yet resolved. Verify visually before trusting it.',
+      'PCB copper-zone creation is unavailable because the verified EasyEDA Pro runtime requires ' +
+      'a complete native argument contract that this integration has not yet recovered. This tool ' +
+      'fails closed and does not call the bridge.',
     profile: 'full',
-    evidence: ['inferred'],
+    evidence: ['runtime-probe'],
     risk: 'high',
     confirmWrite: true,
     group: 'pcb-write',
-    version: '1.0.0',
+    version: '2.0.0',
     annotations: {
       readOnlyHint: false,
       destructiveHint: false,
@@ -502,40 +502,17 @@ function registerPcbWriteTools(
     }),
     outputSchema: z.object({
       success: z.boolean(),
-      primitiveId: z.string().optional(),
+      not_available: z.boolean().optional(),
       error: z.string().optional(),
+      remediation: z.string().optional(),
     }),
-    handler: async (ctx: ToolContext, params: unknown) => {
-      const p = params as {
-        points: Array<{ x: number; y: number }>;
-        layer: number;
-        netName?: string;
-        clearance?: number;
-      };
-      try {
-        const flatPoints = p.points.flatMap((pt) => [pt.x, pt.y]);
-        const result = await ctx.bridge.call<
-          Record<string, unknown>,
-          { primitiveId?: string; result?: string }
-        >('pcb.addZone', {
-          points: flatPoints,
-          layer: p.layer,
-          netName: p.netName,
-          clearance: p.clearance,
-        });
-        const data = result as { primitiveId?: string; result?: string } | string;
-        return {
-          success: true,
-          primitiveId:
-            typeof data === 'string' ? data : (data?.primitiveId ?? data?.result ?? undefined),
-        };
-      } catch (err) {
-        return {
-          success: false,
-          error: err instanceof Error ? err.message : String(err),
-        };
-      }
-    },
+    handler: async () => ({
+      success: false,
+      not_available: true,
+      error: 'PCB copper-zone creation is not supported by the verified EasyEDA Pro runtime.',
+      remediation:
+        'Create or edit the copper zone in EasyEDA Pro manually until the complete native zone-creation contract is live-verified.',
+    }),
   });
 
   registry.register({

--- a/src/tools/L1_pcb_write.ts
+++ b/src/tools/L1_pcb_write.ts
@@ -48,6 +48,46 @@ const failClosedPcbWriteMetadata = {
   'profile' | 'evidence' | 'risk' | 'confirmWrite' | 'group' | 'annotations'
 >;
 
+const failClosedPcbZoneInputSchema = z.object({
+  points: z.array(z.object({ x: z.number(), y: z.number() })),
+  layer: z.number(),
+  netName: z.string().optional(),
+  clearance: z.number().optional(),
+  confirmWrite: z
+    .literal(true)
+    .describe('Must be the literal boolean true (not the string "true") to allow this write.'),
+});
+
+const failClosedPcbZoneOutputSchema = z.object({
+  success: z.boolean(),
+  not_available: z.boolean().optional(),
+  error: z.string().optional(),
+  remediation: z.string().optional(),
+});
+
+const failClosedPcbZoneTool = {
+  name: 'easyeda_pcb_add_zone',
+  title: 'Add PCB copper zone/pour (unavailable)',
+  description:
+    'PCB copper-zone creation is unavailable because the verified EasyEDA Pro runtime requires ' +
+    'a complete native argument contract that this integration has not yet recovered. This tool ' +
+    'fails closed and does not call the bridge.',
+  ...failClosedPcbWriteMetadata,
+  version: '2.0.0',
+  inputSchema: failClosedPcbZoneInputSchema,
+  outputSchema: failClosedPcbZoneOutputSchema,
+  handler: async () => ({
+    success: false,
+    not_available: true,
+    error: 'PCB copper-zone creation is not supported by the verified EasyEDA Pro runtime.',
+    remediation:
+      'Create or edit the copper zone in EasyEDA Pro manually until the complete native zone-creation contract is live-verified.',
+  }),
+} satisfies ToolDefinition<
+  typeof failClosedPcbZoneInputSchema,
+  typeof failClosedPcbZoneOutputSchema
+>;
+
 export async function applyLayoutOperations(
   ctx: ToolContext,
   operations: Array<{ method: string; params: Record<string, unknown> }>,
@@ -489,38 +529,7 @@ function registerPcbWriteTools(
     },
   });
 
-  registry.register({
-    name: 'easyeda_pcb_add_zone',
-    title: 'Add PCB copper zone/pour (unavailable)',
-    description:
-      'PCB copper-zone creation is unavailable because the verified EasyEDA Pro runtime requires ' +
-      'a complete native argument contract that this integration has not yet recovered. This tool ' +
-      'fails closed and does not call the bridge.',
-    ...failClosedPcbWriteMetadata,
-    version: '2.0.0',
-    inputSchema: z.object({
-      points: z.array(z.object({ x: z.number(), y: z.number() })),
-      layer: z.number(),
-      netName: z.string().optional(),
-      clearance: z.number().optional(),
-      confirmWrite: z
-        .literal(true)
-        .describe('Must be the literal boolean true (not the string "true") to allow this write.'),
-    }),
-    outputSchema: z.object({
-      success: z.boolean(),
-      not_available: z.boolean().optional(),
-      error: z.string().optional(),
-      remediation: z.string().optional(),
-    }),
-    handler: async () => ({
-      success: false,
-      not_available: true,
-      error: 'PCB copper-zone creation is not supported by the verified EasyEDA Pro runtime.',
-      remediation:
-        'Create or edit the copper zone in EasyEDA Pro manually until the complete native zone-creation contract is live-verified.',
-    }),
-  });
+  registry.register(failClosedPcbZoneTool);
 
   registry.register({
     name: 'easyeda_pcb_add_text',

--- a/src/tools/L1_pcb_write.ts
+++ b/src/tools/L1_pcb_write.ts
@@ -33,6 +33,21 @@ export const layoutApplyResultSchema = z.object({
   error: z.string().optional(),
 });
 
+const failClosedPcbWriteMetadata = {
+  profile: 'full',
+  evidence: ['runtime-probe'],
+  risk: 'high',
+  confirmWrite: true,
+  group: 'pcb-write',
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+  },
+} satisfies Pick<
+  ToolDefinition,
+  'profile' | 'evidence' | 'risk' | 'confirmWrite' | 'group' | 'annotations'
+>;
+
 export async function applyLayoutOperations(
   ctx: ToolContext,
   operations: Array<{ method: string; params: Record<string, unknown> }>,
@@ -481,16 +496,8 @@ function registerPcbWriteTools(
       'PCB copper-zone creation is unavailable because the verified EasyEDA Pro runtime requires ' +
       'a complete native argument contract that this integration has not yet recovered. This tool ' +
       'fails closed and does not call the bridge.',
-    profile: 'full',
-    evidence: ['runtime-probe'],
-    risk: 'high',
-    confirmWrite: true,
-    group: 'pcb-write',
+    ...failClosedPcbWriteMetadata,
     version: '2.0.0',
-    annotations: {
-      readOnlyHint: false,
-      destructiveHint: false,
-    },
     inputSchema: z.object({
       points: z.array(z.object({ x: z.number(), y: z.number() })),
       layer: z.number(),

--- a/tests/unit/tools/pcb-write.test.ts
+++ b/tests/unit/tools/pcb-write.test.ts
@@ -248,9 +248,8 @@ describe('PCB Write Tools', () => {
     });
   });
 
-  it('easyeda_pcb_add_zone should place a zone', async () => {
+  it('easyeda_pcb_add_zone should fail closed without calling the bridge', async () => {
     const tool = registry.get('easyeda_pcb_add_zone');
-    bridgeCall.mockResolvedValue('zone-111');
 
     const result = await tool?.handler(context, {
       points: [
@@ -265,32 +264,14 @@ describe('PCB Write Tools', () => {
       confirmWrite: true,
     });
 
-    expect(bridgeCall).toHaveBeenCalledWith('pcb.addZone', {
-      points: [0, 0, 20, 0, 20, 20, 0, 20],
-      layer: 2,
-      netName: 'GND',
-      clearance: 0.5,
-    });
+    expect(bridgeCall).not.toHaveBeenCalled();
     expect(result).toEqual({
-      success: true,
-      primitiveId: 'zone-111',
+      success: false,
+      not_available: true,
+      error: 'PCB copper-zone creation is not supported by the verified EasyEDA Pro runtime.',
+      remediation:
+        'Create or edit the copper zone in EasyEDA Pro manually until the complete native zone-creation contract is live-verified.',
     });
-  });
-
-  it('easyeda_pcb_add_zone should report bridge errors instead of throwing', async () => {
-    const tool = registry.get('easyeda_pcb_add_zone');
-    bridgeCall.mockRejectedValue(new Error('not_available'));
-
-    const result = await tool?.handler(context, {
-      points: [
-        { x: 0, y: 0 },
-        { x: 20, y: 0 },
-      ],
-      layer: 2,
-      confirmWrite: true,
-    });
-
-    expect(result).toEqual({ success: false, error: 'not_available' });
   });
 
   describe('PCB text and silkscreen write helpers', () => {


### PR DESCRIPTION
## Summary

Fail closed for PCB copper-zone creation at both the MCP tool and EasyEDA bridge layers until the complete native EasyEDA Pro zone-creation contract is recovered and live-verified.

This PR implements the immediate release-blocking safety phase of #471. The issue remains open for the separately gated native-contract recovery, typed schema, read-back verification, transaction, rollback, and live validation work.

## Root cause

The public `easyeda_pcb_add_zone` tool accepted confirmation and reported success while forwarding only four values (`points`, `layer`, `netName`, and `clearance`) to native zone-creation candidates. The source already documented that the verified runtime requires a wider native argument contract.

Confirmation cannot make an incomplete native mutation contract safe. Unit tests were also preserving the unsafe call as the expected behavior.

## Changes

- return a deterministic `not_available` result from `easyeda_pcb_add_zone` without calling the bridge;
- add an actionable manual EasyEDA Pro remediation message;
- reject direct `pcb.addZone` extension calls before any native method is invoked;
- replace success-path tests with fail-closed and no-native-call regression tests;
- preserve unrelated PCB component modification routing;
- regenerate the public tool reference from repository metadata.

## TDD evidence

### RED

Before production changes:

- server regression test failed because `pcb.addZone` was still called;
- extension regression tests failed because the native zone create path still resolved and executed.

### GREEN

After the minimum fail-closed implementation:

- `tests/unit/tools/pcb-write.test.ts`: 21 passed;
- extension mutation and dispatcher tests: 105 passed.

## Full verification

Executed on Node.js `24.18.1` and pnpm `11.5.1`:

```text
pnpm verify
```

Results:

- server: 183 test files / 1,975 tests passed;
- bridge extension: 25 test files / 334 tests passed;
- formatting, TypeScript, ESLint, tool metadata, complexity ratchet, package-script policy, capability docs, and tool coverage passed;
- package artifacts rebuilt and verified; 591 packed files inspected;
- secret hygiene passed across 1,306 tracked files;
- environment and release metadata parity passed;
- EasyEDA compatibility documentation and VitePress build passed.

## Safety and compatibility

- no live PCB zone mutation was attempted;
- no native zone method is called by either supported entry path;
- the existing tool name and input schema remain present so callers receive an explicit limitation rather than an unknown-tool failure;
- re-enablement requires the remaining acceptance criteria in #471 and a separate reviewed change.

## Related work

- References #471
- Release stabilization milestone: `v1.0.0-rc.2 — Security and release stabilization`
- Dependency/security gate failures are tracked independently in #472 and are not suppressed or modified here.