### PR TITLE
compat(mcp): migrate legacy runtime to SDK v2

### DIFF
--- a/docs/adr/0002-dependency-management.md
+++ b/docs/adr/0002-dependency-management.md
@@ -18,20 +18,20 @@ Third-party dependencies must be kept up to date to receive security patches and
 We choose **Renovate** as our dependency automation provider.
 
 - Renovate will be configured via `.github/renovate.json`.
-- We enforce a **3-day minimum release age** for NPM packages to filter out poisoned versions before they are proposed.
+- We enforce a **7-day minimum release age** for NPM packages to filter out poisoned versions before they are proposed.
 - We enable **Dependency Dashboard** to review major updates and approve them.
 - We enable weekly lockfile maintenance to refresh transient dependencies.
 - We define grouping rules:
   - ESLint toolchain group: `eslint`, `@eslint/js`, `typescript-eslint`.
   - Development toolchain group: `typescript`, `tsx`, `vitest`, `vitepress`.
-  - All other runtime dependencies (`@modelcontextprotocol/sdk`, `zod`, `jose`, `ws`, `undici`) are processed individually.
+  - All other runtime dependencies (`@modelcontextprotocol/server`, `@modelcontextprotocol/node`, `express`, `zod`, `jose`, `ws`, `undici`) are processed individually.
 - We configure **automerge** for patch/minor updates of `devDependencies` if CI passes. We do not automerge `dependencies` (runtime packages).
 
 ## Consequences
 
 - **Pros**:
   - Eliminates manual effort in tracking and upgrading development tools.
-  - Mitigates security risks by filtering out newly published packages (< 3 days old).
+  - Mitigates security risks by filtering out newly published packages (< 7 days old).
   - Groups updates to reduce pull request and CI pipeline noise.
 - **Cons**:
   - Auto-merged PRs require robust unit and integration testing in CI to catch any regressions.

--- a/docs/development/security-tooling.md
+++ b/docs/development/security-tooling.md
@@ -137,7 +137,9 @@ There are currently no active dependency-audit exceptions. The former
 `GHSA-frvp-7c67-39w9` exception for `@hono/node-server@1.19.14` was removed in #382 after the
 workspace pinned the transitive adapter to patched `@hono/node-server@2.0.10` and the complete MCP
 HTTP, Remote Relay, platform, and security verification matrix passed. The exact override remains
-in `pnpm-workspace.yaml` until the production MCP SDK v1 line publishes a patched dependency range.
+in `pnpm-workspace.yaml` because `@modelcontextprotocol/node@2.0.0` still resolves through
+`@hono/node-server`; it should be removed only when the upstream dependency range resolves safely
+without the repository override.
 
 ### Scheduled advisory monitoring
 

--- a/docs/reference/mcp-protocol-compatibility.md
+++ b/docs/reference/mcp-protocol-compatibility.md
@@ -8,7 +8,7 @@ protocol is already enabled.
 
 | Area                  | Current repository behavior                                                     |
 | --------------------- | ------------------------------------------------------------------------------- |
-| MCP SDK               | `@modelcontextprotocol/sdk` v1, currently locked to `1.29.0`                    |
+| MCP SDK               | Modular v2 packages; server/node lock to `2.0.0`, client is test-only           |
 | Default MCP revision  | `2025-11-25`                                                                    |
 | HTTP era              | Legacy/sessionful                                                               |
 | HTTP initialization   | `initialize` followed by `notifications/initialized`                            |
@@ -40,8 +40,9 @@ The official TypeScript SDK v2 line exposes the two eras through different lifec
 
 Research baseline on 2026-08-09: the stable v2 packages
 `@modelcontextprotocol/server`, `@modelcontextprotocol/client`, `@modelcontextprotocol/node`, and
-`@modelcontextprotocol/core` are published at `2.0.0`. The repository must pin and verify the exact
-v2 package set in a dedicated dependency change before any modern protocol path is enabled.
+`@modelcontextprotocol/core` are published at `2.0.0`. The repository now resolves the direct
+server/node SDK packages to `2.0.0` in the lockfile and keeps the client package test-only. This
+changes SDK packaging and handler context compatibility only; no modern protocol path is enabled.
 
 Primary references:
 
@@ -102,8 +103,9 @@ The compatibility work should remain reviewable as separate changes:
 
 1. **Legacy baseline:** lock the current raw HTTP initialize/session/termination behavior and
    unsupported-modern-version rejection in tests. No production behavior changes.
-2. **SDK v2 compile migration:** pin the stable v2 package set and migrate imports while preserving
-   legacy wire behavior. No modern era enabled by default.
+2. **SDK v2 compile migration:** use the stable modular v2 package set and migrate imports while
+   preserving legacy wire behavior. Keep `MCP_V2_EXPERIMENTAL` non-effective; no modern era is
+   enabled by this step.
 3. **Modern HTTP path:** add explicit era routing and `2026-07-28` request handling while keeping
    the existing sessionful route independent.
 4. **Modern stdio path:** adopt the v2 stdio lifecycle behind an explicit compatibility boundary.

--- a/package.json
+++ b/package.json
@@ -128,8 +128,10 @@
     "lint:scripts": "eslint scripts eslint.config.js --max-warnings 0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/node": "^2.0.0",
+    "@modelcontextprotocol/server": "^2.0.0",
     "dotenv": "^17.4.2",
+    "express": "^5.2.1",
     "jose": "^6.2.3",
     "pino": "^10.3.1",
     "undici": "8.9.0",
@@ -139,6 +141,7 @@
   "devDependencies": {
     "@codecov/bundle-analyzer": "2.0.1",
     "@eslint/js": "^10.0.1",
+    "@modelcontextprotocol/client": "^2.0.0",
     "@types/express": "^5.0.6",
     "@types/node": "^24.13.2",
     "@types/ws": "^8.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,12 +22,18 @@ importers:
 
   .:
     dependencies:
-      '@modelcontextprotocol/sdk':
-        specifier: ^1.29.0
-        version: 1.29.0(zod@4.4.3)
+      '@modelcontextprotocol/node':
+        specifier: ^2.0.0
+        version: 2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.34)
+      '@modelcontextprotocol/server':
+        specifier: ^2.0.0
+        version: 2.0.0
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
+      express:
+        specifier: ^5.2.1
+        version: 5.2.1
       jose:
         specifier: ^6.2.3
         version: 6.2.3
@@ -50,6 +56,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0)
+      '@modelcontextprotocol/client':
+        specifier: ^2.0.0
+        version: 2.0.0
       '@types/express':
         specifier: ^5.0.6
         version: 5.0.6
@@ -492,15 +501,27 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@modelcontextprotocol/sdk@1.29.0':
-    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
-    engines: {node: '>=18'}
+  '@modelcontextprotocol/client@2.0.0':
+    resolution: {integrity: sha512-8f1OghQ2rjzIOfqgUCP+8GiUWqRs89njoWLNqAe8kWmDePv3s1fZXseej+QXemssEuuOvLLmLO/kqM3IQHtISw==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/node@2.0.0':
+    resolution: {integrity: sha512-Y4hAC2XdGDUdDOCbLDOCA4+aL3NUldjsOWlDL/YwpAxrPhRm1xHd7lZ+mLacvZ9t3PaH28wgNoaLQGrIk1P2pg==}
+    engines: {node: '>=20'}
     peerDependencies:
-      '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
+      '@modelcontextprotocol/server': ^2.0.0
+      hono: 4.12.34
     peerDependenciesMeta:
-      '@cfworker/json-schema':
+      hono:
         optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@octokit/auth-token@6.0.0':
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
@@ -997,19 +1018,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  ajv-formats@3.0.1:
-    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
-    peerDependencies:
-      ajv: ^8.0.0
-    peerDependenciesMeta:
-      ajv:
-        optional: true
-
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
-
-  ajv@8.20.0:
-    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   algoliasearch@5.55.1:
     resolution: {integrity: sha512-FyaFnnsbVPtevQwqSj/SdxE3jAsSsY0BEH8IVLf9rXxEBdAhAmT6VKCVSMWoaPIHVN1Eufh/1w8q6k8URpIkWw==}
@@ -1199,10 +1209,6 @@ packages:
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
-  cors@2.8.6:
-    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
-    engines: {node: '>= 0.10'}
-
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
@@ -1377,12 +1383,6 @@ packages:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
     engines: {node: '>=12.0.0'}
 
-  express-rate-limit@8.5.2:
-    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
-    engines: {node: '>= 16'}
-    peerDependencies:
-      express: '>= 4.11'
-
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -1402,9 +1402,6 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1516,8 +1513,8 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
-  iconv-lite@0.7.2:
-    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+  iconv-lite@0.7.3:
+    resolution: {integrity: sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -1537,10 +1534,6 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ip-address@10.3.1:
-    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
-    engines: {node: '>= 12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -1602,12 +1595,6 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
-
-  json-schema-traverse@1.0.0:
-    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
-
-  json-schema-typed@8.0.2:
-    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1724,8 +1711,8 @@ packages:
   mdast-util-to-hast@13.2.1:
     resolution: {integrity: sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==}
 
-  media-typer@1.1.0:
-    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+  media-typer@1.1.1:
+    resolution: {integrity: sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==}
     engines: {node: '>= 0.8'}
 
   merge-descriptors@2.0.0:
@@ -1786,10 +1773,6 @@ packages:
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
-    engines: {node: '>=0.10.0'}
-
-  object-assign@4.1.1:
-    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
 
   object-inspect@1.13.4:
@@ -1912,15 +1895,15 @@ packages:
   pure-rand@8.4.2:
     resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
-  qs@6.15.2:
-    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
     engines: {node: '>=0.6'}
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
-  range-parser@1.2.1:
-    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
     engines: {node: '>= 0.6'}
 
   raw-body@3.0.2:
@@ -1956,10 +1939,6 @@ packages:
 
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
-    engines: {node: '>=0.10.0'}
-
-  require-from-string@2.0.2:
-    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
 
   rfdc@1.4.1:
@@ -2379,11 +2358,6 @@ packages:
     resolution: {integrity: sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==}
     engines: {node: '>=18'}
 
-  zod-to-json-schema@3.25.2:
-    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
-    peerDependencies:
-      zod: ^3.25.28 || ^4
-
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -2739,27 +2713,31 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+  '@modelcontextprotocol/client@2.0.0':
     dependencies:
-      '@hono/node-server': 2.0.10(hono@4.12.34)
-      ajv: 8.20.0
-      ajv-formats: 3.0.1(ajv@8.20.0)
-      content-type: 1.0.5
-      cors: 2.8.6
+      '@modelcontextprotocol/core': 2.0.0
       cross-spawn: 7.0.6
       eventsource: 3.0.7
       eventsource-parser: 3.1.0
-      express: 5.2.1
-      express-rate-limit: 8.5.2(express@5.2.1)
-      hono: 4.12.34
       jose: 6.2.3
-      json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
-      raw-body: 3.0.2
       zod: 4.4.3
-      zod-to-json-schema: 3.25.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - supports-color
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.4.3
+
+  '@modelcontextprotocol/node@2.0.0(@modelcontextprotocol/server@2.0.0)(hono@4.12.34)':
+    dependencies:
+      '@hono/node-server': 2.0.10(hono@4.12.34)
+      '@modelcontextprotocol/server': 2.0.0
+    optionalDependencies:
+      hono: 4.12.34
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.4.3
 
   '@octokit/auth-token@6.0.0': {}
 
@@ -3281,23 +3259,12 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  ajv-formats@3.0.1(ajv@8.20.0):
-    optionalDependencies:
-      ajv: 8.20.0
-
   ajv@6.15.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
-
-  ajv@8.20.0:
-    dependencies:
-      fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
-      json-schema-traverse: 1.0.0
-      require-from-string: 2.0.2
 
   algoliasearch@5.55.1:
     dependencies:
@@ -3398,9 +3365,9 @@ snapshots:
       content-type: 2.0.0
       debug: 4.4.3
       http-errors: 2.0.1
-      iconv-lite: 0.7.2
+      iconv-lite: 0.7.3
       on-finished: 2.4.1
-      qs: 6.15.2
+      qs: 6.15.3
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -3485,11 +3452,6 @@ snapshots:
       is-what: 5.5.0
 
   core-util-is@1.0.3: {}
-
-  cors@2.8.6:
-    dependencies:
-      object-assign: 4.1.1
-      vary: 1.1.2
 
   crc-32@1.2.2: {}
 
@@ -3676,11 +3638,6 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  express-rate-limit@8.5.2(express@5.2.1):
-    dependencies:
-      express: 5.2.1
-      ip-address: 10.3.1
-
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -3703,8 +3660,8 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.2
-      range-parser: 1.2.1
+      qs: 6.15.3
+      range-parser: 1.3.0
       router: 2.2.0
       send: 1.2.1
       serve-static: 2.2.1
@@ -3725,8 +3682,6 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
-
-  fast-uri@3.1.5: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3846,7 +3801,7 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
-  iconv-lite@0.7.2:
+  iconv-lite@0.7.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -3859,8 +3814,6 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
-
-  ip-address@10.3.1: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -3904,10 +3857,6 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
-
-  json-schema-traverse@1.0.0: {}
-
-  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -4010,7 +3959,7 @@ snapshots:
       unist-util-visit: 5.1.0
       vfile: 6.0.3
 
-  media-typer@1.1.0: {}
+  media-typer@1.1.1: {}
 
   merge-descriptors@2.0.0: {}
 
@@ -4059,8 +4008,6 @@ snapshots:
   negotiator@1.0.0: {}
 
   normalize-path@3.0.0: {}
-
-  object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
 
@@ -4168,19 +4115,20 @@ snapshots:
 
   pure-rand@8.4.2: {}
 
-  qs@6.15.2:
+  qs@6.15.3:
     dependencies:
+      es-define-property: 1.0.1
       side-channel: 1.1.1
 
   quick-format-unescaped@4.0.4: {}
 
-  range-parser@1.2.1: {}
+  range-parser@1.3.0: {}
 
   raw-body@3.0.2:
     dependencies:
       bytes: 3.1.2
       http-errors: 2.0.1
-      iconv-lite: 0.7.2
+      iconv-lite: 0.7.3
       unpipe: 1.0.0
 
   readable-stream@2.3.8:
@@ -4220,8 +4168,6 @@ snapshots:
       regex-utilities: 2.3.0
 
   require-directory@2.1.1: {}
-
-  require-from-string@2.0.2: {}
 
   rfdc@1.4.1: {}
 
@@ -4289,7 +4235,7 @@ snapshots:
       mime-types: 3.0.2
       ms: 2.1.3
       on-finished: 2.4.1
-      range-parser: 1.2.1
+      range-parser: 1.3.0
       statuses: 2.0.2
     transitivePeerDependencies:
       - supports-color
@@ -4478,7 +4424,7 @@ snapshots:
   type-is@2.1.0:
     dependencies:
       content-type: 2.0.0
-      media-typer: 1.1.0
+      media-typer: 1.1.1
       mime-types: 3.0.2
 
   typescript-eslint@8.62.1(eslint@10.6.0)(typescript@6.0.3):
@@ -4698,10 +4644,6 @@ snapshots:
       compress-commons: 7.0.1
       normalize-path: 3.0.0
       readable-stream: 4.7.0
-
-  zod-to-json-schema@3.25.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
 
   zod@3.25.76: {}
 

--- a/src/server/factory.ts
+++ b/src/server/factory.ts
@@ -1,6 +1,6 @@
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
+import { StdioServerTransport } from '@modelcontextprotocol/server/stdio';
+import { McpServer } from '@modelcontextprotocol/server';
 import { type EnvConfig } from '../config/env.js';
 import { type ToolProfile } from '../config/profiles.js';
 import { SERVER_VERSION } from '../config/version.js';
@@ -32,7 +32,7 @@ export interface CreateServerOptions {
 export interface McpServerInstance {
   server: McpServer;
   registry: ToolRegistry;
-  transport: StdioServerTransport | StreamableHTTPServerTransport;
+  transport: StdioServerTransport | NodeStreamableHTTPServerTransport;
   httpTransport?: HttpTransportInstance;
   context: ToolContext;
   storage?: Storage;

--- a/src/server/resources-prompts.ts
+++ b/src/server/resources-prompts.ts
@@ -1,4 +1,5 @@
-import { ResourceTemplate, type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { ResourceTemplate } from '@modelcontextprotocol/server';
+import type { McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import { type ToolContext } from '../tools/types.js';
 import { listDfmChecklist } from '../design-rules/dfm-checklist.js';
@@ -147,9 +148,9 @@ function promptText(title: string, projectId: string, body: string): string {
   ].join('\n');
 }
 
-const promptArgsSchema = {
+const promptArgsSchema = z.object({
   projectId: z.string().min(1).describe('EasyEDA project identifier to review.'),
-};
+});
 
 export function registerProjectResourcesAndPrompts(server: McpServer, context: ToolContext): void {
   server.registerResource(

--- a/src/server/transports/http.ts
+++ b/src/server/transports/http.ts
@@ -1,11 +1,9 @@
 import { randomUUID } from 'node:crypto';
-import { type Express, type Request, type Response, type NextFunction } from 'express';
-import { createMcpExpressApp } from '@modelcontextprotocol/sdk/server/express.js';
-import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import { isInitializeRequest } from '@modelcontextprotocol/sdk/types.js';
+import express, { type Express, type Request, type Response, type NextFunction } from 'express';
+import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
+import { isInitializeRequest } from '@modelcontextprotocol/server';
+import type { McpServer, AuthInfo } from '@modelcontextprotocol/server';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
-import { type AuthInfo } from '@modelcontextprotocol/sdk/server/auth/types.js';
 import { type EnvConfig } from '../../config/env.js';
 import { SERVER_VERSION } from '../../config/version.js';
 import { getLogger } from '../../utils/logger.js';
@@ -17,7 +15,7 @@ import { RemoteGateway } from '../../remote/gateway.js';
 
 export interface HttpTransportInstance {
   app: Express;
-  transport: StreamableHTTPServerTransport;
+  transport: NodeStreamableHTTPServerTransport;
   readonly activeSessionCount: number;
   start: () => Promise<void>;
   close: () => Promise<void>;
@@ -36,7 +34,7 @@ interface RateLimitEntry {
 
 interface McpHttpSession {
   server: McpServer;
-  transport: StreamableHTTPServerTransport;
+  transport: NodeStreamableHTTPServerTransport;
   closing: boolean;
 }
 
@@ -455,11 +453,12 @@ export function createHttpTransport(
 
   // Retained for compatibility with callers that explicitly attach one MCP
   // server. Production HTTP uses serverFactory and the session map below.
-  const transport = new StreamableHTTPServerTransport({
+  const transport = new NodeStreamableHTTPServerTransport({
     sessionIdGenerator: () => randomUUID(),
   });
 
-  const app = createMcpExpressApp({ host: config.HTTP_HOST });
+  const app = express();
+  app.use(express.json());
 
   app.use(parseRemoteJsonBody);
   app.use(addSecurityHeaders);
@@ -518,7 +517,7 @@ export function createHttpTransport(
       return;
     }
 
-    const sessionTransport = new StreamableHTTPServerTransport({
+    const sessionTransport = new NodeStreamableHTTPServerTransport({
       sessionIdGenerator: () => randomUUID(),
       onsessioninitialized: (sessionId) => {
         sessions.set(sessionId, session);

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -1,4 +1,4 @@
-import { type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { McpServer } from '@modelcontextprotocol/server';
 import { type ToolDefinition, type ToolContext, type ToolSideEffect } from './types.js';
 import {
   registeredOutputSchema,
@@ -200,14 +200,23 @@ function bridgeDisconnectedResponse(
   });
 }
 
+type McpHandlerAuthInfo = {
+  clientId?: string;
+  scopes?: string[];
+  expiresAt?: number;
+  extra?: Record<string, unknown>;
+};
+
 type McpHandlerExtra = {
-  authInfo?: {
-    clientId?: string;
-    scopes?: string[];
-    expiresAt?: number;
-    extra?: Record<string, unknown>;
-  };
+  // v1 and retained 2025-era context shape.
+  authInfo?: McpHandlerAuthInfo;
   requestInfo?: { headers?: unknown };
+  // SDK v2 exposes the HTTP request context under `http` while retaining
+  // the same 2025-era wire lifecycle unless modern serving is explicitly enabled.
+  http?: {
+    authInfo?: McpHandlerAuthInfo;
+    req?: { headers?: unknown };
+  };
 };
 
 function readHeader(headers: unknown, name: string): string | undefined {
@@ -242,9 +251,17 @@ function parseRemoteScopes(value: unknown): RemoteIdentity['scopes'] {
     .filter(Boolean) as RemoteIdentity['scopes'];
 }
 
+function handlerAuthInfo(extra: McpHandlerExtra | undefined): McpHandlerAuthInfo | undefined {
+  return extra?.authInfo ?? extra?.http?.authInfo;
+}
+
+function handlerHeaders(extra: McpHandlerExtra | undefined): unknown {
+  return extra?.requestInfo?.headers ?? extra?.http?.req?.headers;
+}
+
 function remoteIdentityFromExtra(extra: unknown): RemoteIdentity | undefined {
   const handlerExtra = extra as McpHandlerExtra | undefined;
-  const auth = handlerExtra?.authInfo;
+  const auth = handlerAuthInfo(handlerExtra);
   if (auth) {
     const claims = auth.extra ?? {};
     let userId = auth.clientId;
@@ -258,7 +275,7 @@ function remoteIdentityFromExtra(extra: unknown): RemoteIdentity | undefined {
     };
   }
 
-  const headers = handlerExtra?.requestInfo?.headers;
+  const headers = handlerHeaders(handlerExtra);
   const userId = readHeader(headers, 'x-remote-user-id');
   if (!userId) return undefined;
   const expiresAtHeader = readHeader(headers, 'x-remote-expires-at');
@@ -639,8 +656,7 @@ export class ToolRegistry {
           outputSchema: registeredOutputSchema(tool),
           annotations: tool.annotations,
         },
-        async (input: unknown, extra: unknown) =>
-          handleRegisteredToolCall(tool, context, input, extra),
+        async (input: unknown, ctx: unknown) => handleRegisteredToolCall(tool, context, input, ctx),
       );
     }
   }

--- a/tests/unit/remote/http-mcp-integration.test.ts
+++ b/tests/unit/remote/http-mcp-integration.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, it } from 'vitest';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client';
 import { createServer, type McpServerInstance } from '../../../src/server/factory.js';
 import {
   createHttpTransport,

--- a/tests/unit/server/factory.test.ts
+++ b/tests/unit/server/factory.test.ts
@@ -17,17 +17,17 @@ const mocks = vi.hoisted(() => ({
   vendor: vi.fn(),
 }));
 
-vi.mock('@modelcontextprotocol/sdk/server/mcp.js', () => ({
+vi.mock('@modelcontextprotocol/server', () => ({
   McpServer: class MockMcpServer {
     server = { onerror: undefined as ((error: unknown) => void) | undefined };
     close = mocks.close;
   },
 }));
-vi.mock('@modelcontextprotocol/sdk/server/stdio.js', () => ({
+vi.mock('@modelcontextprotocol/server/stdio', () => ({
   StdioServerTransport: class MockStdioServerTransport {},
 }));
-vi.mock('@modelcontextprotocol/sdk/server/streamableHttp.js', () => ({
-  StreamableHTTPServerTransport: class MockStreamableHTTPServerTransport {},
+vi.mock('@modelcontextprotocol/node', () => ({
+  NodeStreamableHTTPServerTransport: class MockStreamableHTTPServerTransport {},
 }));
 vi.mock('../../../src/utils/logger.js', () => ({
   createLogger: () => mocks.logger,

--- a/tests/unit/server/transports/http.test.ts
+++ b/tests/unit/server/transports/http.test.ts
@@ -12,7 +12,7 @@ import {
 import type { Request, Response, NextFunction } from 'express';
 import * as http from 'node:http';
 import { generateKeyPair, exportJWK, SignJWT } from 'jose';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { McpServer } from '@modelcontextprotocol/server';
 
 /** Create mock Express req/res/next for middleware unit tests. */
 function mockReqRes(overrides: Partial<Request> = {}): {

--- a/tests/unit/tools/design-rules.test.ts
+++ b/tests/unit/tools/design-rules.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
+import { Client } from '@modelcontextprotocol/client';
 import { ToolRegistry } from '../../../src/tools/registry.js';
 import { type ToolContext } from '../../../src/tools/types.js';
 import { registerDesignRulesTools } from '../../../src/tools/L1_design_rules.js';


### PR DESCRIPTION
## Summary

Part of #476 — **Slice A only**.

This migrates the existing legacy/sessionful MCP runtime from the monolithic TypeScript SDK v1 package to the modular SDK v2 packages while deliberately preserving the current wire behavior.

- replace `@modelcontextprotocol/sdk` with `@modelcontextprotocol/server` and `@modelcontextprotocol/node`
- keep `@modelcontextprotocol/client` test-only
- use direct Express with the repository's existing Host/Origin/CORS/OAuth protections rather than layering the v2 Express helper ahead of them
- normalize legacy and v2 MCP handler context shapes so Remote Relay identity/header propagation remains unchanged
- migrate prompt argument schemas to the v2 Standard Schema form
- update the existing MCP compatibility/dependency/security docs to match the actual dependency state

## Compatibility boundary

This PR **does not enable MCP `2026-07-28`**.

It intentionally preserves:

- default MCP revision `2025-11-25`
- `initialize` / sessionful HTTP lifecycle
- `MCP-Session-Id` behavior
- current CORS / Host validation / OAuth behavior
- current Remote Relay authorization and identity behavior
- `MCP_V2_EXPERIMENTAL` as non-effective runtime configuration

Modern HTTP era routing/discovery remains a separate follow-up slice.

## Verification

Fresh local verification on Node.js 24.18.0 / pnpm 11.5.1:

- `pnpm verify` — PASS
  - server: 190 files / 2067 tests
  - extension: 28 files / 379 tests
  - format, typecheck, lint, complexity, package checks, secret hygiene, metadata, compatibility docs and VitePress build all passed
- `pnpm security:audit` — PASS, no advisories
- production tree resolves `@modelcontextprotocol/server@2.0.0` and `@modelcontextprotocol/node@2.0.0`; MCP client remains dev-only
- no source/test imports remain from the monolithic SDK or `@modelcontextprotocol/express`
- `git diff --check` — PASS

The initial codemod-only migration reproduced five compatibility regressions (three HTTP Origin/CORS and two Remote Relay identity tests). The final implementation fixes those root causes without changing the legacy wire contract; the focused MCP suite returned to 140/140 green before the full verification run.

## Release hold

> [!IMPORTANT]
> **DO NOT MERGE during the v1.0.0-rc.3 soak.**
>
> This PR changes runtime code and runtime dependencies. Per `docs/RELEASE_POLICY.md`, merging it after the final candidate would reset the current soak and require a new `rc.N`.
>
> Current earliest stable eligibility remains **2026-08-18 00:43:06 +03:00**, subject to #437 and no candidate-sensitive change.

Refs #476
