### PR TITLE
fix(build): support npm 12 pack JSON shape

### DIFF
--- a/scripts/check-packed-file-list.mjs
+++ b/scripts/check-packed-file-list.mjs
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { verifyPackedFileList } from './package-artifacts.mjs';
+import { extractPackedFilePaths, verifyPackedFileList } from './package-artifacts.mjs';
 
 function nodeGlobalModulePath(packageName, ...segments) {
   const binDirectory = dirname(process.execPath);
@@ -40,9 +40,7 @@ try {
   process.exit(1);
 }
 
-const files = Array.isArray(packResult?.[0]?.files)
-  ? packResult[0].files.map((entry) => entry.path)
-  : [];
+const files = extractPackedFilePaths(packResult);
 const verification = verifyPackedFileList(files);
 if (!verification.ok) {
   console.error(`[package:check-pack-list] FAILED — ${verification.errors.length} error(s)`);

--- a/scripts/package-artifacts.mjs
+++ b/scripts/package-artifacts.mjs
@@ -203,6 +203,20 @@ export async function removeGeneratedPackageArtifacts({ root }) {
   );
 }
 
+export function extractPackedFilePaths(packResult) {
+  const packageEntries = Array.isArray(packResult)
+    ? packResult
+    : packResult && typeof packResult === 'object' && !Array.isArray(packResult)
+      ? Object.values(packResult)
+      : [];
+  if (packageEntries.length !== 1) return [];
+
+  const files = packageEntries[0]?.files;
+  if (!Array.isArray(files)) return [];
+  const paths = files.map((entry) => entry?.path);
+  return paths.every((path) => typeof path === 'string' && path.length > 0) ? paths : [];
+}
+
 export function verifyPackedFileList(files) {
   const normalized = new Set(
     files.map((path) => {

--- a/tests/unit/repository/package-artifacts-policy.test.ts
+++ b/tests/unit/repository/package-artifacts-policy.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { writeChecksumManifest } from '../../../easyeda-bridge-extension/scripts/checksums.mjs';
 import {
   PACKAGE_BUILD_MANIFEST_PATH,
+  extractPackedFilePaths,
   REQUIRED_PACKAGE_FILE_ENTRIES,
   removeGeneratedPackageArtifacts,
   verifyPackageArtifacts,
@@ -279,6 +280,27 @@ describe('package artifact policy', () => {
     ]) {
       await expect(readFile(join(fixture.root, path))).rejects.toThrow();
     }
+  });
+
+  it('extracts packed file paths from npm array and npm 12 keyed-object JSON shapes', () => {
+    const files = ['package.json', 'dist/index.js', 'README.md'];
+    const entries = files.map((path) => ({ path, size: 1, mode: 420 }));
+
+    expect(extractPackedFilePaths([{ files: entries }])).toEqual(files);
+    expect(
+      extractPackedFilePaths({
+        'easyeda-mcp-pro': { files: entries },
+      }),
+    ).toEqual(files);
+  });
+
+  it('fails closed for malformed or ambiguous npm pack JSON shapes', () => {
+    const entry = { files: [{ path: 'package.json' }] };
+
+    expect(extractPackedFilePaths(undefined)).toEqual([]);
+    expect(extractPackedFilePaths({})).toEqual([]);
+    expect(extractPackedFilePaths({ first: entry, second: entry })).toEqual([]);
+    expect(extractPackedFilePaths([{ files: [{ size: 1 }] }])).toEqual([]);
   });
 
   it('requires every runtime and legal artifact in the npm pack file list', () => {


### PR DESCRIPTION
## Summary
- accept both the historical array form and npm 12's package-name keyed object form from `npm pack --dry-run --json`
- keep malformed or ambiguous payloads fail-closed
- add regression coverage for both supported shapes and invalid input

## Reproduction
On the pinned Node.js 24.18.0 runtime, bundled npm 12.0.2 emits a top-level object keyed by `easyeda-mcp-pro`. The existing checker read only `packResult[0].files`, treated the file list as empty, and falsely reported every required packed file missing.

## Verification
- TDD RED: two new parser tests failed because `extractPackedFilePaths` did not exist
- targeted policy suite: 16/16 passed
- Node 24.18.0 / npm 12.0.2 / pnpm 11.5.1 real pack-list: `package:prepare` passed with 594 packed files inspected
- touched ESLint + server typecheck passed
- dependency audit: no known vulnerabilities
- fresh full `pnpm verify`: exit 0, server 188 files / 2026 tests, extension 27 files / 361 tests, complexity max 76, package-list 594 files, secret hygiene/metadata/docs passed

Closes #491
