### PR TITLE
feat(mcp): add experimental dual-era HTTP routing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,7 +27,7 @@ ALLOWED_ORIGINS=
 
 # ── MCP reserved and experimental flags ────────────────────
 # Reserved configuration: parsed for compatibility, currently non-functional.
-# MCP Tasks, Apps, and v2 flags remain ineffective; raw execution uses separate experimental gates.
+# MCP Tasks and Apps remain ineffective. MCP v2 HTTP and raw execution use explicit experimental gates.
 MCP_TASKS_ENABLED=false
 MCP_APPS_ENABLED=false
 MCP_V2_EXPERIMENTAL=false

--- a/config/environment-metadata.json
+++ b/config/environment-metadata.json
@@ -137,10 +137,10 @@
     },
     {
       "name": "MCP_V2_EXPERIMENTAL",
-      "description": "Reserved; currently non-functional: does not change MCP protocol negotiation.",
+      "description": "Experimental; enables opt-in dual-era HTTP routing for MCP 2026-07-28 while legacy HTTP remains the default.",
       "format": "boolean",
       "defaultSource": "runtime",
-      "status": "reserved"
+      "status": "experimental"
     },
     {
       "name": "MCP_RAW_EXEC_EXPERIMENTAL",

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -77,19 +77,20 @@ feature is active. `easyeda_get_feature_flags`, `easyeda_get_capabilities`, and
 `easyeda_get_server_config` expose a maturity report with separate `configured` and `effective`
 values.
 
-| Settings                                                                                               | Maturity     | Runtime effect                                                                                                      |
-| ------------------------------------------------------------------------------------------------------ | ------------ | ------------------------------------------------------------------------------------------------------------------- |
-| `MCP_TASKS_ENABLED`                                                                                    | Reserved     | Parsed for compatibility; the server does not advertise or execute MCP Tasks.                                       |
-| `MCP_APPS_ENABLED`                                                                                     | Reserved     | Parsed for compatibility; no Apps UI/resource runtime is registered.                                                |
-| `MCP_V2_EXPERIMENTAL`                                                                                  | Reserved     | Does not change protocol negotiation. See [MCP protocol compatibility](../reference/mcp-protocol-compatibility.md). |
-| `AI_PROVIDER`, `AI_MODEL`, `AI_API_KEY`, `AI_MAX_TOKENS`, `AI_TIMEOUT_MS`, `AI_ALLOW_DESIGN_MUTATIONS` | Reserved     | No in-process AI provider is called and no AI design mutation is enabled.                                           |
-| `OTEL_ENABLED`, `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `TRACE_SAMPLE_RATE`                | Reserved     | No OTLP exporter is started; local structured metrics remain available.                                             |
-| `MCP_BRIDGE_BACKEND=remote_relay`                                                                      | Experimental | Activates the implemented paired relay path with documented non-Beta limitations.                                   |
-| Raw execution gates                                                                                    | Experimental | Effective only when both explicit development-only gates are enabled; refused in production.                        |
-| OAuth/JWKS settings                                                                                    | Implemented  | Enforced for non-loopback HTTP and used for token validation.                                                       |
+| Settings                                                                                               | Maturity     | Runtime effect                                                                                                                                                                                            |
+| ------------------------------------------------------------------------------------------------------ | ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MCP_TASKS_ENABLED`                                                                                    | Reserved     | Parsed for compatibility; the server does not advertise or execute MCP Tasks.                                                                                                                             |
+| `MCP_APPS_ENABLED`                                                                                     | Reserved     | Parsed for compatibility; no Apps UI/resource runtime is registered.                                                                                                                                      |
+| `MCP_V2_EXPERIMENTAL`                                                                                  | Experimental | Enables opt-in dual-era HTTP routing for MCP `2026-07-28`; legacy HTTP remains the default and modern stdio is not enabled. See [MCP protocol compatibility](../reference/mcp-protocol-compatibility.md). |
+| `AI_PROVIDER`, `AI_MODEL`, `AI_API_KEY`, `AI_MAX_TOKENS`, `AI_TIMEOUT_MS`, `AI_ALLOW_DESIGN_MUTATIONS` | Reserved     | No in-process AI provider is called and no AI design mutation is enabled.                                                                                                                                 |
+| `OTEL_ENABLED`, `OTEL_SERVICE_NAME`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `TRACE_SAMPLE_RATE`                | Reserved     | No OTLP exporter is started; local structured metrics remain available.                                                                                                                                   |
+| `MCP_BRIDGE_BACKEND=remote_relay`                                                                      | Experimental | Activates the implemented paired relay path with documented non-Beta limitations.                                                                                                                         |
+| Raw execution gates                                                                                    | Experimental | Effective only when both explicit development-only gates are enabled; refused in production.                                                                                                              |
+| OAuth/JWKS settings                                                                                    | Implemented  | Enforced for non-loopback HTTP and used for token validation.                                                                                                                                             |
 
-Reserved settings report `effective: false` even when configured. They are retained so future
-implementation can avoid unnecessary configuration churn, but must not be presented as shipped
+Reserved settings report `effective: false` even when configured. Experimental settings report
+their actual runtime state. Reserved settings are retained so future implementation can avoid
+unnecessary configuration churn, but must not be presented as shipped
 product capabilities.
 
 ---

--- a/docs/reference/mcp-protocol-compatibility.md
+++ b/docs/reference/mcp-protocol-compatibility.md
@@ -1,25 +1,27 @@
 # MCP protocol compatibility
 
 This document records the protocol boundary that must remain explicit while `easyeda-mcp-pro`
-adds support for MCP `2026-07-28`. It is a compatibility contract, not a claim that the modern
-protocol is already enabled.
+adds support for MCP `2026-07-28`. The modern HTTP era is opt-in behind
+`MCP_V2_EXPERIMENTAL`; legacy/sessionful HTTP remains the default and modern stdio remains pending.
 
 ## Current support
 
-| Area                  | Current repository behavior                                                     |
-| --------------------- | ------------------------------------------------------------------------------- |
-| MCP SDK               | Modular v2 packages; server/node lock to `2.0.0`, client is test-only           |
-| Default MCP revision  | `2025-11-25`                                                                    |
-| HTTP era              | Legacy/sessionful                                                               |
-| HTTP initialization   | `initialize` followed by `notifications/initialized`                            |
-| HTTP session identity | `MCP-Session-Id`                                                                |
-| HTTP session routing  | Per-session `McpServer` + `StreamableHTTPServerTransport` instances             |
-| Stdio                 | `McpServer.connect(new StdioServerTransport())`                                 |
-| MCP `2026-07-28`      | Not supported; `MCP_V2_EXPERIMENTAL` remains reserved and has no runtime effect |
+| Area                  | Current repository behavior                                                 |
+| --------------------- | --------------------------------------------------------------------------- |
+| MCP SDK               | Modular v2 packages; server/node lock to `2.0.0`, client is test-only       |
+| Default MCP revision  | `2025-11-25`                                                                |
+| HTTP era              | Legacy/sessionful by default; dual-era when `MCP_V2_EXPERIMENTAL=true`      |
+| HTTP initialization   | `initialize` followed by `notifications/initialized`                        |
+| HTTP session identity | `MCP-Session-Id`                                                            |
+| HTTP session routing  | Per-session `McpServer` + `StreamableHTTPServerTransport` instances         |
+| Stdio                 | `McpServer.connect(new StdioServerTransport())`                             |
+| MCP `2026-07-28`      | Experimental HTTP support behind `MCP_V2_EXPERIMENTAL`; disabled by default |
 
 The server intentionally accepts a missing `MCP-Protocol-Version` header for retained legacy
-clients. If the header is present today, it must equal the configured legacy revision. A
-`2026-07-28` request is therefore rejected before legacy session state is created.
+clients. With the experimental flag disabled, an explicit non-legacy version is rejected before
+legacy session state is created. With the flag enabled, official SDK classification routes legacy
+requests to the retained session map and modern claims to a strict per-request v2 handler; malformed
+or unsupported modern claims stay on the modern rejection path and cannot create legacy sessions.
 
 ## Upstream protocol eras
 
@@ -42,7 +44,7 @@ Research baseline on 2026-08-09: the stable v2 packages
 `@modelcontextprotocol/server`, `@modelcontextprotocol/client`, `@modelcontextprotocol/node`, and
 `@modelcontextprotocol/core` are published at `2.0.0`. The repository now resolves the direct
 server/node SDK packages to `2.0.0` in the lockfile and keeps the client package test-only. This
-changes SDK packaging and handler context compatibility only; no modern protocol path is enabled.
+provides the modular SDK foundation used by the opt-in modern HTTP path.
 
 Primary references:
 
@@ -57,25 +59,25 @@ Every row is a migration invariant. `Retain` means the current behavior remains 
 `Replace` means the modern path needs a separate implementation; `Remove` means the behavior must
 not leak into modern requests.
 
-| Current behavior                                          | Legacy path                                | Modern `2026-07-28` path                                              | Migration rule                                                                                                                              |
-| --------------------------------------------------------- | ------------------------------------------ | --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
-| `initialize` + `notifications/initialized`                | Retain                                     | Remove                                                                | Never emulate modern support by accepting an initialize request under a new version string.                                                 |
-| `MCP-Session-Id`                                          | Retain                                     | Remove                                                                | Modern request handling must not depend on legacy session headers or the legacy session map.                                                |
-| `Map<sessionId, McpHttpSession>`                          | Retain                                     | Replace                                                               | Build modern request state per request; do not share a legacy `McpServer`/transport instance with modern traffic.                           |
-| POST without a session ID is accepted only for initialize | Retain                                     | Replace                                                               | Modern POST requests are self-contained and must be routed to the modern handler instead of the legacy initialize gate.                     |
-| GET `/mcp` session stream routing                         | Retain                                     | Replace where the v2 handler requires streaming                       | Do not route a modern request through `sessionForRequest`.                                                                                  |
-| DELETE `/mcp` session termination                         | Retain                                     | Remove from modern session semantics                                  | A modern request has no legacy MCP session to terminate.                                                                                    |
-| Missing protocol header accepted                          | Retain for legacy compatibility            | Do not use as proof of modern era                                     | Era detection must be explicit and deterministic.                                                                                           |
-| Single configured `MCP_PROTOCOL_VERSION` equality check   | Retain only as legacy compatibility policy | Replace                                                               | Modern negotiation must validate supported eras/versions rather than silently widening the legacy middleware.                               |
-| Unsupported-version JSON response                         | Retain                                     | Replace with the modern SDK/protocol structured rejection             | Rejections must name supported protocol eras/versions and create no session/request state.                                                  |
-| `createSessionServer()` factory                           | Retain for sessionful legacy HTTP          | Replace with an era-aware fresh server factory                        | Tool/resource/prompt registration must be deterministic in both eras.                                                                       |
-| Direct `McpServer` + `StdioServerTransport`               | Retain                                     | Replace with `serveStdio(...)` when modern stdio is enabled           | Do not change stdio wire behavior merely by upgrading package imports.                                                                      |
-| OAuth/JWKS verification                                   | Retain                                     | Retain                                                                | Era selection happens inside the same authenticated trust boundary; issuer, audience, signature, expiry, and scope checks stay fail closed. |
-| Host validation / DNS-rebinding protection                | Retain                                     | Retain                                                                | Modern routing must not bypass the existing Host-header policy.                                                                             |
-| Origin allowlist / CORS                                   | Retain                                     | Retain, with modern MCP headers added only as required                | Never use permissive CORS as protocol negotiation.                                                                                          |
-| Rate limiting and security headers                        | Retain                                     | Retain                                                                | Apply before dispatch for both eras.                                                                                                        |
-| Remote Relay authorization and invocation grants          | Retain                                     | Retain                                                                | Protocol-era changes must not weaken user/session isolation, approval requirements, or one-invocation grant scope.                          |
-| `MCP_V2_EXPERIMENTAL` reserved/no-op                      | Retain until an implementation is complete | Replace only with an explicit, tested rollout control if still needed | Setting the variable must not silently activate a partial modern stack.                                                                     |
+| Current behavior                                          | Legacy path                                | Modern `2026-07-28` path                                    | Migration rule                                                                                                                              |
+| --------------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `initialize` + `notifications/initialized`                | Retain                                     | Remove                                                      | Never emulate modern support by accepting an initialize request under a new version string.                                                 |
+| `MCP-Session-Id`                                          | Retain                                     | Remove                                                      | Modern request handling must not depend on legacy session headers or the legacy session map.                                                |
+| `Map<sessionId, McpHttpSession>`                          | Retain                                     | Replace                                                     | Build modern request state per request; do not share a legacy `McpServer`/transport instance with modern traffic.                           |
+| POST without a session ID is accepted only for initialize | Retain                                     | Replace                                                     | Modern POST requests are self-contained and must be routed to the modern handler instead of the legacy initialize gate.                     |
+| GET `/mcp` session stream routing                         | Retain                                     | Replace where the v2 handler requires streaming             | Do not route a modern request through `sessionForRequest`.                                                                                  |
+| DELETE `/mcp` session termination                         | Retain                                     | Remove from modern session semantics                        | A modern request has no legacy MCP session to terminate.                                                                                    |
+| Missing protocol header accepted                          | Retain for legacy compatibility            | Do not use as proof of modern era                           | Era detection must be explicit and deterministic.                                                                                           |
+| Single configured `MCP_PROTOCOL_VERSION` equality check   | Retain only as legacy compatibility policy | Replace                                                     | Modern negotiation must validate supported eras/versions rather than silently widening the legacy middleware.                               |
+| Unsupported-version JSON response                         | Retain                                     | Replace with the modern SDK/protocol structured rejection   | Rejections must name supported protocol eras/versions and create no session/request state.                                                  |
+| `createSessionServer()` factory                           | Retain for sessionful legacy HTTP          | Replace with an era-aware fresh server factory              | Tool/resource/prompt registration must be deterministic in both eras.                                                                       |
+| Direct `McpServer` + `StdioServerTransport`               | Retain                                     | Replace with `serveStdio(...)` when modern stdio is enabled | Do not change stdio wire behavior merely by upgrading package imports.                                                                      |
+| OAuth/JWKS verification                                   | Retain                                     | Retain                                                      | Era selection happens inside the same authenticated trust boundary; issuer, audience, signature, expiry, and scope checks stay fail closed. |
+| Host validation / DNS-rebinding protection                | Retain                                     | Retain                                                      | Modern routing must not bypass the existing Host-header policy.                                                                             |
+| Origin allowlist / CORS                                   | Retain                                     | Retain, with modern MCP headers added only as required      | Never use permissive CORS as protocol negotiation.                                                                                          |
+| Rate limiting and security headers                        | Retain                                     | Retain                                                      | Apply before dispatch for both eras.                                                                                                        |
+| Remote Relay authorization and invocation grants          | Retain                                     | Retain                                                      | Protocol-era changes must not weaken user/session isolation, approval requirements, or one-invocation grant scope.                          |
+| `MCP_V2_EXPERIMENTAL` rollout gate                        | Retain for legacy/default-off behavior     | Experimental opt-in for modern HTTP                         | Flag-on uses official era classification; flag-off preserves the pre-existing legacy contract.                                              |
 
 ## Security invariants
 
@@ -104,15 +106,15 @@ The compatibility work should remain reviewable as separate changes:
 1. **Legacy baseline:** lock the current raw HTTP initialize/session/termination behavior and
    unsupported-modern-version rejection in tests. No production behavior changes.
 2. **SDK v2 compile migration:** use the stable modular v2 package set and migrate imports while
-   preserving legacy wire behavior. Keep `MCP_V2_EXPERIMENTAL` non-effective; no modern era is
-   enabled by this step.
-3. **Modern HTTP path:** add explicit era routing and `2026-07-28` request handling while keeping
-   the existing sessionful route independent.
+   preserving legacy wire behavior. This foundation is complete.
+3. **Modern HTTP path:** explicit era routing and `2026-07-28` request handling are available
+   behind `MCP_V2_EXPERIMENTAL`; the existing sessionful route remains independent.
 4. **Modern stdio path:** adopt the v2 stdio lifecycle behind an explicit compatibility boundary.
 5. **Security and Remote Relay parity:** prove OAuth, origin/Host, rate-limit, scope, approval, and
    relay isolation on both eras with independent fixtures.
 6. **Rollout:** document supported/experimental/deprecated states, verify rollback to the retained
    legacy path, then consider changing defaults only through a separate release decision.
 
-Until those steps are complete, `2025-11-25` remains the supported MCP application protocol and
-`MCP_V2_EXPERIMENTAL` remains non-effective.
+Until the remaining stdio, parity, and rollout steps are complete, `2025-11-25` remains the
+default supported MCP application protocol. Experimental `2026-07-28` HTTP support requires
+`MCP_V2_EXPERIMENTAL=true`.

--- a/server.json
+++ b/server.json
@@ -135,7 +135,7 @@
         },
         {
           "name": "MCP_V2_EXPERIMENTAL",
-          "description": "Reserved; currently non-functional: does not change MCP protocol negotiation.",
+          "description": "Experimental; enables opt-in dual-era HTTP routing for MCP 2026-07-28 while legacy HTTP remains the default.",
           "isRequired": false,
           "format": "boolean",
           "default": "false"

--- a/src/config/feature-maturity.ts
+++ b/src/config/feature-maturity.ts
@@ -41,10 +41,10 @@ export function getFeatureMaturity(config: EnvConfig): FeatureMaturityReport {
       note: 'The setting is reserved; no MCP Apps UI/resource runtime is registered.',
     },
     mcp_v2: {
-      maturity: 'reserved',
+      maturity: 'experimental',
       configured: config.MCP_V2_EXPERIMENTAL,
-      effective: false,
-      note: 'The setting is reserved and does not change the negotiated MCP protocol.',
+      effective: config.MCP_V2_EXPERIMENTAL,
+      note: 'Enables opt-in dual-era HTTP routing for MCP 2026-07-28 while retaining the legacy sessionful path.',
     },
     ai_provider: {
       maturity: 'reserved',

--- a/src/server/transports/http.ts
+++ b/src/server/transports/http.ts
@@ -1,7 +1,15 @@
 import { randomUUID } from 'node:crypto';
 import express, { type Express, type Request, type Response, type NextFunction } from 'express';
-import { NodeStreamableHTTPServerTransport } from '@modelcontextprotocol/node';
-import { isInitializeRequest } from '@modelcontextprotocol/server';
+import {
+  NodeStreamableHTTPServerTransport,
+  toNodeHandler,
+  toWebRequest,
+} from '@modelcontextprotocol/node';
+import {
+  createMcpHandler,
+  isInitializeRequest,
+  isLegacyRequest,
+} from '@modelcontextprotocol/server';
 import type { McpServer, AuthInfo } from '@modelcontextprotocol/server';
 import { createRemoteJWKSet, jwtVerify } from 'jose';
 import { type EnvConfig } from '../../config/env.js';
@@ -356,7 +364,11 @@ export function validateMcpProtocolVersion(config: EnvConfig) {
 
     const header = req.headers['mcp-protocol-version'];
     const requestedVersion = Array.isArray(header) ? header[0] : header;
-    if (requestedVersion === undefined || requestedVersion === config.MCP_PROTOCOL_VERSION) {
+    if (
+      config.MCP_V2_EXPERIMENTAL ||
+      requestedVersion === undefined ||
+      requestedVersion === config.MCP_PROTOCOL_VERSION
+    ) {
       next();
       return;
     }
@@ -450,6 +462,19 @@ export function createHttpTransport(
   const logger = getLogger();
   const gateway = options.gateway ?? new RemoteGateway();
   const sessions = new Map<string, McpHttpSession>();
+  const serverFactory = options.serverFactory;
+  const modernHandler =
+    config.MCP_V2_EXPERIMENTAL && serverFactory
+      ? createMcpHandler(() => serverFactory(), {
+          legacy: 'reject',
+          onerror: (error) => logger.error({ err: error.message }, 'modern MCP HTTP handler error'),
+        })
+      : undefined;
+  const modernNodeHandler = modernHandler
+    ? toNodeHandler(modernHandler, {
+        onerror: (error) => logger.error({ err: error.message }, 'modern MCP HTTP adapter error'),
+      })
+    : undefined;
 
   // Retained for compatibility with callers that explicitly attach one MCP
   // server. Production HTTP uses serverFactory and the session map below.
@@ -560,6 +585,13 @@ export function createHttpTransport(
   };
 
   app.post('/mcp', async (req, res) => {
+    if (modernNodeHandler) {
+      if (!(await isLegacyRequest(await toWebRequest(req), req.body))) {
+        await modernNodeHandler(req, res, req.body);
+        return;
+      }
+    }
+
     if (!options.serverFactory) {
       await transport.handleRequest(req, res, req.body);
       return;
@@ -629,6 +661,7 @@ export function createHttpTransport(
     const activeSessions = [...sessions.values()];
     await Promise.allSettled(activeSessions.map(closeMcpSession));
     await transport.close();
+    await modernHandler?.close();
     const s = server;
     if (s) {
       await new Promise<void>((resolve) => s.close(() => resolve()));

--- a/tests/unit/config/env.test.ts
+++ b/tests/unit/config/env.test.ts
@@ -657,7 +657,7 @@ describe('loadFeatureFlags', () => {
     expect(loadFeatureFlags(config)).toEqual({
       mcpTasksEnabled: false,
       mcpAppsEnabled: false,
-      mcpV2Experimental: false,
+      mcpV2Experimental: true,
       jlcpcbOrderingEnabled: true,
       jlcsearchEnabled: true,
       mouserEnabled: true,

--- a/tests/unit/repository/feature-maturity-docs-policy.test.ts
+++ b/tests/unit/repository/feature-maturity-docs-policy.test.ts
@@ -8,7 +8,6 @@ const read = (path: string) => readFileSync(resolve(repoRoot, path), 'utf8').rep
 const reservedNames = [
   'MCP_TASKS_ENABLED',
   'MCP_APPS_ENABLED',
-  'MCP_V2_EXPERIMENTAL',
   'AI_PROVIDER',
   'AI_MODEL',
   'AI_API_KEY',

--- a/tests/unit/server/transports/http.test.ts
+++ b/tests/unit/server/transports/http.test.ts
@@ -1019,4 +1019,111 @@ describe('createHttpTransport — legacy protocol migration baseline', () => {
       await harness.close();
     }
   });
+
+  it('routes 2026-era discovery through the modern handler when explicitly enabled', async () => {
+    const config = createTestConfig({
+      HTTP_AUTH_DISABLED: true,
+      MCP_V2_EXPERIMENTAL: true,
+    });
+    const transport = createHttpTransport(config, {
+      serverFactory: () =>
+        new McpServer({ name: 'dual-era', version: '1.0.0' }, { capabilities: { tools: {} } }),
+    });
+    const server = http.createServer(transport.app);
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    if (!address || typeof address === 'string')
+      throw new Error('HTTP test server has no TCP port');
+    const mcpUrl = `http://127.0.0.1:${address.port}/mcp`;
+
+    try {
+      const malformedModern = await fetch(mcpUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'MCP-Protocol-Version': '2026-07-28',
+          'Mcp-Method': 'ping',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 40, method: 'ping', params: {} }),
+      });
+      expect(malformedModern.status).toBe(400);
+      await expect(malformedModern.json()).resolves.toMatchObject({
+        jsonrpc: '2.0',
+        id: 40,
+        error: { code: -32602 },
+      });
+      expect(transport.activeSessionCount).toBe(0);
+
+      const response = await fetch(mcpUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'MCP-Protocol-Version': '2026-07-28',
+          'Mcp-Method': 'server/discover',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 41,
+          method: 'server/discover',
+          params: {
+            _meta: {
+              'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+              'io.modelcontextprotocol/clientInfo': { name: 'dual-era-test', version: '1.0.0' },
+              'io.modelcontextprotocol/clientCapabilities': {},
+            },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get('mcp-session-id')).toBeNull();
+      await expect(response.json()).resolves.toMatchObject({
+        jsonrpc: '2.0',
+        id: 41,
+        result: {
+          supportedVersions: ['2026-07-28'],
+          ttlMs: 0,
+          cacheScope: 'private',
+        },
+      });
+      expect(transport.activeSessionCount).toBe(0);
+
+      const legacyInitialize = await fetch(mcpUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 42,
+          method: 'initialize',
+          params: {
+            protocolVersion: '2025-11-25',
+            capabilities: {},
+            clientInfo: { name: 'legacy-alongside-modern', version: '1.0.0' },
+          },
+        }),
+      });
+      expect(legacyInitialize.status).toBe(200);
+      const legacySessionId = legacyInitialize.headers.get('mcp-session-id');
+      expect(legacySessionId).toMatch(/^[0-9a-f-]{36}$/i);
+      expect(transport.activeSessionCount).toBe(1);
+
+      const legacyDelete = await fetch(mcpUrl, {
+        method: 'DELETE',
+        headers: {
+          Accept: 'application/json, text/event-stream',
+          'MCP-Session-Id': legacySessionId!,
+        },
+      });
+      expect(legacyDelete.status).toBe(200);
+      expect(transport.activeSessionCount).toBe(0);
+    } finally {
+      await transport.close();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
 });

--- a/tests/unit/server/transports/http.test.ts
+++ b/tests/unit/server/transports/http.test.ts
@@ -1035,6 +1035,7 @@ describe('createHttpTransport — legacy protocol migration baseline', () => {
     if (!address || typeof address === 'string')
       throw new Error('HTTP test server has no TCP port');
     const mcpUrl = `http://127.0.0.1:${address.port}/mcp`;
+    let transportClosed = false;
 
     try {
       const malformedModern = await fetch(mcpUrl, {
@@ -1121,8 +1122,36 @@ describe('createHttpTransport — legacy protocol migration baseline', () => {
       });
       expect(legacyDelete.status).toBe(200);
       expect(transport.activeSessionCount).toBe(0);
-    } finally {
+
       await transport.close();
+      transportClosed = true;
+      const afterClose = await fetch(mcpUrl, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'MCP-Protocol-Version': '2026-07-28',
+          'Mcp-Method': 'server/discover',
+        },
+        body: JSON.stringify({
+          jsonrpc: '2.0',
+          id: 43,
+          method: 'server/discover',
+          params: {
+            _meta: {
+              'io.modelcontextprotocol/protocolVersion': '2026-07-28',
+              'io.modelcontextprotocol/clientInfo': {
+                name: 'closed-handler-test',
+                version: '1.0.0',
+              },
+              'io.modelcontextprotocol/clientCapabilities': {},
+            },
+          },
+        }),
+      });
+      expect(afterClose.status).toBe(500);
+    } finally {
+      if (!transportClosed) await transport.close();
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });

--- a/tests/unit/tools/diagnostics-feature-report.test.ts
+++ b/tests/unit/tools/diagnostics-feature-report.test.ts
@@ -32,18 +32,18 @@ describe('diagnostics feature reporting', () => {
     MCP_RAW_EXEC_EXPERIMENTAL: 'true',
   });
 
-  it('keeps reserved flags ineffective across every public diagnostics view', () => {
+  it('keeps reserved flags ineffective while reporting the experimental MCP v2 flag', () => {
     expect(buildCapabilityFeatureFlags(config)).toEqual({
       tasks_enabled: false,
       apps_enabled: false,
-      v2_experimental: false,
+      v2_experimental: true,
       ordering_enabled: true,
     });
 
     expect(buildServerConfigFeatureFlags(config)).toEqual({
       mcp_tasks_enabled: false,
       mcp_apps_enabled: false,
-      mcp_v2_experimental: false,
+      mcp_v2_experimental: true,
       ai_enabled: false,
       otel_enabled: false,
     });
@@ -53,7 +53,7 @@ describe('diagnostics feature reporting', () => {
     expect(buildDetailedFeatureFlags(config)).toEqual({
       mcp_tasks_enabled: false,
       mcp_apps_enabled: false,
-      mcp_v2_experimental: false,
+      mcp_v2_experimental: true,
       jlcpcb_ordering_enabled: true,
       jlcsearch_enabled: true,
       mouser_enabled: true,

--- a/tests/unit/tools/diagnostics.test.ts
+++ b/tests/unit/tools/diagnostics.test.ts
@@ -214,7 +214,7 @@ describe('Diagnostics Tools', () => {
     expect(activeProfile?.name).toBe('core');
   });
 
-  it('reports reserved feature configuration as configured but not effective', async () => {
+  it('reports reserved features as ineffective and the MCP v2 rollout as experimental', async () => {
     const configuredRegistry = new ToolRegistry();
     registerDiagnosticsCore(
       configuredRegistry,
@@ -232,14 +232,14 @@ describe('Diagnostics Tools', () => {
     expect(flags?.flags).toMatchObject({
       mcp_tasks_enabled: false,
       mcp_apps_enabled: false,
-      mcp_v2_experimental: false,
+      mcp_v2_experimental: true,
       ai_enabled: false,
       otel_enabled: false,
     });
     expect(flags?.maturity).toMatchObject({
       mcp_tasks: { maturity: 'reserved', configured: true, effective: false },
       mcp_apps: { maturity: 'reserved', configured: true, effective: false },
-      mcp_v2: { maturity: 'reserved', configured: true, effective: false },
+      mcp_v2: { maturity: 'experimental', configured: true, effective: true },
       ai_provider: { maturity: 'reserved', configured: true, effective: false },
       otel_export: { maturity: 'reserved', configured: true, effective: false },
     });


### PR DESCRIPTION
## Summary
- add opt-in dual-era HTTP routing for MCP 2026-07-28 behind `MCP_V2_EXPERIMENTAL`
- classify requests with the official SDK and route modern traffic through the strict modern handler while preserving the legacy sessionful path
- update feature maturity/environment metadata and protocol compatibility docs
- add regression coverage proving malformed modern traffic cannot fall into legacy sessions and modern discovery coexists with legacy initialize/delete

## Verification
- `pnpm verify`
- `pnpm security:audit`
- `pnpm security:semgrep`
- targeted MCP/config/diagnostics suite: 153 tests passed

Refs #476

This PR completes the dual-era HTTP routing slice only. #476 should remain open for modern stdio/client/doctor interop and final dual-era smoke evidence.
