### PR TITLE
refactor: extract live E2E phases

### DIFF
--- a/config/complexity-baseline.json
+++ b/config/complexity-baseline.json
@@ -22,7 +22,7 @@
     "scripts/check-runtime-pins.mjs": [26],
     "scripts/e2e/diag.mjs": [18],
     "scripts/e2e/http.mjs": [75],
-    "scripts/e2e/live.mjs": [150],
+    "scripts/e2e/live.mjs": [55],
     "scripts/generate-easyeda-compatibility.mjs": [16],
     "scripts/generate-tools-doc.ts": [19],
     "scripts/package-script-targets.mjs": [24],

--- a/scripts/e2e/live-phases.mjs
+++ b/scripts/e2e/live-phases.mjs
@@ -1,0 +1,390 @@
+import { extractPinsPayload } from './payloads.mjs';
+
+const DEFAULT_REQUIRED_METHODS = [
+  'schematic.createNetFlag',
+  'schematic.createNetPort',
+  'schematic.connectPinToNet',
+  'schematic.connectPinsByNet',
+  'schematic.validateNetlist',
+  'project.save',
+];
+const DEFAULT_DEVICE_KEYWORDS = ['resistor', 'R_0603', 'R_0805', 'capacitor'];
+
+export async function waitForLiveBridge({
+  toolCall,
+  maxWaitSeconds,
+  sleep,
+  log = console.log,
+  reporter,
+}) {
+  let status = {};
+  const attempts = Math.ceil(maxWaitSeconds / 3);
+  for (let index = 0; index < attempts; index += 1) {
+    try {
+      const { text } = await toolCall('easyeda_bridge_status');
+      const parsed = JSON.parse(text);
+      status = parsed;
+      if (parsed.connected === true) {
+        reporter.ok(
+          'Bridge connected',
+          `version=${parsed.bridge_version || parsed.version || '?'}`,
+        );
+        reporter.capture('bridge status', parsed);
+        return { connected: true, status: parsed };
+      }
+    } catch {}
+    const elapsed = (index + 1) * 3;
+    if (elapsed >= maxWaitSeconds) break;
+    if ((index + 1) % 5 === 0) log(`  ⏳ waiting for bridge... ${elapsed}s elapsed`);
+    await sleep(3000);
+  }
+  return { connected: false, status };
+}
+
+export async function verifyRequiredBridgeMethods({
+  toolCall,
+  capabilities,
+  requiredMethods = DEFAULT_REQUIRED_METHODS,
+  reporter,
+}) {
+  const methodResults = {};
+  for (const method of requiredMethods) {
+    let found = capabilities.includes(method);
+    if (!found) {
+      try {
+        const { text: inventory } = await toolCall('easyeda_api_inventory', { filter: method });
+        if (inventory.includes(method)) found = true;
+      } catch {}
+    }
+    methodResults[method] = found;
+    if (found) reporter.ok(`Bridge method declared: ${method}`);
+    else reporter.fail(`Bridge method: ${method}`, 'not in capabilities');
+  }
+  return methodResults;
+}
+
+export async function discoverActiveDocument({ toolCall, projectId, reporter }) {
+  try {
+    const { text: netsText } = await toolCall('easyeda_schematic_nets', { projectId });
+    const parsed = JSON.parse(netsText);
+    if (!parsed.not_available) {
+      const initialNets = parsed.nets || [];
+      reporter.ok('Active document confirmed', `${initialNets.length} initial nets`);
+      reporter.capture('initial nets', netsText);
+      return true;
+    }
+  } catch {}
+
+  try {
+    const { text: componentText } = await toolCall('easyeda_schematic_components', {
+      projectId,
+      limit: 1,
+    });
+    const parsed = JSON.parse(componentText);
+    if (parsed && !parsed.not_available) {
+      reporter.ok('Active document confirmed via components');
+      return true;
+    }
+  } catch {}
+  return false;
+}
+
+export async function searchValidationDevices({
+  toolCall,
+  reporter,
+  keywords = DEFAULT_DEVICE_KEYWORDS,
+}) {
+  let deviceItems = [];
+  for (const keyword of keywords) {
+    try {
+      const { text } = await toolCall('easyeda_schematic_search_device', {
+        key: keyword,
+        itemsOfPage: 10,
+        page: 1,
+      });
+      const parsed = JSON.parse(text);
+      const devices = parsed.devices || parsed.results || [];
+      if (devices.length > 0) deviceItems = devices;
+      if (deviceItems.length >= 2) break;
+    } catch (error) {
+      reporter.warn('Device search attempt', `${keyword}: ${error.message}`);
+    }
+  }
+  return deviceItems;
+}
+
+function deviceSearchName(device) {
+  return device.title || device.name || '';
+}
+
+function findDeviceBySize(deviceItems, size) {
+  return deviceItems.find((device) => deviceSearchName(device).toLowerCase().includes(size));
+}
+
+function deviceUuid(device) {
+  return device.uuid || device.deviceUUID || device.mp || '';
+}
+
+function deviceLibraryUuid(device) {
+  return device.libraryUuid || device.libraryId || '';
+}
+
+function deviceDisplayName(device, fallbackUuid) {
+  return device.title || device.name || device.display || fallbackUuid;
+}
+
+export function selectValidationDevicePair(deviceItems) {
+  let dev0 = findDeviceBySize(deviceItems, '0603') || deviceItems[0];
+  let dev1 =
+    findDeviceBySize(deviceItems, '0805') ||
+    (deviceItems.length > 1 ? deviceItems[1] : deviceItems[0]);
+  if (dev0 === dev1) dev1 = deviceItems[1] || deviceItems[0];
+
+  const d0Uuid = deviceUuid(dev0);
+  const d0LibraryUuid = deviceLibraryUuid(dev0);
+  const d1Uuid = deviceUuid(dev1);
+  const d1LibraryUuid = deviceLibraryUuid(dev1);
+
+  return {
+    dev0,
+    dev1,
+    d0Uuid,
+    d0LibraryUuid,
+    d1Uuid,
+    d1LibraryUuid,
+    dev0Name: deviceDisplayName(dev0, d0Uuid),
+    dev1Name: deviceDisplayName(dev1, d1Uuid),
+  };
+}
+
+function extractPlacedPrimitiveId(text) {
+  try {
+    return JSON.parse(text).component?.primitiveId || '';
+  } catch {
+    return '';
+  }
+}
+
+async function placeOneComponent({ toolCall, deviceItem, x, label, reporter }) {
+  try {
+    const result = await toolCall('easyeda_schematic_place_component', {
+      deviceItem,
+      x,
+      y: 200,
+      rotation: 0,
+      confirmWrite: true,
+    });
+    reporter.ok(`Placed ${label}`, result.text.slice(0, 200));
+    reporter.capture(`place ${label}`, result.text);
+    return extractPlacedPrimitiveId(result.text);
+  } catch (error) {
+    reporter.fail(`Place ${label}`, error.message);
+    return '';
+  }
+}
+
+function componentReference(component) {
+  return component.reference || component.ref || component.name || '';
+}
+
+function componentPrimitiveId(component) {
+  return component.primitiveId || component.uuid || component.id || '';
+}
+
+function isValidationReference(reference) {
+  return reference.startsWith('E2E_') || reference.startsWith('R');
+}
+
+function recoverIdsFromComponents(components, initialR1PrimId, initialR2PrimId) {
+  let r1PrimId = initialR1PrimId;
+  let r2PrimId = initialR2PrimId;
+  for (const component of components) {
+    if (!isValidationReference(componentReference(component))) continue;
+    const primitiveId = componentPrimitiveId(component);
+    if (!r1PrimId) {
+      r1PrimId = primitiveId;
+      continue;
+    }
+    if (!r2PrimId && primitiveId !== r1PrimId) r2PrimId = primitiveId;
+  }
+  return { r1PrimId, r2PrimId };
+}
+
+async function recoverPlacedPrimitiveIds({ toolCall, projectId, r1PrimId, r2PrimId, reporter }) {
+  if (r1PrimId && r2PrimId) return { r1PrimId, r2PrimId };
+  try {
+    const { text } = await toolCall('easyeda_schematic_components', { projectId, limit: 50 });
+    reporter.capture('components list', text);
+    const parsed = JSON.parse(text);
+    return recoverIdsFromComponents(parsed.components || parsed.results || [], r1PrimId, r2PrimId);
+  } catch (error) {
+    reporter.warn('Component enumeration', error.message);
+    return { r1PrimId, r2PrimId };
+  }
+}
+
+async function readPins({ toolCall, primitiveId, label, reporter }) {
+  try {
+    const { text } = await toolCall('easyeda_schematic_component_pins', { primitiveId });
+    const pins = extractPinsPayload(JSON.parse(text));
+    reporter.ok(
+      `${label} pins`,
+      `${pins.length} pins: ${pins.map((pin) => pin.number || pin.pinNumber || '').join(', ')}`,
+    );
+    return pins;
+  } catch (error) {
+    reporter.warn(`${label} pins`, error.message);
+    return [];
+  }
+}
+
+async function exerciseNativeNoConnect({ toolCall, projectId, r2PrimId, r2Pins, reporter }) {
+  const noConnectPin = r2Pins[0]?.pinNumber || r2Pins[0]?.number;
+  if (!noConnectPin) {
+    reporter.warn('Native No Connect', 'Skipped because no addressable R2 pin was available');
+    return;
+  }
+
+  try {
+    const setResult = await toolCall('easyeda_schematic_set_pin_no_connect', {
+      projectId,
+      primitiveId: r2PrimId,
+      pinNumber: String(noConnectPin),
+      noConnected: true,
+      confirmWrite: true,
+    });
+    const setPayload = JSON.parse(setResult.text);
+    if (setPayload.no_connected !== true || setPayload.verified !== true) {
+      throw new Error(`set readback was not verified: ${setResult.text}`);
+    }
+    reporter.ok('Set native No Connect', `${r2PrimId}/${noConnectPin}`);
+    reporter.capture('set native no-connect', setResult.text);
+
+    const { text: readText } = await toolCall('easyeda_schematic_component_pins', {
+      primitiveId: r2PrimId,
+    });
+    const readPins = extractPinsPayload(JSON.parse(readText));
+    const readPin = readPins.find(
+      (pin) => String(pin.pinNumber || pin.number || '') === String(noConnectPin),
+    );
+    if (readPin?.noConnected !== true) {
+      throw new Error(`component pin readback did not expose noConnected=true: ${readText}`);
+    }
+    reporter.ok(
+      'Read back native No Connect',
+      `pinPrimitiveId=${readPin.primitiveId || 'unknown'}`,
+    );
+
+    const clearResult = await toolCall('easyeda_schematic_set_pin_no_connect', {
+      projectId,
+      primitiveId: r2PrimId,
+      pinNumber: String(noConnectPin),
+      noConnected: false,
+      confirmWrite: true,
+    });
+    const clearPayload = JSON.parse(clearResult.text);
+    if (clearPayload.no_connected !== false || clearPayload.verified !== true) {
+      throw new Error(`clear readback was not verified: ${clearResult.text}`);
+    }
+    reporter.ok('Clear native No Connect', `${r2PrimId}/${noConnectPin}`);
+    reporter.capture('clear native no-connect', clearResult.text);
+  } catch (error) {
+    reporter.fail('Native No Connect set/readback/clear', error.message);
+  }
+}
+
+export async function placeValidationComponents({ toolCall, projectId, devices, reporter }) {
+  const r1Ref = 'E2E_R1';
+  const r2Ref = 'E2E_R2';
+  let r1PrimId = await placeOneComponent({
+    toolCall,
+    deviceItem: { libraryUuid: devices.d0LibraryUuid, uuid: devices.d0Uuid },
+    x: 100,
+    label: 'R1',
+    reporter,
+  });
+  let r2PrimId = await placeOneComponent({
+    toolCall,
+    deviceItem: { libraryUuid: devices.d1LibraryUuid, uuid: devices.d1Uuid },
+    x: 500,
+    label: 'R2',
+    reporter,
+  });
+
+  ({ r1PrimId, r2PrimId } = await recoverPlacedPrimitiveIds({
+    toolCall,
+    projectId,
+    r1PrimId,
+    r2PrimId,
+    reporter,
+  }));
+  if (!r1PrimId) r1PrimId = r1Ref;
+  if (!r2PrimId) r2PrimId = r2Ref;
+  reporter.ok('Component primitive IDs', `R1=${r1PrimId} R2=${r2PrimId}`);
+
+  await readPins({ toolCall, primitiveId: r1PrimId, label: 'R1', reporter });
+  const r2Pins = await readPins({ toolCall, primitiveId: r2PrimId, label: 'R2', reporter });
+  await exerciseNativeNoConnect({ toolCall, projectId, r2PrimId, r2Pins, reporter });
+
+  return { r1PrimId, r2PrimId, r2Pins, r1Ref, r2Ref };
+}
+
+async function createNetArtifact({
+  toolCall,
+  name,
+  args,
+  resultKey,
+  label,
+  captureLabel,
+  reporter,
+}) {
+  let primitiveId = 'unknown';
+  try {
+    const result = await toolCall(name, args);
+    try {
+      primitiveId = JSON.parse(result.text)[resultKey]?.primitiveId || 'unknown';
+    } catch {}
+    reporter.ok(label, `primitiveId=${primitiveId}`);
+    reporter.capture(captureLabel, result.text);
+  } catch (error) {
+    reporter.fail(label.replace(' TEST_NET', ''), error.message);
+  }
+  return primitiveId;
+}
+
+export async function createValidationNetArtifacts({ toolCall, projectId, netName, reporter }) {
+  const flagPrimId = await createNetArtifact({
+    toolCall,
+    name: 'easyeda_schematic_create_net_flag',
+    args: {
+      projectId,
+      netName,
+      x: 300,
+      y: 100,
+      rotation: 0,
+      confirmWrite: true,
+    },
+    resultKey: 'netFlag',
+    label: 'Create net flag TEST_NET',
+    captureLabel: 'net flag result',
+    reporter,
+  });
+  const portPrimId = await createNetArtifact({
+    toolCall,
+    name: 'easyeda_schematic_create_net_port',
+    args: {
+      projectId,
+      netName,
+      x: 300,
+      y: 300,
+      portType: 'passive',
+      rotation: 0,
+      confirmWrite: true,
+    },
+    resultKey: 'netPort',
+    label: 'Create net port TEST_NET',
+    captureLabel: 'net port result',
+    reporter,
+  });
+  return { flagPrimId, portPrimId };
+}

--- a/scripts/e2e/live.mjs
+++ b/scripts/e2e/live.mjs
@@ -4,9 +4,16 @@
  *
  * Exits: 0=all passed, 1=one or more checks failed
  */
-import { spawnTrackedProcess } from './harness.mjs';
-import { extractPinsPayload } from './payloads.mjs';
-import { createInterface } from 'node:readline';
+import { sleep, startStdioMcpServer } from './harness.mjs';
+import {
+  createValidationNetArtifacts,
+  discoverActiveDocument,
+  placeValidationComponents,
+  searchValidationDevices,
+  selectValidationDevicePair,
+  verifyRequiredBridgeMethods,
+  waitForLiveBridge,
+} from './live-phases.mjs';
 import process from 'node:process';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
@@ -43,35 +50,6 @@ function capture(label, data) {
   );
 }
 
-// ─────── MCP RPC helpers ──────────────────────────────────────────────────
-let reqId = 0;
-const pending = new Map();
-let serverStdin;
-
-function mcpCall(method, params = {}, timeoutMs = CMD_TIMEOUT) {
-  return new Promise((resolve, reject) => {
-    const id = ++reqId;
-    const timer = setTimeout(() => {
-      pending.delete(id);
-      reject(new Error(`TIMEOUT ${method} (${timeoutMs}ms)`));
-    }, timeoutMs);
-    pending.set(id, { resolve, reject, timer });
-    const msg = JSON.stringify({ jsonrpc: '2.0', id, method, params }) + '\n';
-    serverStdin.write(msg);
-  });
-}
-
-async function toolCall(name, args = {}) {
-  const result = await mcpCall('tools/call', { name, arguments: args });
-  const content = result.content || [];
-  const text = content.map((c) => c.text || c?.toString?.() || JSON.stringify(c)).join('\n');
-  return { result, text, isError: result.isError === true };
-}
-
-function wait(ms) {
-  return new Promise((r) => setTimeout(r, ms));
-}
-
 // ─────── Main ─────────────────────────────────────────────────────────────
 async function main() {
   console.log('\n' + '='.repeat(60));
@@ -81,90 +59,39 @@ async function main() {
   // ── Step 1: Start MCP server ───────────────────────────────────────────
   console.log('\u2500\u2500 [1/7] Start MCP Server & Connect Bridge \u2500\u2500\n');
 
-  const serverProcess = spawnTrackedProcess('node', ['dist/index.js'], {
-    cwd: repoRoot,
-    env: {
-      TRANSPORT: 'stdio',
-      LOG_LEVEL: 'silent',
-      TOOL_PROFILE: 'full',
-      BRIDGE_TIMEOUT_MS: '30000',
-    },
-  });
-  const server = serverProcess.child;
-
-  serverStdin = server.stdin;
-  let serverExited = false;
-  server.on('exit', () => {
-    serverExited = true;
-  });
-
-  const rl = createInterface({ input: server.stdout });
-  rl.on('line', (line) => {
-    let parsed;
-    try {
-      parsed = JSON.parse(line);
-    } catch {
-      return;
-    }
-    if (parsed.id && pending.has(parsed.id)) {
-      const { resolve, reject, timer } = pending.get(parsed.id);
-      pending.delete(parsed.id);
-      clearTimeout(timer);
-      if (parsed.error) reject(new Error(parsed.error.message));
-      else resolve(parsed.result);
-    }
-  });
-
-  const stderrLog = [];
-  server.stderr.on('data', (d) => {
-    stderrLog.push(d.toString().trim());
-  });
+  const server = startStdioMcpServer({ cwd: repoRoot, timeoutMs: CMD_TIMEOUT });
+  const { mcpCall, toolCall } = server;
+  const reporter = { ok, fail: fail_, warn, capture };
 
   function shutdown(label) {
-    serverProcess.shutdown(label);
-    serverProcess.detach();
+    server.shutdown(label);
+    server.detach();
   }
 
-  await wait(2000);
-  if (serverExited) {
+  await sleep(2000);
+  if (server.exited) {
     fail_('MCP server start', 'exited immediately');
     shutdown();
     process.exit(1);
   }
   ok('MCP server started');
 
-  // Initialize MCP
   const init = await mcpCall('initialize', {
     protocolVersion: '2025-11-25',
     capabilities: {},
     clientInfo: { name: 'e2e-validator', version: '1.0' },
   });
-  serverStdin.write(JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }) + '\n');
+  server.notifyInitialized();
   const sv = init.serverInfo;
   ok('MCP initialized', `${sv?.name} v${sv?.version} proto=${init.protocolVersion}`);
   capture('server info', init);
 
-  // ── Bridge connection ──────────────────────────────────────────────────
-  let bridgeConnected = false;
-  let bridgeStatusData = {};
-  for (let i = 0; ; i++) {
-    try {
-      const { text } = await toolCall('easyeda_bridge_status');
-      const parsed = JSON.parse(text);
-      bridgeStatusData = parsed;
-      if (parsed.connected === true) {
-        bridgeConnected = true;
-        ok('Bridge connected', `version=${parsed.bridge_version || parsed.version || '?'}`);
-        capture('bridge status', parsed);
-        break;
-      }
-    } catch {}
-    const elapsed = (i + 1) * 3;
-    if (elapsed >= BRIDGE_MAX_WAIT_S) break;
-    if ((i + 1) % 5 === 0) console.log(`  \u23f3 waiting for bridge... ${elapsed}s elapsed`);
-    await wait(3000);
-  }
-
+  const { connected: bridgeConnected, status: bridgeStatusData } = await waitForLiveBridge({
+    toolCall,
+    maxWaitSeconds: BRIDGE_MAX_WAIT_S,
+    sleep,
+    reporter,
+  });
   if (!bridgeConnected) {
     fail_('Bridge connection', `not connected after ${BRIDGE_MAX_WAIT_S}s`);
     shutdown();
@@ -180,72 +107,22 @@ async function main() {
   // ── Phase 2: Runtime Method Verification ──────────────────────────────
   console.log('\n\u2500\u2500 [2/7] Runtime Method Verification \u2500\u2500\n');
 
-  const requiredMethods = [
-    'schematic.createNetFlag',
-    'schematic.createNetPort',
-    'schematic.connectPinToNet',
-    'schematic.connectPinsByNet',
-    'schematic.validateNetlist',
-    'project.save',
-  ];
-
-  const capabilitiesFromBridge = bridgeStatusData.capabilities || [];
-
-  const methodResults = {};
-  for (const method of requiredMethods) {
-    let found = capabilitiesFromBridge.includes(method);
-    // Also check via api_inventory
-    if (!found) {
-      try {
-        const { text: inv } = await toolCall('easyeda_api_inventory', { filter: method });
-        if (inv.includes(method)) found = true;
-      } catch {}
-    }
-    if (found) {
-      methodResults[method] = true;
-      ok(`Bridge method declared: ${method}`);
-    } else {
-      methodResults[method] = false;
-      fail_(`Bridge method: ${method}`, 'not in capabilities');
-    }
-  }
+  await verifyRequiredBridgeMethods({
+    toolCall,
+    capabilities: bridgeStatusData.capabilities || [],
+    reporter,
+  });
 
   // ── Phase 3: Active Document Discovery ─────────────────────────────────
   console.log('\n\u2500\u2500 [3/7] Project Context & Component Search \u2500\u2500\n');
 
   // The bridge doesn't expose projectId. Probe with a sentinel value.
   const PLACEHOLDER_ID = 'active';
-
-  // First try schematic_nets to see if there's an active document
-  let activeDoc = false;
-  try {
-    const { text: netsText } = await toolCall('easyeda_schematic_nets', {
-      projectId: PLACEHOLDER_ID,
-    });
-    const netsParsed = JSON.parse(netsText);
-    if (!netsParsed.not_available) {
-      activeDoc = true;
-      const initialNets = netsParsed.nets || [];
-      ok('Active document confirmed', `${initialNets.length} initial nets`);
-      capture('initial nets', netsText);
-    }
-  } catch {}
-
-  // Fallback: try listComponents
-  if (!activeDoc) {
-    try {
-      const { text: compText } = await toolCall('easyeda_schematic_components', {
-        projectId: PLACEHOLDER_ID,
-        limit: 1,
-      });
-      const compParsed = JSON.parse(compText);
-      if (compParsed && !compParsed.not_available) {
-        activeDoc = true;
-        ok('Active document confirmed via components');
-      }
-    } catch {}
-  }
-
+  const activeDoc = await discoverActiveDocument({
+    toolCall,
+    projectId: PLACEHOLDER_ID,
+    reporter,
+  });
   if (!activeDoc) {
     fail_(
       'Active document',
@@ -255,251 +132,54 @@ async function main() {
     process.exit(1);
   }
 
-  // Search for devices to place
-  let deviceItems = [];
-  for (const keyword of ['resistor', 'R_0603', 'R_0805', 'capacitor']) {
-    try {
-      const { text: dt } = await toolCall('easyeda_schematic_search_device', {
-        key: keyword,
-        itemsOfPage: 10,
-        page: 1,
-      });
-      const d = JSON.parse(dt);
-      const devs = d.devices || d.results || [];
-      if (devs.length > 0) deviceItems = devs;
-      if (deviceItems.length >= 2) break;
-    } catch (e) {
-      warn('Device search attempt', `${keyword}: ${e.message}`);
-    }
-  }
-
+  const deviceItems = await searchValidationDevices({ toolCall, reporter });
   if (deviceItems.length < 2) {
     fail_('Device search', `need 2 devices, found ${deviceItems.length}`);
     shutdown();
     process.exit(1);
   }
-
-  // Pick the first two suitable devices - prefer R_0603 or R_0805
-  let dev0 =
-    deviceItems.find((d) => (d.title || d.name || '').toLowerCase().includes('0603')) ||
-    deviceItems[0];
-  let dev1 =
-    deviceItems.find((d) => (d.title || d.name || '').toLowerCase().includes('0805')) ||
-    (deviceItems.length > 1 ? deviceItems[1] : deviceItems[0]);
-  if (dev0 === dev1) dev1 = deviceItems[1] || deviceItems[0];
-
-  // Extract separate uuid and libraryUuid - SCH_PrimitiveComponent.create requires both
-  const d0_uuid = dev0.uuid || dev0.deviceUUID || dev0.mp || '';
-  const d0_libUuid = dev0.libraryUuid || dev0.libraryId || '';
-  const d1_uuid = dev1.uuid || dev1.deviceUUID || dev1.mp || '';
-  const d1_libUuid = dev1.libraryUuid || dev1.libraryId || '';
-  const dev0Name = dev0.title || dev0.name || dev0.display || d0_uuid;
-  const dev1Name = dev1.title || dev1.name || dev1.display || d1_uuid;
-
-  ok('Search devices', `found "${dev0Name}" & "${dev1Name}"`);
+  const devices = selectValidationDevicePair(deviceItems);
+  ok('Search devices', `found "${devices.dev0Name}" & "${devices.dev1Name}"`);
   capture('device items', {
-    dev0: { uuid: d0_uuid, libraryUuid: d0_libUuid, name: dev0Name, raw: dev0 },
-    dev1: { uuid: d1_uuid, libraryUuid: d1_libUuid, name: dev1Name, raw: dev1 },
+    dev0: {
+      uuid: devices.d0Uuid,
+      libraryUuid: devices.d0LibraryUuid,
+      name: devices.dev0Name,
+      raw: devices.dev0,
+    },
+    dev1: {
+      uuid: devices.d1Uuid,
+      libraryUuid: devices.d1LibraryUuid,
+      name: devices.dev1Name,
+      raw: devices.dev1,
+    },
   });
 
   // ── Phase 4: Place Components ─────────────────────────────────────────
   console.log('\n\u2500\u2500 [4/7] Place Components \u2500\u2500\n');
 
-  const R1_REF = 'E2E_R1';
-  const R2_REF = 'E2E_R2';
-  let r1PrimId = '',
-    r2PrimId = '',
-    r1Result,
-    r2Result;
-
-  try {
-    r1Result = await toolCall('easyeda_schematic_place_component', {
-      deviceItem: { libraryUuid: d0_libUuid, uuid: d0_uuid },
-      x: 100,
-      y: 200,
-      rotation: 0,
-      confirmWrite: true,
-    });
-    ok('Placed R1', r1Result.text.slice(0, 200));
-    capture('place R1', r1Result.text);
-    // Extract primitiveId
-    try {
-      const parsed = JSON.parse(r1Result.text);
-      if (parsed.component?.primitiveId) r1PrimId = parsed.component.primitiveId;
-    } catch {}
-  } catch (err) {
-    fail_('Place R1', err.message);
-  }
-
-  try {
-    r2Result = await toolCall('easyeda_schematic_place_component', {
-      deviceItem: { libraryUuid: d1_libUuid, uuid: d1_uuid },
-      x: 500,
-      y: 200,
-      rotation: 0,
-      confirmWrite: true,
-    });
-    ok('Placed R2', r2Result.text.slice(0, 200));
-    capture('place R2', r2Result.text);
-    try {
-      const parsed = JSON.parse(r2Result.text);
-      if (parsed.component?.primitiveId) r2PrimId = parsed.component.primitiveId;
-    } catch {}
-  } catch (err) {
-    fail_('Place R2', err.message);
-  }
-
-  // Enumerate components to get primitive IDs if not extracted from place result
-  if (!r1PrimId || !r2PrimId) {
-    try {
-      const { text: compText } = await toolCall('easyeda_schematic_components', {
-        projectId: PLACEHOLDER_ID,
-        limit: 50,
-      });
-      capture('components list', compText);
-      const cp = JSON.parse(compText);
-      const comps = cp.components || cp.results || [];
-      for (const c of comps) {
-        const ref = c.reference || c.ref || c.name || '';
-        const pid = c.primitiveId || c.uuid || c.id || '';
-        if (ref.startsWith('E2E_') || ref.startsWith('R')) {
-          if (!r1PrimId) r1PrimId = pid;
-          else if (!r2PrimId && pid !== r1PrimId) r2PrimId = pid;
-        }
-      }
-    } catch (e) {
-      warn('Component enumeration', e.message);
-    }
-  }
-
-  if (!r1PrimId) r1PrimId = R1_REF;
-  if (!r2PrimId) r2PrimId = R2_REF;
-  ok('Component primitive IDs', `R1=${r1PrimId} R2=${r2PrimId}`);
-
-  // Also get component pins
-  let r2Pins = [];
-  try {
-    const { text: pins1 } = await toolCall('easyeda_schematic_component_pins', {
-      primitiveId: r1PrimId,
-    });
-    const r1Pins = extractPinsPayload(JSON.parse(pins1));
-    ok(
-      'R1 pins',
-      `${r1Pins.length} pins: ${r1Pins.map((p) => p.number || p.pinNumber || '').join(', ')}`,
-    );
-  } catch (e) {
-    warn('R1 pins', e.message);
-  }
-  try {
-    const { text: pins2 } = await toolCall('easyeda_schematic_component_pins', {
-      primitiveId: r2PrimId,
-    });
-    r2Pins = extractPinsPayload(JSON.parse(pins2));
-    ok(
-      'R2 pins',
-      `${r2Pins.length} pins: ${r2Pins.map((p) => p.number || p.pinNumber || '').join(', ')}`,
-    );
-  } catch (e) {
-    warn('R2 pins', e.message);
-  }
-
-  // Native No Connect set/readback/clear on a disposable test pin.
-  const noConnectPin = r2Pins[0]?.pinNumber || r2Pins[0]?.number;
-  if (noConnectPin) {
-    try {
-      const setResult = await toolCall('easyeda_schematic_set_pin_no_connect', {
-        projectId: PLACEHOLDER_ID,
-        primitiveId: r2PrimId,
-        pinNumber: String(noConnectPin),
-        noConnected: true,
-        confirmWrite: true,
-      });
-      const setPayload = JSON.parse(setResult.text);
-      if (setPayload.no_connected !== true || setPayload.verified !== true) {
-        throw new Error(`set readback was not verified: ${setResult.text}`);
-      }
-      ok('Set native No Connect', `${r2PrimId}/${noConnectPin}`);
-      capture('set native no-connect', setResult.text);
-
-      const { text: readText } = await toolCall('easyeda_schematic_component_pins', {
-        primitiveId: r2PrimId,
-      });
-      const readPins = extractPinsPayload(JSON.parse(readText));
-      const readPin = readPins.find(
-        (pin) => String(pin.pinNumber || pin.number || '') === String(noConnectPin),
-      );
-      if (readPin?.noConnected !== true) {
-        throw new Error(`component pin readback did not expose noConnected=true: ${readText}`);
-      }
-      ok('Read back native No Connect', `pinPrimitiveId=${readPin.primitiveId || 'unknown'}`);
-
-      const clearResult = await toolCall('easyeda_schematic_set_pin_no_connect', {
-        projectId: PLACEHOLDER_ID,
-        primitiveId: r2PrimId,
-        pinNumber: String(noConnectPin),
-        noConnected: false,
-        confirmWrite: true,
-      });
-      const clearPayload = JSON.parse(clearResult.text);
-      if (clearPayload.no_connected !== false || clearPayload.verified !== true) {
-        throw new Error(`clear readback was not verified: ${clearResult.text}`);
-      }
-      ok('Clear native No Connect', `${r2PrimId}/${noConnectPin}`);
-      capture('clear native no-connect', clearResult.text);
-    } catch (err) {
-      fail_('Native No Connect set/readback/clear', err.message);
-    }
-  } else {
-    warn('Native No Connect', 'Skipped because no addressable R2 pin was available');
-  }
+  const {
+    r1PrimId,
+    r2PrimId,
+    r1Ref: R1_REF,
+    r2Ref: R2_REF,
+  } = await placeValidationComponents({
+    toolCall,
+    projectId: PLACEHOLDER_ID,
+    devices,
+    reporter,
+  });
 
   // ── Phase 5: Create TEST_NET Flag & Port ──────────────────────────────
   console.log('\n\u2500\u2500 [5/7] Create TEST_NET \u2691 & \u2690 \u2500\u2500\n');
 
   const TEST_NET = 'TEST_NET';
-  let flagPrimId = 'unknown',
-    portPrimId = 'unknown';
-
-  // Create net flag
-  try {
-    const res = await toolCall('easyeda_schematic_create_net_flag', {
-      projectId: PLACEHOLDER_ID,
-      netName: TEST_NET,
-      x: 300,
-      y: 100,
-      rotation: 0,
-      confirmWrite: true,
-    });
-    try {
-      const parsed = JSON.parse(res.text);
-      flagPrimId = parsed.netFlag?.primitiveId || 'unknown';
-    } catch {}
-    ok('Create net flag TEST_NET', `primitiveId=${flagPrimId}`);
-    capture('net flag result', res.text);
-  } catch (err) {
-    fail_('Create net flag', err.message);
-  }
-
-  // Create net port
-  try {
-    const res = await toolCall('easyeda_schematic_create_net_port', {
-      projectId: PLACEHOLDER_ID,
-      netName: TEST_NET,
-      x: 300,
-      y: 300,
-      portType: 'passive',
-      rotation: 0,
-      confirmWrite: true,
-    });
-    try {
-      const parsed = JSON.parse(res.text);
-      portPrimId = parsed.netPort?.primitiveId || 'unknown';
-    } catch {}
-    ok('Create net port TEST_NET', `primitiveId=${portPrimId}`);
-    capture('net port result', res.text);
-  } catch (err) {
-    fail_('Create net port', err.message);
-  }
+  const { flagPrimId, portPrimId } = await createValidationNetArtifacts({
+    toolCall,
+    projectId: PLACEHOLDER_ID,
+    netName: TEST_NET,
+    reporter,
+  });
 
   // ── Phase 6: Connect Pins & Save ──────────────────────────────────────
   console.log('\n\u2500\u2500 [6/7] Connect Pins & Save \u2500\u2500\n');

--- a/tests/unit/repository/live-e2e-phases.test.ts
+++ b/tests/unit/repository/live-e2e-phases.test.ts
@@ -1,0 +1,581 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  createValidationNetArtifacts,
+  discoverActiveDocument,
+  placeValidationComponents,
+  searchValidationDevices,
+  selectValidationDevicePair,
+  verifyRequiredBridgeMethods,
+  waitForLiveBridge,
+} from '../../../scripts/e2e/live-phases.mjs';
+
+function createReporter() {
+  return {
+    ok: vi.fn(),
+    fail: vi.fn(),
+    warn: vi.fn(),
+    capture: vi.fn(),
+  };
+}
+
+describe('live E2E bounded phases', () => {
+  it('uses the shared stdio harness instead of hand-rolled process/RPC lifecycle code', () => {
+    const livePath = fileURLToPath(new URL('../../../scripts/e2e/live.mjs', import.meta.url));
+    const source = readFileSync(livePath, 'utf8');
+
+    expect(source).toContain('startStdioMcpServer');
+    expect(source).not.toContain('spawnTrackedProcess');
+    expect(source).not.toContain("from 'node:readline'");
+    expect(source).not.toContain('const pending = new Map()');
+  });
+
+  it('returns the connected bridge status without sleeping', async () => {
+    const reporter = createReporter();
+    const toolCall = vi.fn(async () => ({
+      text: JSON.stringify({ connected: true, bridge_version: '9.1.0', capabilities: ['x'] }),
+    }));
+    const sleep = vi.fn(async () => undefined);
+
+    await expect(
+      waitForLiveBridge({ toolCall, maxWaitSeconds: 120, sleep, log: vi.fn(), reporter }),
+    ).resolves.toEqual({
+      connected: true,
+      status: { connected: true, bridge_version: '9.1.0', capabilities: ['x'] },
+    });
+    expect(toolCall).toHaveBeenCalledTimes(1);
+    expect(sleep).not.toHaveBeenCalled();
+    expect(reporter.ok).toHaveBeenCalledWith('Bridge connected', 'version=9.1.0');
+    expect(reporter.capture).toHaveBeenCalledWith(
+      'bridge status',
+      expect.objectContaining({ connected: true }),
+    );
+  });
+
+  it('bounds bridge retries and logs every 15 seconds', async () => {
+    const toolCall = vi
+      .fn()
+      .mockResolvedValueOnce({ text: 'not-json' })
+      .mockResolvedValue({ text: JSON.stringify({ connected: false }) });
+    const sleep = vi.fn(async () => undefined);
+    const log = vi.fn();
+
+    await expect(
+      waitForLiveBridge({
+        toolCall,
+        maxWaitSeconds: 18,
+        sleep,
+        log,
+        reporter: createReporter(),
+      }),
+    ).resolves.toEqual({ connected: false, status: { connected: false } });
+    expect(toolCall).toHaveBeenCalledTimes(6);
+    expect(sleep).toHaveBeenCalledTimes(5);
+    expect(sleep).toHaveBeenCalledWith(3000);
+    expect(log).toHaveBeenCalledWith('  ⏳ waiting for bridge... 15s elapsed');
+  });
+
+  it('verifies required methods from capabilities and inventory fallback', async () => {
+    const reporter = createReporter();
+    const toolCall = vi
+      .fn()
+      .mockResolvedValueOnce({ text: 'inventory includes schematic.createNetPort' })
+      .mockResolvedValueOnce({ text: 'nothing useful' });
+
+    await expect(
+      verifyRequiredBridgeMethods({
+        toolCall,
+        capabilities: ['schematic.createNetFlag'],
+        requiredMethods: [
+          'schematic.createNetFlag',
+          'schematic.createNetPort',
+          'schematic.validateNetlist',
+        ],
+        reporter,
+      }),
+    ).resolves.toEqual({
+      'schematic.createNetFlag': true,
+      'schematic.createNetPort': true,
+      'schematic.validateNetlist': false,
+    });
+    expect(toolCall).toHaveBeenCalledTimes(2);
+    expect(reporter.ok).toHaveBeenCalledTimes(2);
+    expect(reporter.fail).toHaveBeenCalledWith(
+      'Bridge method: schematic.validateNetlist',
+      'not in capabilities',
+    );
+  });
+
+  it('treats an inventory error as a missing required method', async () => {
+    const reporter = createReporter();
+    const toolCall = vi.fn(async () => {
+      throw new Error('inventory unavailable');
+    });
+
+    await expect(
+      verifyRequiredBridgeMethods({
+        toolCall,
+        capabilities: [],
+        requiredMethods: ['project.save'],
+        reporter,
+      }),
+    ).resolves.toEqual({ 'project.save': false });
+    expect(reporter.fail).toHaveBeenCalledWith(
+      'Bridge method: project.save',
+      'not in capabilities',
+    );
+  });
+
+  it('discovers an active document from nets and captures initial net evidence', async () => {
+    const reporter = createReporter();
+    const toolCall = vi.fn(async () => ({
+      text: JSON.stringify({ nets: [{ netName: 'GND' }] }),
+    }));
+
+    await expect(discoverActiveDocument({ toolCall, projectId: 'active', reporter })).resolves.toBe(
+      true,
+    );
+    expect(toolCall).toHaveBeenCalledTimes(1);
+    expect(reporter.ok).toHaveBeenCalledWith('Active document confirmed', '1 initial nets');
+    expect(reporter.capture).toHaveBeenCalledWith('initial nets', expect.any(String));
+  });
+
+  it('falls back to components when net discovery is unavailable', async () => {
+    const reporter = createReporter();
+    const toolCall = vi
+      .fn()
+      .mockResolvedValueOnce({ text: JSON.stringify({ not_available: true }) })
+      .mockResolvedValueOnce({ text: JSON.stringify({ components: [] }) });
+
+    await expect(discoverActiveDocument({ toolCall, projectId: 'active', reporter })).resolves.toBe(
+      true,
+    );
+    expect(toolCall).toHaveBeenNthCalledWith(2, 'easyeda_schematic_components', {
+      projectId: 'active',
+      limit: 1,
+    });
+    expect(reporter.ok).toHaveBeenCalledWith('Active document confirmed via components');
+  });
+
+  it('returns false when both active-document probes fail', async () => {
+    const toolCall = vi.fn(async () => {
+      throw new Error('no active document');
+    });
+
+    await expect(
+      discoverActiveDocument({ toolCall, projectId: 'active', reporter: createReporter() }),
+    ).resolves.toBe(false);
+    expect(toolCall).toHaveBeenCalledTimes(2);
+  });
+
+  it('searches live device keywords in order and warns on recoverable errors', async () => {
+    const reporter = createReporter();
+    const first = { uuid: 'one' };
+    const second = { uuid: 'two' };
+    const toolCall = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('search unavailable'))
+      .mockResolvedValueOnce({ text: JSON.stringify({ devices: [first] }) })
+      .mockResolvedValueOnce({ text: JSON.stringify({ results: [first, second] }) });
+
+    await expect(searchValidationDevices({ toolCall, reporter })).resolves.toEqual([first, second]);
+    expect(toolCall).toHaveBeenNthCalledWith(1, 'easyeda_schematic_search_device', {
+      key: 'resistor',
+      itemsOfPage: 10,
+      page: 1,
+    });
+    expect(toolCall).toHaveBeenNthCalledWith(3, 'easyeda_schematic_search_device', {
+      key: 'R_0805',
+      itemsOfPage: 10,
+      page: 1,
+    });
+    expect(reporter.warn).toHaveBeenCalledWith(
+      'Device search attempt',
+      'resistor: search unavailable',
+    );
+  });
+
+  it('prefers 0603 and 0805 devices and normalizes device identifiers', () => {
+    const devices = [
+      { title: 'Generic', uuid: 'g', libraryUuid: 'lg' },
+      { title: 'R_0805', deviceUUID: 'u8', libraryId: 'l8' },
+      { title: 'R_0603', mp: 'u6', libraryUuid: 'l6' },
+    ];
+
+    expect(selectValidationDevicePair(devices)).toEqual({
+      dev0: devices[2],
+      dev1: devices[1],
+      d0Uuid: 'u6',
+      d0LibraryUuid: 'l6',
+      d1Uuid: 'u8',
+      d1LibraryUuid: 'l8',
+      dev0Name: 'R_0603',
+      dev1Name: 'R_0805',
+    });
+  });
+
+  it('keeps two distinct fallback devices when preferred names are absent', () => {
+    const devices = [
+      { name: 'A', uuid: 'a' },
+      { display: 'B', uuid: 'b' },
+    ];
+    const selected = selectValidationDevicePair(devices);
+    expect(selected.dev0).toBe(devices[0]);
+    expect(selected.dev1).toBe(devices[1]);
+    expect(selected.dev0Name).toBe('A');
+    expect(selected.dev1Name).toBe('B');
+  });
+
+  it('places components, reads pins, and verifies native no-connect set/readback/clear', async () => {
+    const reporter = createReporter();
+    const responses = [
+      { text: JSON.stringify({ component: { primitiveId: 'r1-id' } }) },
+      { text: JSON.stringify({ component: { primitiveId: 'r2-id' } }) },
+      { text: JSON.stringify({ pins: [{ pinNumber: '1' }, { pinNumber: '2' }] }) },
+      { text: JSON.stringify({ pins: [{ pinNumber: '1', primitiveId: 'pin-1' }] }) },
+      { text: JSON.stringify({ no_connected: true, verified: true }) },
+      {
+        text: JSON.stringify({
+          pins: [{ pinNumber: '1', primitiveId: 'pin-1', noConnected: true }],
+        }),
+      },
+      { text: JSON.stringify({ no_connected: false, verified: true }) },
+    ];
+    const toolCall = vi.fn(async () => responses.shift()!);
+
+    await expect(
+      placeValidationComponents({
+        toolCall,
+        projectId: 'active',
+        devices: {
+          d0Uuid: 'u0',
+          d0LibraryUuid: 'l0',
+          d1Uuid: 'u1',
+          d1LibraryUuid: 'l1',
+        },
+        reporter,
+      }),
+    ).resolves.toEqual({
+      r1PrimId: 'r1-id',
+      r2PrimId: 'r2-id',
+      r2Pins: [{ pinNumber: '1', primitiveId: 'pin-1' }],
+      r1Ref: 'E2E_R1',
+      r2Ref: 'E2E_R2',
+    });
+    expect(toolCall).toHaveBeenCalledWith(
+      'easyeda_schematic_set_pin_no_connect',
+      expect.objectContaining({ primitiveId: 'r2-id', pinNumber: '1', noConnected: true }),
+    );
+    expect(toolCall).toHaveBeenCalledWith(
+      'easyeda_schematic_set_pin_no_connect',
+      expect.objectContaining({ primitiveId: 'r2-id', pinNumber: '1', noConnected: false }),
+    );
+    expect(reporter.fail).not.toHaveBeenCalled();
+  });
+
+  it('recovers primitive IDs from component enumeration when placement responses omit them', async () => {
+    const reporter = createReporter();
+    const responses = [
+      { text: '{}' },
+      { text: '{}' },
+      {
+        text: JSON.stringify({
+          components: [
+            { reference: 'R1', primitiveId: 'enum-1' },
+            { reference: 'R2', primitiveId: 'enum-2' },
+          ],
+        }),
+      },
+      { text: JSON.stringify({ pins: [] }) },
+      { text: JSON.stringify({ pins: [] }) },
+    ];
+    const toolCall = vi.fn(async () => responses.shift()!);
+
+    const result = await placeValidationComponents({
+      toolCall,
+      projectId: 'active',
+      devices: { d0Uuid: 'u0', d0LibraryUuid: '', d1Uuid: 'u1', d1LibraryUuid: '' },
+      reporter,
+    });
+
+    expect(result.r1PrimId).toBe('enum-1');
+    expect(result.r2PrimId).toBe('enum-2');
+    expect(reporter.warn).toHaveBeenCalledWith(
+      'Native No Connect',
+      'Skipped because no addressable R2 pin was available',
+    );
+  });
+
+  it('covers bridge version fallbacks and the default logger adapter', async () => {
+    const reporter = createReporter();
+    const sleep = vi.fn(async () => undefined);
+
+    await expect(
+      waitForLiveBridge({
+        toolCall: vi.fn(async () => ({
+          text: JSON.stringify({ connected: true, version: '2.0' }),
+        })),
+        maxWaitSeconds: 3,
+        sleep,
+        reporter,
+      }),
+    ).resolves.toMatchObject({ connected: true });
+    expect(reporter.ok).toHaveBeenCalledWith('Bridge connected', 'version=2.0');
+
+    const unknownReporter = createReporter();
+    await waitForLiveBridge({
+      toolCall: vi.fn(async () => ({ text: JSON.stringify({ connected: true }) })),
+      maxWaitSeconds: 3,
+      sleep,
+      reporter: unknownReporter,
+    });
+    expect(unknownReporter.ok).toHaveBeenCalledWith('Bridge connected', 'version=?');
+  });
+
+  it('uses the default required-method set without inventory calls when capabilities are complete', async () => {
+    const reporter = createReporter();
+    const toolCall = vi.fn();
+    const capabilities = [
+      'schematic.createNetFlag',
+      'schematic.createNetPort',
+      'schematic.connectPinToNet',
+      'schematic.connectPinsByNet',
+      'schematic.validateNetlist',
+      'project.save',
+    ];
+
+    const result = await verifyRequiredBridgeMethods({ toolCall, capabilities, reporter });
+
+    expect(Object.keys(result)).toEqual(capabilities);
+    expect(Object.values(result)).toEqual(capabilities.map(() => true));
+    expect(toolCall).not.toHaveBeenCalled();
+  });
+
+  it('handles empty active-document payloads and a null component fallback', async () => {
+    const emptyReporter = createReporter();
+    await expect(
+      discoverActiveDocument({
+        toolCall: vi.fn(async () => ({ text: '{}' })),
+        projectId: 'active',
+        reporter: emptyReporter,
+      }),
+    ).resolves.toBe(true);
+    expect(emptyReporter.ok).toHaveBeenCalledWith('Active document confirmed', '0 initial nets');
+
+    const fallbackToolCall = vi
+      .fn()
+      .mockResolvedValueOnce({ text: JSON.stringify({ not_available: true }) })
+      .mockResolvedValueOnce({ text: 'null' });
+    await expect(
+      discoverActiveDocument({
+        toolCall: fallbackToolCall,
+        projectId: 'active',
+        reporter: createReporter(),
+      }),
+    ).resolves.toBe(false);
+  });
+
+  it('returns an empty device set after exhausting empty default-keyword responses', async () => {
+    const toolCall = vi.fn(async () => ({ text: '{}' }));
+
+    await expect(
+      searchValidationDevices({ toolCall, reporter: createReporter() }),
+    ).resolves.toEqual([]);
+    expect(toolCall).toHaveBeenCalledTimes(4);
+  });
+
+  it('normalizes a single sparse device through empty identifier fallbacks', () => {
+    const device = { display: 'Display only' };
+
+    expect(selectValidationDevicePair([device])).toEqual({
+      dev0: device,
+      dev1: device,
+      d0Uuid: '',
+      d0LibraryUuid: '',
+      d1Uuid: '',
+      d1LibraryUuid: '',
+      dev0Name: 'Display only',
+      dev1Name: 'Display only',
+    });
+  });
+
+  it('tolerates placement and pin-read errors while recovering IDs from results aliases', async () => {
+    const reporter = createReporter();
+    let placeCount = 0;
+    let pinCount = 0;
+    const toolCall = vi.fn(async (name: string) => {
+      if (name === 'easyeda_schematic_place_component') {
+        placeCount += 1;
+        if (placeCount === 1) throw new Error('place failed');
+        return { text: 'not-json' };
+      }
+      if (name === 'easyeda_schematic_components') {
+        return {
+          text: JSON.stringify({
+            results: [
+              { ref: 'R_A', uuid: 'enum-a' },
+              { name: 'E2E_B', id: 'enum-b' },
+              { reference: 'IGNORED', primitiveId: 'ignore-me' },
+            ],
+          }),
+        };
+      }
+      if (name === 'easyeda_schematic_component_pins') {
+        pinCount += 1;
+        if (pinCount === 1) throw new Error('pins unavailable');
+        return { text: JSON.stringify({ pins: [{ number: '7' }] }) };
+      }
+      if (name === 'easyeda_schematic_set_pin_no_connect') {
+        return { text: JSON.stringify({ no_connected: false, verified: true }) };
+      }
+      throw new Error(`unexpected tool ${name}`);
+    });
+
+    const result = await placeValidationComponents({
+      toolCall,
+      projectId: 'active',
+      devices: { d0Uuid: 'u0', d0LibraryUuid: '', d1Uuid: 'u1', d1LibraryUuid: '' },
+      reporter,
+    });
+
+    expect(result.r1PrimId).toBe('enum-a');
+    expect(result.r2PrimId).toBe('enum-b');
+    expect(reporter.fail).toHaveBeenCalledWith('Place R1', 'place failed');
+    expect(reporter.warn).toHaveBeenCalledWith('R1 pins', 'pins unavailable');
+    expect(reporter.fail).toHaveBeenCalledWith(
+      'Native No Connect set/readback/clear',
+      expect.stringContaining('set readback was not verified'),
+    );
+  });
+
+  it('falls back to synthetic component refs when placement and enumeration both fail', async () => {
+    const reporter = createReporter();
+    const toolCall = vi.fn(async (name: string) => {
+      if (name === 'easyeda_schematic_place_component') return { text: '{}' };
+      if (name === 'easyeda_schematic_components') throw new Error('enumeration unavailable');
+      if (name === 'easyeda_schematic_component_pins')
+        return { text: JSON.stringify({ pins: [] }) };
+      throw new Error(`unexpected tool ${name}`);
+    });
+
+    const result = await placeValidationComponents({
+      toolCall,
+      projectId: 'active',
+      devices: { d0Uuid: 'u0', d0LibraryUuid: '', d1Uuid: 'u1', d1LibraryUuid: '' },
+      reporter,
+    });
+
+    expect(result.r1PrimId).toBe('E2E_R1');
+    expect(result.r2PrimId).toBe('E2E_R2');
+    expect(reporter.warn).toHaveBeenCalledWith('Component enumeration', 'enumeration unavailable');
+  });
+
+  it('reports a native no-connect readback mismatch', async () => {
+    const reporter = createReporter();
+    const responses = [
+      { text: JSON.stringify({ component: { primitiveId: 'r1' } }) },
+      { text: JSON.stringify({ component: { primitiveId: 'r2' } }) },
+      { text: JSON.stringify({ pins: [] }) },
+      { text: JSON.stringify({ pins: [{ number: '9' }] }) },
+      { text: JSON.stringify({ no_connected: true, verified: true }) },
+      { text: JSON.stringify({ pins: [{ number: '9', noConnected: false }] }) },
+    ];
+    const toolCall = vi.fn(async () => responses.shift()!);
+
+    await placeValidationComponents({
+      toolCall,
+      projectId: 'active',
+      devices: { d0Uuid: 'u0', d0LibraryUuid: '', d1Uuid: 'u1', d1LibraryUuid: '' },
+      reporter,
+    });
+
+    expect(reporter.fail).toHaveBeenCalledWith(
+      'Native No Connect set/readback/clear',
+      expect.stringContaining('component pin readback did not expose noConnected=true'),
+    );
+  });
+
+  it('reports an invalid clear readback and uses the unknown pin primitive marker', async () => {
+    const reporter = createReporter();
+    const responses = [
+      { text: JSON.stringify({ component: { primitiveId: 'r1' } }) },
+      { text: JSON.stringify({ component: { primitiveId: 'r2' } }) },
+      { text: JSON.stringify({ pins: [] }) },
+      { text: JSON.stringify({ pins: [{ number: '9' }] }) },
+      { text: JSON.stringify({ no_connected: true, verified: true }) },
+      { text: JSON.stringify({ pins: [{ number: '9', noConnected: true }] }) },
+      { text: JSON.stringify({ no_connected: true, verified: false }) },
+    ];
+    const toolCall = vi.fn(async () => responses.shift()!);
+
+    await placeValidationComponents({
+      toolCall,
+      projectId: 'active',
+      devices: { d0Uuid: 'u0', d0LibraryUuid: '', d1Uuid: 'u1', d1LibraryUuid: '' },
+      reporter,
+    });
+
+    expect(reporter.ok).toHaveBeenCalledWith(
+      'Read back native No Connect',
+      'pinPrimitiveId=unknown',
+    );
+    expect(reporter.fail).toHaveBeenCalledWith(
+      'Native No Connect set/readback/clear',
+      expect.stringContaining('clear readback was not verified'),
+    );
+  });
+
+  it('keeps unknown net IDs when creation fails or returns a payload without an ID', async () => {
+    const reporter = createReporter();
+    const toolCall = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('flag creation failed'))
+      .mockResolvedValueOnce({ text: '{}' });
+
+    await expect(
+      createValidationNetArtifacts({
+        toolCall,
+        projectId: 'active',
+        netName: 'TEST_NET',
+        reporter,
+      }),
+    ).resolves.toEqual({ flagPrimId: 'unknown', portPrimId: 'unknown' });
+    expect(reporter.fail).toHaveBeenCalledWith('Create net flag', 'flag creation failed');
+    expect(reporter.ok).toHaveBeenCalledWith('Create net port TEST_NET', 'primitiveId=unknown');
+  });
+
+  it('creates TEST_NET flag and port while preserving unknown-id fallbacks', async () => {
+    const reporter = createReporter();
+    const toolCall = vi
+      .fn()
+      .mockResolvedValueOnce({ text: JSON.stringify({ netFlag: { primitiveId: 'flag-1' } }) })
+      .mockResolvedValueOnce({ text: 'not-json' });
+
+    await expect(
+      createValidationNetArtifacts({
+        toolCall,
+        projectId: 'active',
+        netName: 'TEST_NET',
+        reporter,
+      }),
+    ).resolves.toEqual({ flagPrimId: 'flag-1', portPrimId: 'unknown' });
+    expect(toolCall).toHaveBeenNthCalledWith(1, 'easyeda_schematic_create_net_flag', {
+      projectId: 'active',
+      netName: 'TEST_NET',
+      x: 300,
+      y: 100,
+      rotation: 0,
+      confirmWrite: true,
+    });
+    expect(toolCall).toHaveBeenNthCalledWith(2, 'easyeda_schematic_create_net_port', {
+      projectId: 'active',
+      netName: 'TEST_NET',
+      x: 300,
+      y: 300,
+      portType: 'passive',
+      rotation: 0,
+      confirmWrite: true,
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
         'scripts/check-metadata.mjs',
         'scripts/extension-metadata-policy.mjs',
         'scripts/e2e/http-helpers.mjs',
+        'scripts/e2e/live-phases.mjs',
         'scripts/package-artifacts.mjs',
       ],
       exclude: [


### PR DESCRIPTION
Final acceptance slice for #474. This PR intentionally does **not** use `Fixes/Closes #474`; close the issue only after this exact merge SHA passes post-merge health checks.

## Summary
- replace `scripts/e2e/live.mjs` hand-rolled stdio process/JSON-RPC lifecycle with the repository-required `startStdioMcpServer()` harness
- extract bounded live-E2E phases for bridge wait, required-method verification, active-document discovery, device discovery/selection, component placement/ID recovery/pin + native No Connect checks, and TEST_NET flag/port creation
- preserve existing live-write tool names and payloads
- keep Phase 6 (`Connect Pins & Save`) through cleanup/report behavior identical to `main` except whitespace (source parity verified)

## TDD / coverage
RED: the new phase test suite failed because `scripts/e2e/live-phases.mjs` did not yet exist.

GREEN:
- live phase tests: **24/24**
- live phase + shared E2E payload tests: **32/32**
- full server coverage: **188 files / 2023 tests**
- `live-phases.mjs`: **100% statements / 93.75% branches / 100% functions / 100% lines** (`155/155` lines, `105/112` branches)
- touched-file ESLint, Prettier, Node syntax, and repo typecheck passed

## Complexity
- `scripts/e2e/live.mjs` `main()`: **150 → 55**
- new phase-module maximum function complexity: **13**; no new function above 15
- baseline tightens only `scripts/e2e/live.mjs: [150] → [55]`
- repo ratchet: **88 hotspots across 63 files, maximum 76**
- resulting key maxima: dispatcher **76**, HTTP E2E **75**, live E2E **55**
- therefore no repository function remains above #474's maximum-80 criterion

## Full verification
Pinned runtime: Node 24.18.0 / pnpm 11.5.1. On head `e386208b8ba835acfc59f0e008d87e7b68fe9fab`:
- dependency audit passed with no advisories
- `pnpm verify` passed: server **188/2023**, extension **27/355**
- package artifacts and **594-file** pack-list validation passed
- secret hygiene scanned **1305 tracked files**, 0 oversized skipped
- metadata/environment parity, capability/compatibility docs, and VitePress build passed
- `pnpm check:complexity` passed, max **76**
- `git diff --check` passed
- branch was **0/0 divergent** from `origin/main` immediately before commit

## Scope / risk
Exactly five files change: complexity baseline, `live.mjs`, new `live-phases.mjs`, new phase tests, and coverage config. No public API/schema, workflow permission, repository setting, release behavior, or Phase 6+ live-write payload changes.

Risk is medium-low because this moves maintainer live-E2E orchestration, but it uses the existing hardened shared harness, keeps live payloads stable, has direct high-coverage tests, and preserves Phase 6→end source behavior. Rollback is a single squash-commit revert.

## #474 closure handling
This code completes the remaining measured acceptance work. Keep #474 open until the squash merge commit itself passes post-merge CI, Static Security Analysis, Scorecard, and Golden Benchmark; then add the complete before/after evidence and close explicitly.
