### PR TITLE
test(mcp): lock output schema dialect compatibility

### DIFF
--- a/tests/unit/tools/registry.test.ts
+++ b/tests/unit/tools/registry.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { Client } from '@modelcontextprotocol/client';
+import { InMemoryTransport, McpServer } from '@modelcontextprotocol/server';
 import { z } from 'zod';
 import {
   ToolRegistry,
@@ -142,6 +144,44 @@ describe('ToolRegistry', () => {
       registry.register(createMockTool('b', 'pro'));
       const all = registry.getAllTools();
       expect(all).toHaveLength(2);
+    });
+  });
+
+  describe('MCP schema dialect compatibility', () => {
+    it('publishes only MCP-compatible 2020-12/default schema dialects', async () => {
+      const server = new McpServer({ name: 'schema-dialect-test', version: '1.0.0' });
+      const client = new Client({ name: 'schema-dialect-client', version: '1.0.0' });
+      const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+      registry.setProfile('dev');
+      registerBuiltinTools(registry, TEST_CONFIG);
+      registry.registerAllOnServer(server, mockContext({ profile: 'dev' }));
+
+      try {
+        await server.connect(serverTransport);
+        await client.connect(clientTransport);
+
+        const listed = await client.listTools();
+        expect(listed.tools).toHaveLength(registry.getEnabledTools().length);
+        expect(listed.tools.length).toBeGreaterThan(0);
+
+        for (const tool of listed.tools) {
+          const inputSchema = tool.inputSchema as Record<string, unknown>;
+          const outputSchema = tool.outputSchema as Record<string, unknown> | undefined;
+
+          const supportedDialects = [undefined, 'https://json-schema.org/draft/2020-12/schema'];
+
+          expect(supportedDialects, `${tool.name} inputSchema dialect`).toContain(
+            inputSchema.$schema,
+          );
+          expect(outputSchema, `${tool.name} outputSchema`).toBeDefined();
+          expect(supportedDialects, `${tool.name} outputSchema dialect`).toContain(
+            outputSchema?.$schema,
+          );
+        }
+      } finally {
+        await Promise.allSettled([client.close(), server.close()]);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Closes #520.

The reported incompatibility is real on the current stable `0.35.4`, but the runtime behavior is already corrected on `main` by the MCP SDK v2 migration in #516. This PR adds a regression gate so incompatible schema dialects cannot silently return.

- reproduce `0.35.4` through a real in-memory MCP `tools/list`: all 115 dev-profile input/output schemas advertise draft-07; core advertises 71/71 output schemas as draft-07
- verify current `main` through the same MCP path: all 117 dev-profile input/output schemas advertise JSON Schema 2020-12; core advertises 73/73 output schemas as 2020-12
- add a test over the real `McpServer` + `Client` + `InMemoryTransport` path for every enabled dev-profile tool
- accept the MCP default (omitted `$schema`) or explicit 2020-12, while rejecting incompatible advertised dialects such as draft-07

No production code changes are required: #516 already moved the runtime from the monolithic SDK v1 package to the modular SDK v2 packages whose current schema conversion path emits 2020-12.

## Verification

Node.js 24.18.0 / pnpm 11.5.1:

- focused `tests/unit/tools/registry.test.ts` — **58/58 PASS**
- `pnpm verify` — **PASS**
  - server: **190 files / 2069 tests**
  - extension: **28 files / 379 tests**
  - format, typecheck, lint, complexity, package preparation, secret hygiene, metadata, compatibility docs, and VitePress build all passed
- `git diff --check` — PASS

The installed Claude Code binary is `2.1.220`, but its non-interactive SSH session is not authenticated, so this PR does **not** claim an end-to-end Claude API validation. The compatibility assertion is based on the actual MCP `tools/list` payloads on stable versus current `main`.
