### PR TITLE
security: harden legacy Sonar vulnerability surfaces

### DIFF
--- a/easyeda-bridge-extension/src/remote-client.ts
+++ b/easyeda-bridge-extension/src/remote-client.ts
@@ -69,9 +69,22 @@ const RECONNECT_MAX_MS = 30_000;
 const HEARTBEAT_LIVENESS_MS = 45_000;
 const HEARTBEAT_SWEEP_MS = 15_000;
 
+let fallbackMessageSequence = 0;
+
 function makeMessageId(): string {
-  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) return crypto.randomUUID();
-  return `msg_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+  const webCrypto = globalThis.crypto;
+  if (typeof webCrypto?.randomUUID === 'function') return webCrypto.randomUUID();
+  if (typeof webCrypto?.getRandomValues === 'function') {
+    const bytes = new Uint8Array(16);
+    webCrypto.getRandomValues(bytes);
+    return `msg_${Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('')}`;
+  }
+
+  // Last-resort uniqueness only: when Web Crypto is unavailable, do not pretend
+  // Math.random() provides a security property. The sequence prevents same-tick
+  // collisions within this extension process.
+  fallbackMessageSequence = (fallbackMessageSequence + 1) % Number.MAX_SAFE_INTEGER;
+  return `msg_${Date.now().toString(16)}_${fallbackMessageSequence.toString(16)}`;
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/easyeda-bridge-extension/tests/remote-client.test.ts
+++ b/easyeda-bridge-extension/tests/remote-client.test.ts
@@ -124,6 +124,52 @@ describe('RemoteRelayClient resilience', () => {
     expect(client.getStatus()).toMatchObject({ state: 'disconnected', sessionId: undefined });
   });
 
+  it('uses Web Crypto bytes for message ids when randomUUID is unavailable', () => {
+    const getRandomValues = vi.fn((values: Uint8Array) => {
+      values.fill(0xab);
+      return values;
+    });
+    vi.stubGlobal('crypto', { getRandomValues });
+    const mathRandom = vi.spyOn(Math, 'random').mockImplementation(() => {
+      throw new Error('Math.random must not be used for relay message ids');
+    });
+    const { client } = makeClient();
+
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+
+    const registration = JSON.parse(socket.sent[0]) as { messageId: string; type: string };
+    expect(registration.type).toBe('register_session');
+    expect(registration.messageId).toBe(`msg_${'ab'.repeat(16)}`);
+    expect(getRandomValues).toHaveBeenCalledTimes(1);
+    expect(mathRandom).not.toHaveBeenCalled();
+  });
+
+  it('keeps message ids unique without Web Crypto and never falls back to Math.random', () => {
+    vi.stubGlobal('crypto', undefined);
+    const mathRandom = vi.spyOn(Math, 'random').mockImplementation(() => {
+      throw new Error('Math.random must not be used for relay message ids');
+    });
+    vi.setSystemTime(new Date('2026-08-22T00:00:00.000Z'));
+    const { client } = makeClient();
+
+    client.connect({ mode: 'hosted', relayUrl: 'wss://relay.example/session' });
+    const socket = FakeWebSocket.instances[0];
+    socket.open();
+    socket.receive(relayMessage('heartbeat'));
+
+    const [registration, heartbeat] = socket.sent.map(
+      (payload) => JSON.parse(payload) as { messageId: string; type: string },
+    );
+    expect(registration.type).toBe('register_session');
+    expect(heartbeat.type).toBe('heartbeat');
+    expect(registration.messageId).toMatch(/^msg_[0-9a-f]+_[0-9a-f]+$/);
+    expect(heartbeat.messageId).toMatch(/^msg_[0-9a-f]+_[0-9a-f]+$/);
+    expect(heartbeat.messageId).not.toBe(registration.messageId);
+    expect(mathRandom).not.toHaveBeenCalled();
+  });
+
   it('updates heartbeat liveness and echoes heartbeat messages', () => {
     const { client } = makeClient();
 

--- a/scripts/e2e/harness.mjs
+++ b/scripts/e2e/harness.mjs
@@ -7,7 +7,7 @@ export { sleep };
 export function startStdioMcpServer(options = {}) {
   const cwd = options.cwd ?? process.cwd();
   const timeoutMs = options.timeoutMs ?? 45_000;
-  const child = spawn('node', options.args ?? ['dist/index.js'], {
+  const child = spawn(process.execPath, options.args ?? ['dist/index.js'], {
     cwd,
     stdio: ['pipe', 'pipe', 'pipe'],
     env: {

--- a/scripts/e2e/log-sanitization.mjs
+++ b/scripts/e2e/log-sanitization.mjs
@@ -1,7 +1,7 @@
 function escapeControlCharacter(character) {
   const codePoint = character.codePointAt(0) ?? 0;
   if (codePoint >= 0x20 && (codePoint < 0x7f || codePoint > 0x9f)) return character;
-  return `\\u${codePoint.toString(16).padStart(4, '0')}`;
+  return String.raw`\u${codePoint.toString(16).padStart(4, '0')}`;
 }
 
 export function sanitizeLogFragment(value, maxLength) {

--- a/scripts/e2e/log-sanitization.mjs
+++ b/scripts/e2e/log-sanitization.mjs
@@ -1,0 +1,13 @@
+function escapeControlCharacter(character) {
+  const codePoint = character.codePointAt(0) ?? 0;
+  if (codePoint >= 0x20 && (codePoint < 0x7f || codePoint > 0x9f)) return character;
+  return `\\u${codePoint.toString(16).padStart(4, '0')}`;
+}
+
+export function sanitizeLogFragment(value, maxLength) {
+  if (!Number.isSafeInteger(maxLength) || maxLength <= 0) {
+    throw new TypeError('maxLength must be a positive integer');
+  }
+
+  return Array.from(String(value).slice(0, maxLength), escapeControlCharacter).join('');
+}

--- a/scripts/e2e/waiter.mjs
+++ b/scripts/e2e/waiter.mjs
@@ -1,4 +1,5 @@
 import { spawnTrackedProcess } from './harness.mjs';
+import { sanitizeLogFragment } from './log-sanitization.mjs';
 import { Socket } from 'net';
 import { setTimeout as sleep } from 'timers/promises';
 
@@ -8,7 +9,7 @@ const SRV_TIMEOUT = 5 * 60 * 1000; // 5 min
 console.log('Process started at', new Date().toISOString());
 
 console.log('=== Starting MCP Server ===');
-const serverProcess = spawnTrackedProcess('node', ['dist/index.js'], {
+const serverProcess = spawnTrackedProcess(process.execPath, ['dist/index.js'], {
   env: { LOG_LEVEL: 'info' },
 });
 const server = serverProcess.child;
@@ -47,7 +48,7 @@ const initReq =
 sock.write(initReq);
 await sleep(1000);
 
-console.log('Initial buf:', buf.slice(0, 300));
+console.log('Initial buf: %s', sanitizeLogFragment(buf, 300));
 
 // Poll bridge status
 console.log('\n=== Waiting for Bridge Connection ===');
@@ -113,7 +114,7 @@ if (connected) {
   await sleep(1500);
 
   const capsResp = buf.slice(prevLen);
-  console.log('Capabilities response:', capsResp.slice(0, 2000));
+  console.log('Capabilities response: %s', sanitizeLogFragment(capsResp, 2000));
 
   // Fetch bridge info
   const prevLen2 = buf.length;
@@ -126,7 +127,7 @@ if (connected) {
     }) + '\n',
   );
   await sleep(1500);
-  console.log('Info response:', buf.slice(prevLen2, prevLen2 + 2000));
+  console.log('Info response: %s', sanitizeLogFragment(buf.slice(prevLen2), 2000));
 
   // Try easyeda_bridge_call with schematic methods
   const schematicMethods = [
@@ -150,16 +151,19 @@ if (connected) {
     );
     await sleep(1000);
     const r = buf.slice(p, p + 1000);
-    console.log('%s: %s', method, r.slice(0, 300));
+    console.log('%s: %s', method, sanitizeLogFragment(r, 300));
   }
 }
 
 // Final output
 console.log('\n=== Server Logs ===');
-console.log((serverProcess.stdoutLog + serverProcess.stderrLog).slice(-3000));
+console.log(
+  '%s',
+  sanitizeLogFragment((serverProcess.stdoutLog + serverProcess.stderrLog).slice(-3000), 3000),
+);
 
 console.log('\n=== Raw Buffer (last 2000) ===');
-console.log(buf.slice(-2000));
+console.log('%s', sanitizeLogFragment(buf.slice(-2000), 2000));
 
 sock.destroy();
 serverProcess.shutdown('waiter complete');

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
-import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
+import { format, resolveConfig } from 'prettier';
 import { resolveEasyedaManifestVersion } from './extension-metadata-policy.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -69,11 +69,12 @@ try {
     fs.existsSync(f),
   );
   if (prettierFiles.length > 0) {
-    execFileSync('npx', ['prettier', '--write', ...prettierFiles], {
-      cwd: root,
-      stdio: 'pipe',
-      encoding: 'utf8',
-    });
+    for (const prettierFile of prettierFiles) {
+      const prettierConfig = (await resolveConfig(prettierFile)) ?? {};
+      const source = fs.readFileSync(prettierFile, 'utf8');
+      const formatted = await format(source, { ...prettierConfig, filepath: prettierFile });
+      fs.writeFileSync(prettierFile, formatted);
+    }
     console.log('- Formatted synced JSON files with Prettier');
   }
 } catch (err) {

--- a/tests/unit/repository/e2e-log-sanitization.test.ts
+++ b/tests/unit/repository/e2e-log-sanitization.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { sanitizeLogFragment } from '../../../scripts/e2e/log-sanitization.mjs';
+
+describe('E2E diagnostic log sanitization', () => {
+  it('escapes ANSI and C0/C1 control characters instead of emitting terminal controls', () => {
+    const input = `ok\u001b[31mred\u001b[0m\nnext\u009b31m`;
+    const result = sanitizeLogFragment(input, 200);
+
+    expect(result).toContain('ok\\u001b[31mred\\u001b[0m\\u000anext\\u009b31m');
+    expect(
+      [...result].some((character) => {
+        const code = character.codePointAt(0) ?? 0;
+        return code < 0x20 || (code >= 0x7f && code <= 0x9f);
+      }),
+    ).toBe(false);
+  });
+
+  it('truncates before escaping so diagnostics stay bounded', () => {
+    expect(sanitizeLogFragment('abcdef', 3)).toBe('abc');
+  });
+
+  it('preserves ordinary printable diagnostic text', () => {
+    expect(sanitizeLogFragment('bridge connected: Fixture', 100)).toBe('bridge connected: Fixture');
+  });
+
+  it('rejects invalid length limits', () => {
+    expect(() => sanitizeLogFragment('x', 0)).toThrow('positive integer');
+    expect(() => sanitizeLogFragment('x', 1.5)).toThrow('positive integer');
+  });
+});

--- a/tests/unit/repository/live-e2e-phases.test.ts
+++ b/tests/unit/repository/live-e2e-phases.test.ts
@@ -31,6 +31,14 @@ describe('live E2E bounded phases', () => {
     expect(source).not.toContain('const pending = new Map()');
   });
 
+  it('starts the stdio MCP server with the exact current Node executable', () => {
+    const harnessPath = fileURLToPath(new URL('../../../scripts/e2e/harness.mjs', import.meta.url));
+    const source = readFileSync(harnessPath, 'utf8');
+
+    expect(source).toContain("spawn(process.execPath, options.args ?? ['dist/index.js']");
+    expect(source).not.toContain("spawn('node', options.args ?? ['dist/index.js']");
+  });
+
   it('returns the connected bridge status without sleeping', async () => {
     const reporter = createReporter();
     const toolCall = vi.fn(async () => ({

--- a/tests/unit/repository/security-tooling-policy.test.ts
+++ b/tests/unit/repository/security-tooling-policy.test.ts
@@ -263,8 +263,16 @@ describe('repository security tooling policy', () => {
     expect(verifyDist).toContain("pathSegments[0] === '..'");
     expect(verifyDist).toContain('entryEscapesRoot');
 
+    const syncVersions = readText('scripts/sync-versions.mjs');
+    expect(syncVersions).toContain("from 'prettier'");
+    expect(syncVersions).toContain('resolveConfig(prettierFile)');
+    expect(syncVersions).not.toContain('resolveConfig(prettierFiles[0])');
+    expect(syncVersions).not.toContain("execFileSync('npx'");
+
     const e2eWaiter = readText('scripts/e2e/waiter.mjs');
-    expect(e2eWaiter).toContain("console.log('%s: %s', method, r.slice(0, 300));");
+    expect(e2eWaiter).toContain("from './log-sanitization.mjs'");
+    expect(e2eWaiter).toContain('sanitizeLogFragment(r, 300)');
+    expect(e2eWaiter).not.toContain("console.log('%s: %s', method, r.slice(0, 300));");
 
     expect(releaseWorkflow).toContain(
       'uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610',


### PR DESCRIPTION
## Summary

Fixes #536.

This PR hardens the actionable legacy Sonar vulnerability findings discovered during the post-merge security review of #535 while deliberately avoiding portability-breaking scanner-only changes.

### Changes

- Remote Relay message IDs now prefer `crypto.randomUUID()`, fall back to `crypto.getRandomValues()`, and use an explicitly non-security timestamp+sequence uniqueness fallback only when Web Crypto is unavailable. `Math.random()` is no longer used for relay message IDs.
- E2E MCP server startup uses the exact current Node executable via `process.execPath` instead of PATH lookup for `node`.
- `scripts/sync-versions.mjs` formats metadata through the installed Prettier API instead of resolving `npx` through PATH; Prettier config is resolved per file so `.claude-plugin/plugin.json` keeps its existing override formatting.
- E2E waiter diagnostics sanitize and bound untrusted/raw MCP and server output before writing it to the terminal, escaping ANSI/C0/C1 controls.
- Regression/policy tests cover all of the above.

### Sonar findings intentionally classified as safe-by-context

The remaining legacy findings are not changed merely to silence the scanner:

- `src/bridge/manager.ts` uses `Math.random()` only for ±10% reconnect timing jitter; it is not a token, secret, nonce, or authorization primitive.
- `easyeda-bridge-extension/scripts/verify-dist.mjs` uses `python3` only as a cross-platform developer/release package-verification dependency. Hard-coding `/usr/bin/python3` would reduce portability without establishing a meaningful new trust boundary.
- `src/cli/client-definitions.ts` intentionally invokes the platform file-location launcher (`explorer`, `open`, `xdg-open`) with argument arrays and no shell. Hard-coding OS-specific absolute paths would reduce portability and is not appropriate on Windows/macOS.

## Verification

Exact head: `5d0624059596fb28ad4bf2cebd74c9fb0d9ed3c1`

Node 24.18.0 / pnpm 11.5.1:

- TDD RED confirmed the old `Math.random`, PATH-based Node/npx lookup, and raw terminal logging behavior.
- Focused repository tests: 39/39 passed.
- Remote Relay tests: 16/16 passed.
- `pnpm verify`: exit 0.
  - server: 192 files / 2090 tests passed
  - extension: 28 files / 392 tests passed
  - format, typecheck, lint, complexity ratchet, tool metadata, package metadata, secret hygiene, compatibility docs, VitePress docs passed
- `sync-versions` generated drift: none.
- extension package/size gate passed:
  - `.eext`: 173157 / 200000 B
  - `dist/index.js`: 249293 / 260000 B
  - `dist/dispatcher.js`: 184988 / 185000 B
- `git diff --cached --check`: passed before commit.
- Initial Sonar PR scan found one new style issue in the sanitizer (`String.raw` guidance); it was fixed in `5d0624059596fb28ad4bf2cebd74c9fb0d9ed3c1`. The exact corrected tree was then re-verified from scratch with `pnpm verify` exit 0.

## Release impact

This PR changes EasyEDA extension runtime code (`remote-client.ts`). Therefore the RC.5 live compatibility evidence must **not** be reused for a later stable promotion. If merged, the next candidate must be RC.6 (or later) with fresh commit-bound live EasyEDA compatibility evidence and a fresh soak per release policy.

## Merge gate

Merge only after fresh CI/security checks on this exact head are green, Sonar/CodeQL/Semgrep/Trivy/Socket/Codecov/Mergify contain no actionable findings, and post-merge `main` is re-verified.

