### PR TITLE
fix(drc): surface focused-document preconditions

### DIFF
--- a/docs/reference/tools.md
+++ b/docs/reference/tools.md
@@ -27,8 +27,8 @@ These tools are profile-gated. Set the `TOOL_PROFILE` environment variable to en
 | `easyeda_catalog_verify_device`                    | `pro`   | `medium` | Resolve an LCSC part number into a catalog device entry (keyless LCSC metadata plus an EasyEDA symbol/footprint reference, if already known locally), validate it, and write it to the local device cache (confirmWrite required). Does NOT verify pin/pad geometry — see docs/catalog-ingestion.md.                             |
 | `easyeda_component_probe`                          | `dev`   | `low`    | Inspect live schematic component objects, including available methods and state getter values, to validate EasyEDA runtime mappings.                                                                                                                                                                                             |
 | `easyeda_design_rules_lookup`                      | `core`  | `low`    | Look up generic engineering reference guidance: IPC-2221 trace-width/current-capacity, clearance bands, protocol routing data (USB/RS-485/I2C/SPI/UART/Ethernet), decoupling recipes and bulk capacitance sizing, and a static DFM checklist. Every result cites a source and caveat: these are estimates, not certified values. |
-| `easyeda_drc_run`                                  | `core`  | `medium` | Run the native design rule check (DRC): same as clicking "Check DRC" in EasyEDA Pro, so the bottom DRC panel opens/refreshes in the user's window as a visible side effect. Returns coarse per-severity counts only — which specific wire/net/component is affected is shown only in EasyEDA Pro's own DRC panel.                |
-| `easyeda_erc_run`                                  | `core`  | `medium` | Run native ERC and supplement its coarse counts with inferred_floating_pins. Only a strict native noConnected=true readback suppresses a pin; unavailable or malformed state remains visible. Native counts remain authoritative for other categories.                                                                           |
+| `easyeda_drc_run`                                  | `core`  | `medium` | Run EasyEDA Pro's native PCB DRC and refresh its visible DRC panel. Requires a PCB document to be focused; otherwise returns an indeterminate not_available result with an actionable focus error. Returns coarse severity counts; per-violation detail stays in EasyEDA Pro.                                                    |
+| `easyeda_erc_run`                                  | `core`  | `medium` | Run EasyEDA Pro's native schematic ERC and supplement coarse counts with inferred_floating_pins. Requires a schematic document to be focused; otherwise returns an indeterminate not_available result with an actionable focus error. Native counts remain authoritative.                                                        |
 | `easyeda_export_gerbers`                           | `core`  | `medium` | Export PCB design to Gerber files for PCB fabrication.                                                                                                                                                                                                                                                                           |
 | `easyeda_export_netlist`                           | `pro`   | `low`    | Export the schematic netlist in a specified EDA tool format (PADS, Allegro, or Altium).                                                                                                                                                                                                                                          |
 | `easyeda_export_pdf`                               | `pro`   | `low`    | Export the schematic and/or board layout to PDF.                                                                                                                                                                                                                                                                                 |
@@ -766,7 +766,7 @@ Returns a JSON object matching the schema:
 
 **Profile:** `core` | **Risk Level:** `medium`
 
-> Run the native design rule check (DRC): same as clicking "Check DRC" in EasyEDA Pro, so the bottom DRC panel opens/refreshes in the user's window as a visible side effect. Returns coarse per-severity counts only — which specific wire/net/component is affected is shown only in EasyEDA Pro's own DRC panel.
+> Run EasyEDA Pro's native PCB DRC and refresh its visible DRC panel. Requires a PCB document to be focused; otherwise returns an indeterminate not_available result with an actionable focus error. Returns coarse severity counts; per-violation detail stays in EasyEDA Pro.
 
 ### Input Parameters
 
@@ -798,7 +798,7 @@ Returns a JSON object matching the schema:
 
 **Profile:** `core` | **Risk Level:** `medium`
 
-> Run native ERC and supplement its coarse counts with inferred_floating_pins. Only a strict native noConnected=true readback suppresses a pin; unavailable or malformed state remains visible. Native counts remain authoritative for other categories.
+> Run EasyEDA Pro's native schematic ERC and supplement coarse counts with inferred_floating_pins. Requires a schematic document to be focused; otherwise returns an indeterminate not_available result with an actionable focus error. Native counts remain authoritative.
 
 ### Input Parameters
 

--- a/easyeda-bridge-extension/src/design-rule-check-operations.ts
+++ b/easyeda-bridge-extension/src/design-rule-check-operations.ts
@@ -207,17 +207,23 @@ export function createDesignRuleCheckOperations(
     return runNative(['SCH_Drc.check']);
   }
 
-  async function runDrc(): Promise<DrcResult> {
+  async function runFocusedNative(
+    paths: string[],
+    document: string,
+    method: string,
+  ): Promise<DrcResult> {
     try {
-      return await runNative(['PCB_Drc.check']);
+      return await runNative(paths);
     } catch (error) {
-      throw dependencies.createBridgeError(
-        'CONTEXT_UNAVAILABLE',
-        'PCB DRC is unavailable in the current editor context.',
-        'Open and focus a PCB document, then retry design.drc.',
-        { cause: dependencies.errorMessage(error) },
-      );
+      const message = `Focus a ${document} document, then retry ${method}.`;
+      throw dependencies.createBridgeError('CONTEXT_UNAVAILABLE', message, message, {
+        cause: dependencies.errorMessage(error),
+      });
     }
+  }
+
+  async function runDrc(): Promise<DrcResult> {
+    return runFocusedNative(['PCB_Drc.check'], 'PCB', 'design.drc');
   }
 
   async function runRuleCheck(): Promise<DrcResult> {
@@ -247,7 +253,7 @@ export function createDesignRuleCheckOperations(
   }
 
   async function runErc(): ReturnType<DesignRuleCheckOperations['runErc']> {
-    const result = await runNative(['SCH_Drc.check']);
+    const result = await runFocusedNative(['SCH_Drc.check'], 'schematic', 'design.erc');
     try {
       const { floatingPins } = await dependencies.findFloatingPins();
       return {

--- a/easyeda-bridge-extension/tests/design-rule-check-operations.test.ts
+++ b/easyeda-bridge-extension/tests/design-rule-check-operations.test.ts
@@ -231,10 +231,23 @@ describe('design rule-check operations', () => {
 
     await expect(operations.runDrc()).rejects.toMatchObject({
       code: 'CONTEXT_UNAVAILABLE',
-      message: 'PCB DRC is unavailable in the current editor context.',
-      suggestion: 'Open and focus a PCB document, then retry design.drc.',
+      message: 'Focus a PCB document, then retry design.drc.',
+      suggestion: 'Focus a PCB document, then retry design.drc.',
       data: { cause: 'no PCB canvas' },
     });
+  });
+
+  it('translates an inactive schematic context for design.erc', async () => {
+    const { operations, callFirst, findFloatingPins } = createSubject();
+    callFirst.mockRejectedValue(new Error('no schematic canvas'));
+
+    await expect(operations.runErc()).rejects.toMatchObject({
+      code: 'CONTEXT_UNAVAILABLE',
+      message: 'Focus a schematic document, then retry design.erc.',
+      suggestion: 'Focus a schematic document, then retry design.erc.',
+      data: { cause: 'no schematic canvas' },
+    });
+    expect(findFloatingPins).not.toHaveBeenCalled();
   });
 
   it('falls back from PCB to schematic for design.ruleCheck', async () => {

--- a/easyeda-bridge-extension/tests/dispatcher.test.ts
+++ b/easyeda-bridge-extension/tests/dispatcher.test.ts
@@ -1276,9 +1276,24 @@ describe('createDispatcher', () => {
 
     await expect(dispatcher.dispatch('design.drc', {})).rejects.toMatchObject({
       code: 'CONTEXT_UNAVAILABLE',
-      message: 'PCB DRC is unavailable in the current editor context.',
-      suggestion: 'Open and focus a PCB document, then retry design.drc.',
+      message: 'Focus a PCB document, then retry design.drc.',
+      suggestion: 'Focus a PCB document, then retry design.drc.',
       data: { cause: 'localized message-bus error' },
+    });
+    expect(check).toHaveBeenCalledWith(true, true, true);
+  });
+
+  it('design.erc translates an inactive schematic canvas failure into CONTEXT_UNAVAILABLE', async () => {
+    const check = vi.fn(async () => {
+      throw new Error('localized schematic message-bus error');
+    });
+    const dispatcher = createDispatcher(makeToolkit({ SCH_Drc: { check } }));
+
+    await expect(dispatcher.dispatch('design.erc', {})).rejects.toMatchObject({
+      code: 'CONTEXT_UNAVAILABLE',
+      message: 'Focus a schematic document, then retry design.erc.',
+      suggestion: 'Focus a schematic document, then retry design.erc.',
+      data: { cause: 'localized schematic message-bus error' },
     });
     expect(check).toHaveBeenCalledWith(true, true, true);
   });

--- a/src/tools/L1_drc_erc.ts
+++ b/src/tools/L1_drc_erc.ts
@@ -94,10 +94,9 @@ function registerDrcErcTools(
     name: 'easyeda_drc_run',
     title: 'Run design rule check',
     description:
-      'Run the native design rule check (DRC): same as clicking "Check DRC" in EasyEDA Pro, so ' +
-      "the bottom DRC panel opens/refreshes in the user's window as a visible side effect. " +
-      'Returns coarse per-severity counts only — which specific wire/net/component is affected ' +
-      "is shown only in EasyEDA Pro's own DRC panel.",
+      "Run EasyEDA Pro's native PCB DRC and refresh its visible DRC panel. Requires a PCB document " +
+      'to be focused; otherwise returns an indeterminate not_available result with an actionable focus error. ' +
+      'Returns coarse severity counts; per-violation detail stays in EasyEDA Pro.',
     profile: 'core',
     evidence: ['official-docs'],
     risk: 'medium',
@@ -205,9 +204,9 @@ function registerDrcErcTools(
     name: 'easyeda_erc_run',
     title: 'Run electrical rule check',
     description:
-      'Run native ERC and supplement its coarse counts with inferred_floating_pins. Only a strict ' +
-      'native noConnected=true readback suppresses a pin; unavailable or malformed state remains ' +
-      'visible. Native counts remain authoritative for other categories.',
+      "Run EasyEDA Pro's native schematic ERC and supplement coarse counts with inferred_floating_pins. " +
+      'Requires a schematic document to be focused; otherwise returns an indeterminate not_available result ' +
+      'with an actionable focus error. Native counts remain authoritative.',
     profile: 'core',
     evidence: ['official-docs', 'runtime-probe'],
     risk: 'medium',

--- a/tests/unit/tools/drc-erc.test.ts
+++ b/tests/unit/tools/drc-erc.test.ts
@@ -660,6 +660,44 @@ describe('DRC/ERC Tools', () => {
     expect(result?.error).toBe('Bridge timeout');
   });
 
+  it('easyeda_drc_run exposes the focused-PCB precondition as an actionable indeterminate result', async () => {
+    const tool = registry.get('easyeda_drc_run');
+    bridgeCall.mockRejectedValue(
+      Object.assign(new Error('Focus a PCB document, then retry design.drc.'), {
+        code: 'CONTEXT_UNAVAILABLE',
+        suggestion: 'Focus a PCB document, then retry design.drc.',
+      }),
+    );
+
+    const result = await tool?.handler(context, { projectId: 'proj-focus' });
+
+    expect(result).toMatchObject({
+      project_id: 'proj-focus',
+      passed: null,
+      not_available: true,
+      error: 'Focus a PCB document, then retry design.drc.',
+    });
+  });
+
+  it('easyeda_erc_run exposes the focused-schematic precondition as an actionable indeterminate result', async () => {
+    const tool = registry.get('easyeda_erc_run');
+    bridgeCall.mockRejectedValue(
+      Object.assign(new Error('Focus a schematic document, then retry design.erc.'), {
+        code: 'CONTEXT_UNAVAILABLE',
+        suggestion: 'Focus a schematic document, then retry design.erc.',
+      }),
+    );
+
+    const result = await tool?.handler(context, { projectId: 'proj-focus' });
+
+    expect(result).toMatchObject({
+      project_id: 'proj-focus',
+      passed: null,
+      not_available: true,
+      error: 'Focus a schematic document, then retry design.erc.',
+    });
+  });
+
   it('easyeda_rule_check_summary preserves ERC when DRC is unavailable', async () => {
     const tool = registry.get('easyeda_rule_check_summary');
 


### PR DESCRIPTION
Fixes #511

## What changed
- make native PCB DRC and schematic ERC expose symmetric focused-document preconditions
- preserve the existing indeterminate public contract (`passed: null`, `not_available: true`) when the required editor document is not focused
- keep `easyeda_rule_check_summary` independent so a valid DRC/ERC result is preserved when the other side is unavailable
- update generated tool reference text; no automatic document/tab switching and no mutation behavior added

## Verification
- `pnpm verify` PASS: 2067 server tests / 379 extension tests
- extension coverage run PASS; changed DRC/ERC bridge operations covered by focused regression tests in both directions
- `pnpm check:extension-size` PASS:
  - package: 173121 / 200000 B
  - loader: 248835 / 260000 B
  - dispatcher: 184940 / 185000 B
- generated tool docs are idempotent; `git diff --check` clean
- exact candidate extension SHA-256: `8531218a1fd756bf6c214999c3c0d8262888d9e73907a2487c952d4fcf7fab54`

## Live EasyEDA Pro proof
Disposable EasyEDA Pro `3.2.149.88089769` profile/project only; normal user profile was not modified.

- schematic focused: ERC returned its real native result (0 errors / 1 warning / passed=true), while DRC returned `not_available` with `Focus a PCB document, then retry design.drc.`
- PCB focused: DRC returned its real native netlist-mismatch result (1 error / passed=false), while ERC returned `not_available` with `Focus a schematic document, then retry design.erc.`
- summary preserved the working side in both cases
- no automatic focus/tab switch was performed
