### PR TITLE
fix(quality): reduce Sonar new-code duplication

### DIFF
--- a/easyeda-bridge-extension/tests/capture-binary-result.test.ts
+++ b/easyeda-bridge-extension/tests/capture-binary-result.test.ts
@@ -5,6 +5,36 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+type CanvasRuntime = {
+  createImageBitmap: typeof globalThis.createImageBitmap;
+  OffscreenCanvas: typeof globalThis.OffscreenCanvas;
+};
+
+async function withCanvasRuntime<T>(runtime: CanvasRuntime, run: () => Promise<T>) {
+  const originalCreateImageBitmap = globalThis.createImageBitmap;
+  const originalOffscreenCanvas = globalThis.OffscreenCanvas;
+  Object.defineProperty(globalThis, 'createImageBitmap', {
+    configurable: true,
+    value: runtime.createImageBitmap,
+  });
+  Object.defineProperty(globalThis, 'OffscreenCanvas', {
+    configurable: true,
+    value: runtime.OffscreenCanvas,
+  });
+  try {
+    return await run();
+  } finally {
+    Object.defineProperty(globalThis, 'createImageBitmap', {
+      configurable: true,
+      value: originalCreateImageBitmap,
+    });
+    Object.defineProperty(globalThis, 'OffscreenCanvas', {
+      configurable: true,
+      value: originalOffscreenCanvas,
+    });
+  }
+}
+
 describe('canvas binary result policy', () => {
   it('caps the canvas budget at 1 MiB even when the bridge transport limit is larger', async () => {
     const originalBytes = new Uint8Array([1, 2, 3]);
@@ -38,221 +68,151 @@ describe('canvas binary result policy', () => {
 
   it('fails closed when the runtime cannot decode an oversized capture', async () => {
     const original = new Blob([new Uint8Array(1_000)], { type: 'image/png' });
-    const originalCreateImageBitmap = globalThis.createImageBitmap;
-    const originalOffscreenCanvas = globalThis.OffscreenCanvas;
-    Object.defineProperty(globalThis, 'createImageBitmap', {
-      configurable: true,
-      value: vi.fn(async () => {
-        throw new Error('decode failed');
-      }),
-    });
-    Object.defineProperty(globalThis, 'OffscreenCanvas', {
-      configurable: true,
-      value: class {},
-    });
-
-    try {
-      await expect(
-        normalizeCanvasBinaryResult(original, 'capture.png', 1_000),
-      ).rejects.toMatchObject({
-        code: 'PAYLOAD_TOO_LARGE',
-      });
-    } finally {
-      Object.defineProperty(globalThis, 'createImageBitmap', {
-        configurable: true,
-        value: originalCreateImageBitmap,
-      });
-      Object.defineProperty(globalThis, 'OffscreenCanvas', {
-        configurable: true,
-        value: originalOffscreenCanvas,
-      });
-    }
+    await withCanvasRuntime(
+      {
+        createImageBitmap: vi.fn(async () => {
+          throw new Error('decode failed');
+        }),
+        OffscreenCanvas: class {} as typeof globalThis.OffscreenCanvas,
+      },
+      async () => {
+        await expect(
+          normalizeCanvasBinaryResult(original, 'capture.png', 1_000),
+        ).rejects.toMatchObject({ code: 'PAYLOAD_TOO_LARGE' });
+      },
+    );
   });
 
   it('fails closed when resized PNG encoding throws', async () => {
     const original = new Blob([new Uint8Array(1_000)], { type: 'image/png' });
-    const originalCreateImageBitmap = globalThis.createImageBitmap;
-    const originalOffscreenCanvas = globalThis.OffscreenCanvas;
-    Object.defineProperty(globalThis, 'createImageBitmap', {
-      configurable: true,
-      value: vi.fn(async () => ({ width: 100, height: 50, close: vi.fn() })),
-    });
-    Object.defineProperty(globalThis, 'OffscreenCanvas', {
-      configurable: true,
-      value: class {
-        getContext() {
-          return { drawImage: vi.fn() };
-        }
-        async convertToBlob() {
-          throw new Error('encode failed');
-        }
+    await withCanvasRuntime(
+      {
+        createImageBitmap: vi.fn(async () => ({ width: 100, height: 50, close: vi.fn() })),
+        OffscreenCanvas: class {
+          getContext() {
+            return { drawImage: vi.fn() };
+          }
+          async convertToBlob() {
+            throw new Error('encode failed');
+          }
+        } as typeof globalThis.OffscreenCanvas,
       },
-    });
-
-    try {
-      await expect(
-        normalizeCanvasBinaryResult(original, 'capture.png', 1_000),
-      ).rejects.toMatchObject({
-        code: 'PAYLOAD_TOO_LARGE',
-      });
-    } finally {
-      Object.defineProperty(globalThis, 'createImageBitmap', {
-        configurable: true,
-        value: originalCreateImageBitmap,
-      });
-      Object.defineProperty(globalThis, 'OffscreenCanvas', {
-        configurable: true,
-        value: originalOffscreenCanvas,
-      });
-    }
+      async () => {
+        await expect(
+          normalizeCanvasBinaryResult(original, 'capture.png', 1_000),
+        ).rejects.toMatchObject({ code: 'PAYLOAD_TOO_LARGE' });
+      },
+    );
   });
 
   it('retries compression deterministically and fails if even a 1x1 PNG exceeds budget', async () => {
     const original = new Blob([new Uint8Array(1_000)], { type: 'image/png' });
-    const originalCreateImageBitmap = globalThis.createImageBitmap;
-    const originalOffscreenCanvas = globalThis.OffscreenCanvas;
     const convertToBlob = vi
       .fn()
       .mockResolvedValueOnce(new Blob([new Uint8Array(900)], { type: 'image/png' }))
       .mockResolvedValueOnce(new Blob([new Uint8Array(500)], { type: 'image/png' }));
-    Object.defineProperty(globalThis, 'createImageBitmap', {
-      configurable: true,
-      value: vi.fn(async () => ({ width: 100, height: 50, close: vi.fn() })),
-    });
-    Object.defineProperty(globalThis, 'OffscreenCanvas', {
-      configurable: true,
-      value: class {
-        getContext() {
-          return { drawImage: vi.fn() };
-        }
-        convertToBlob = convertToBlob;
+
+    await withCanvasRuntime(
+      {
+        createImageBitmap: vi.fn(async () => ({ width: 100, height: 50, close: vi.fn() })),
+        OffscreenCanvas: class {
+          getContext() {
+            return { drawImage: vi.fn() };
+          }
+          convertToBlob = convertToBlob;
+        } as typeof globalThis.OffscreenCanvas,
       },
-    });
+      async () => {
+        const result = (await normalizeCanvasBinaryResult(original, 'capture.png', 1_000)) as {
+          byteLength: number;
+        };
+        expect(convertToBlob).toHaveBeenCalledTimes(2);
+        expect(result.byteLength).toBe(500);
+      },
+    );
 
-    try {
-      const result = (await normalizeCanvasBinaryResult(original, 'capture.png', 1_000)) as {
-        byteLength: number;
-      };
-      expect(convertToBlob).toHaveBeenCalledTimes(2);
-      expect(result.byteLength).toBe(500);
-
-      Object.defineProperty(globalThis, 'createImageBitmap', {
-        configurable: true,
-        value: vi.fn(async () => ({ width: 1, height: 1, close: vi.fn() })),
-      });
-      Object.defineProperty(globalThis, 'OffscreenCanvas', {
-        configurable: true,
-        value: class {
+    await withCanvasRuntime(
+      {
+        createImageBitmap: vi.fn(async () => ({ width: 1, height: 1, close: vi.fn() })),
+        OffscreenCanvas: class {
           getContext() {
             return { drawImage: vi.fn() };
           }
           async convertToBlob() {
             return new Blob([new Uint8Array(700)], { type: 'image/png' });
           }
-        },
-      });
-      await expect(
-        normalizeCanvasBinaryResult(original, 'capture.png', 1_000),
-      ).rejects.toMatchObject({
-        code: 'PAYLOAD_TOO_LARGE',
-      });
-    } finally {
-      Object.defineProperty(globalThis, 'createImageBitmap', {
-        configurable: true,
-        value: originalCreateImageBitmap,
-      });
-      Object.defineProperty(globalThis, 'OffscreenCanvas', {
-        configurable: true,
-        value: originalOffscreenCanvas,
-      });
-    }
+        } as typeof globalThis.OffscreenCanvas,
+      },
+      async () => {
+        await expect(
+          normalizeCanvasBinaryResult(original, 'capture.png', 1_000),
+        ).rejects.toMatchObject({ code: 'PAYLOAD_TOO_LARGE' });
+      },
+    );
   });
 
   it('fails closed with an actionable error when oversized capture resizing is unavailable', async () => {
     const original = new Blob([new Uint8Array(1_000)], { type: 'image/png' });
-    const originalCreateImageBitmap = globalThis.createImageBitmap;
-    const originalOffscreenCanvas = globalThis.OffscreenCanvas;
-    Object.defineProperty(globalThis, 'createImageBitmap', {
-      configurable: true,
-      value: undefined,
-    });
-    Object.defineProperty(globalThis, 'OffscreenCanvas', { configurable: true, value: undefined });
-
-    try {
-      await expect(
-        normalizeCanvasBinaryResult(original, 'capture.png', 1_000),
-      ).rejects.toMatchObject({
-        code: 'PAYLOAD_TOO_LARGE',
-        message: expect.stringContaining('cannot safely downsample'),
-        suggestion: expect.stringContaining('smaller capture region'),
-      });
-    } finally {
-      Object.defineProperty(globalThis, 'createImageBitmap', {
-        configurable: true,
-        value: originalCreateImageBitmap,
-      });
-      Object.defineProperty(globalThis, 'OffscreenCanvas', {
-        configurable: true,
-        value: originalOffscreenCanvas,
-      });
-    }
+    await withCanvasRuntime(
+      {
+        createImageBitmap: undefined as typeof globalThis.createImageBitmap,
+        OffscreenCanvas: undefined as typeof globalThis.OffscreenCanvas,
+      },
+      async () => {
+        await expect(
+          normalizeCanvasBinaryResult(original, 'capture.png', 1_000),
+        ).rejects.toMatchObject({
+          code: 'PAYLOAD_TOO_LARGE',
+          message: expect.stringContaining('cannot safely downsample'),
+          suggestion: expect.stringContaining('smaller capture region'),
+        });
+      },
+    );
   });
 
   it('downsamples an oversized PNG below the safe encoded-result budget', async () => {
     const original = new Blob([new Uint8Array(1_000)], { type: 'image/png' });
-    const originalCreateImageBitmap = globalThis.createImageBitmap;
-    const originalOffscreenCanvas = globalThis.OffscreenCanvas;
-    Object.defineProperty(globalThis, 'createImageBitmap', {
-      configurable: true,
-      value: vi.fn(async () => ({ width: 100, height: 50, close: vi.fn() })),
-    });
-    Object.defineProperty(globalThis, 'OffscreenCanvas', {
-      configurable: true,
-      value: class {
-        constructor(
-          public width: number,
-          public height: number,
-        ) {}
-        getContext() {
-          return { drawImage: vi.fn() };
-        }
-        async convertToBlob() {
-          return new Blob(
-            [new Uint8Array(Math.max(1, Math.ceil((this.width * this.height) / 10)))],
-            {
-              type: 'image/png',
-            },
-          );
-        }
+    await withCanvasRuntime(
+      {
+        createImageBitmap: vi.fn(async () => ({ width: 100, height: 50, close: vi.fn() })),
+        OffscreenCanvas: class {
+          constructor(
+            public width: number,
+            public height: number,
+          ) {}
+          getContext() {
+            return { drawImage: vi.fn() };
+          }
+          async convertToBlob() {
+            return new Blob(
+              [new Uint8Array(Math.max(1, Math.ceil((this.width * this.height) / 10)))],
+              { type: 'image/png' },
+            );
+          }
+        } as typeof globalThis.OffscreenCanvas,
       },
-    });
-
-    try {
-      const result = (await normalizeCanvasBinaryResult(original, 'capture-region.png', 1_000)) as {
-        byteLength: number;
-        downsampled: boolean;
-        originalDimensions: { width: number; height: number };
-        imageDimensions: { width: number; height: number };
-        payloadBudgetBytes: number;
-      };
-      expect(result).toMatchObject({
-        downsampled: true,
-        originalDimensions: { width: 100, height: 50 },
-        payloadBudgetBytes: 600,
-      });
-      expect(result.byteLength).toBeLessThanOrEqual(600);
-      expect(result.imageDimensions.width).toBeLessThan(100);
-      expect(result.imageDimensions.height).toBeLessThan(50);
-      expect(result.imageDimensions.width / result.imageDimensions.height).toBeCloseTo(2, 1);
-    } finally {
-      Object.defineProperty(globalThis, 'createImageBitmap', {
-        configurable: true,
-        value: originalCreateImageBitmap,
-      });
-      Object.defineProperty(globalThis, 'OffscreenCanvas', {
-        configurable: true,
-        value: originalOffscreenCanvas,
-      });
-    }
+      async () => {
+        const result = (await normalizeCanvasBinaryResult(
+          original,
+          'capture-region.png',
+          1_000,
+        )) as {
+          byteLength: number;
+          downsampled: boolean;
+          originalDimensions: { width: number; height: number };
+          imageDimensions: { width: number; height: number };
+          payloadBudgetBytes: number;
+        };
+        expect(result).toMatchObject({
+          downsampled: true,
+          originalDimensions: { width: 100, height: 50 },
+          payloadBudgetBytes: 600,
+        });
+        expect(result.byteLength).toBeLessThanOrEqual(600);
+        expect(result.imageDimensions.width).toBeLessThan(100);
+        expect(result.imageDimensions.height).toBeLessThan(50);
+        expect(result.imageDimensions.width / result.imageDimensions.height).toBeCloseTo(2, 1);
+      },
+    );
   });
 });

--- a/tests/unit/repository/release-readiness-hermetic.test.ts
+++ b/tests/unit/repository/release-readiness-hermetic.test.ts
@@ -32,17 +32,25 @@ async function writeJson(path: string, value: unknown) {
   await writeFile(path, `${JSON.stringify(value, null, 2)}\n`, 'utf8');
 }
 
+function commitFixture(root: string, message: string) {
+  git(root, ['add', '.']);
+  git(root, ['commit', '-m', message]);
+  return git(root, ['rev-parse', 'HEAD']);
+}
+
+function initializeFixtureRepository(root: string) {
+  git(root, ['init']);
+  git(root, ['config', 'user.email', 'fixture@example.invalid']);
+  git(root, ['config', 'user.name', 'Release Readiness Fixture']);
+}
+
 async function createGitFixture() {
   const root = await mkdtemp(join(tmpdir(), 'release-readiness-git-'));
   temporaryRoots.push(root);
   await mkdir(join(root, 'src/tools'), { recursive: true });
   await writeFile(join(root, 'src/tools/example.ts'), 'export const value = 1;\n');
-  git(root, ['init']);
-  git(root, ['config', 'user.email', 'fixture@example.invalid']);
-  git(root, ['config', 'user.name', 'Release Readiness Fixture']);
-  git(root, ['add', '.']);
-  git(root, ['commit', '-m', 'fixture: add sensitive source']);
-  const evidenceCommit = git(root, ['rev-parse', 'HEAD']);
+  initializeFixtureRepository(root);
+  const evidenceCommit = commitFixture(root, 'fixture: add sensitive source');
 
   await writeJson(join(root, 'config/easyeda-compatibility.json'), {
     schemaVersion: 1,
@@ -104,12 +112,8 @@ async function createExtensionVersionPromotionFixture() {
     join(root, 'easyeda-bridge-extension/src/index.ts'),
     "// first `extensionVersion: '...'` property is release managed\nconst EXTENSION_INFO = { extensionVersion: '1.0.0-rc.6', behavior: 'unchanged' };\n",
   );
-  git(root, ['init']);
-  git(root, ['config', 'user.email', 'fixture@example.invalid']);
-  git(root, ['config', 'user.name', 'Release Readiness Fixture']);
-  git(root, ['add', '.']);
-  git(root, ['commit', '-m', 'fixture: add prerelease extension source']);
-  const evidenceCommit = git(root, ['rev-parse', 'HEAD']);
+  initializeFixtureRepository(root);
+  const evidenceCommit = commitFixture(root, 'fixture: add prerelease extension source');
 
   await writeJson(join(root, 'config/easyeda-compatibility.json'), {
     schemaVersion: 1,
@@ -127,6 +131,39 @@ async function createExtensionVersionPromotionFixture() {
   git(root, ['add', 'config/easyeda-compatibility.json']);
   git(root, ['commit', '-m', 'fixture: bind prerelease compatibility evidence']);
   return { root, evidenceCommit };
+}
+
+async function bindUnavailableExtensionSnapshot(root: string, evidenceCommit: string) {
+  const sourcePath = join(root, 'config/easyeda-compatibility.json');
+  const source = JSON.parse(await readFile(sourcePath, 'utf8')) as {
+    records: Array<{
+      server: {
+        commit: string;
+        compatibilitySnapshot?: { algorithm: string; paths: Record<string, string> };
+      };
+    }>;
+  };
+  source.records[0]!.server = {
+    commit: 'f'.repeat(40),
+    compatibilitySnapshot: {
+      algorithm: 'git-tree-sha1',
+      paths: {
+        'easyeda-bridge-extension/src': git(root, [
+          'rev-parse',
+          `${evidenceCommit}:easyeda-bridge-extension/src`,
+        ]),
+      },
+    },
+  };
+  await writeJson(sourcePath, source);
+  git(root, ['add', 'config/easyeda-compatibility.json']);
+  git(root, ['commit', '-m', 'fixture: preserve prerelease snapshot without evidence object']);
+}
+
+async function commitExtensionSource(root: string, source: string, message: string) {
+  await writeFile(join(root, 'easyeda-bridge-extension/src/index.ts'), source);
+  git(root, ['add', 'easyeda-bridge-extension/src/index.ts']);
+  git(root, ['commit', '-m', message]);
 }
 
 async function createPassingCommand(directory: string, name: string) {
@@ -225,45 +262,12 @@ describe('hermetic release readiness', { timeout: GIT_FIXTURE_TEST_TIMEOUT_MS },
 
   it('accepts a stable promotion from a recorded snapshot when the evidence commit is unavailable', async () => {
     const fixture = await createExtensionVersionPromotionFixture();
-    const sourcePath = join(fixture.root, 'config/easyeda-compatibility.json');
-    const source = JSON.parse(await readFile(sourcePath, 'utf8')) as {
-      records: Array<{
-        server: {
-          commit: string;
-          compatibilitySnapshot?: { algorithm: string; paths: Record<string, string> };
-        };
-      }>;
-    };
-    source.records[0]!.server = {
-      commit: 'f'.repeat(40),
-      compatibilitySnapshot: {
-        algorithm: 'git-tree-sha1',
-        paths: {
-          'easyeda-bridge-extension/src': git(fixture.root, [
-            'rev-parse',
-            `${fixture.evidenceCommit}:easyeda-bridge-extension/src`,
-          ]),
-        },
-      },
-    };
-    await writeJson(sourcePath, source);
-    git(fixture.root, ['add', 'config/easyeda-compatibility.json']);
-    git(fixture.root, [
-      'commit',
-      '-m',
-      'fixture: preserve prerelease snapshot without evidence object',
-    ]);
-
-    await writeFile(
-      join(fixture.root, 'easyeda-bridge-extension/src/index.ts'),
+    await bindUnavailableExtensionSnapshot(fixture.root, fixture.evidenceCommit);
+    await commitExtensionSource(
+      fixture.root,
       "// first `extensionVersion: '...'` property is release managed\nconst EXTENSION_INFO = { extensionVersion: '1.0.0', behavior: 'unchanged' };\n",
-    );
-    git(fixture.root, ['add', 'easyeda-bridge-extension/src/index.ts']);
-    git(fixture.root, [
-      'commit',
-      '-m',
       'chore: promote snapshot-backed extension version to stable',
-    ]);
+    );
 
     const report = await inspectCompatibilityFreshness({ root: fixture.root, gitBinary });
 
@@ -273,41 +277,12 @@ describe('hermetic release readiness', { timeout: GIT_FIXTURE_TEST_TIMEOUT_MS },
 
   it('rejects a snapshot-backed stable promotion when extension behavior also changes', async () => {
     const fixture = await createExtensionVersionPromotionFixture();
-    const sourcePath = join(fixture.root, 'config/easyeda-compatibility.json');
-    const source = JSON.parse(await readFile(sourcePath, 'utf8')) as {
-      records: Array<{
-        server: {
-          commit: string;
-          compatibilitySnapshot?: { algorithm: string; paths: Record<string, string> };
-        };
-      }>;
-    };
-    source.records[0]!.server = {
-      commit: 'f'.repeat(40),
-      compatibilitySnapshot: {
-        algorithm: 'git-tree-sha1',
-        paths: {
-          'easyeda-bridge-extension/src': git(fixture.root, [
-            'rev-parse',
-            `${fixture.evidenceCommit}:easyeda-bridge-extension/src`,
-          ]),
-        },
-      },
-    };
-    await writeJson(sourcePath, source);
-    git(fixture.root, ['add', 'config/easyeda-compatibility.json']);
-    git(fixture.root, [
-      'commit',
-      '-m',
-      'fixture: preserve prerelease snapshot without evidence object',
-    ]);
-
-    await writeFile(
-      join(fixture.root, 'easyeda-bridge-extension/src/index.ts'),
+    await bindUnavailableExtensionSnapshot(fixture.root, fixture.evidenceCommit);
+    await commitExtensionSource(
+      fixture.root,
       "// first `extensionVersion: '...'` property is release managed\nconst EXTENSION_INFO = { extensionVersion: '1.0.0', behavior: 'changed' };\n",
+      'fix: change behavior during snapshot-backed promotion',
     );
-    git(fixture.root, ['add', 'easyeda-bridge-extension/src/index.ts']);
-    git(fixture.root, ['commit', '-m', 'fix: change behavior during snapshot-backed promotion']);
 
     const report = await inspectCompatibilityFreshness({ root: fixture.root, gitBinary });
 
@@ -320,12 +295,11 @@ describe('hermetic release readiness', { timeout: GIT_FIXTURE_TEST_TIMEOUT_MS },
 
   it('rejects an RC-to-RC version-only change without fresh live evidence', async () => {
     const fixture = await createExtensionVersionPromotionFixture();
-    await writeFile(
-      join(fixture.root, 'easyeda-bridge-extension/src/index.ts'),
+    await commitExtensionSource(
+      fixture.root,
       "// first `extensionVersion: '...'` property is release managed\nconst EXTENSION_INFO = { extensionVersion: '1.0.0-rc.7', behavior: 'unchanged' };\n",
+      'chore: advance release candidate',
     );
-    git(fixture.root, ['add', 'easyeda-bridge-extension/src/index.ts']);
-    git(fixture.root, ['commit', '-m', 'chore: advance release candidate']);
 
     const report = await inspectCompatibilityFreshness({ root: fixture.root, gitBinary });
 
@@ -335,12 +309,11 @@ describe('hermetic release readiness', { timeout: GIT_FIXTURE_TEST_TIMEOUT_MS },
 
   it('rejects stable promotion when extension behavior changes with the version', async () => {
     const fixture = await createExtensionVersionPromotionFixture();
-    await writeFile(
-      join(fixture.root, 'easyeda-bridge-extension/src/index.ts'),
+    await commitExtensionSource(
+      fixture.root,
       "// first `extensionVersion: '...'` property is release managed\nconst EXTENSION_INFO = { extensionVersion: '1.0.0', behavior: 'changed' };\n",
+      'fix: change behavior during promotion',
     );
-    git(fixture.root, ['add', 'easyeda-bridge-extension/src/index.ts']);
-    git(fixture.root, ['commit', '-m', 'fix: change behavior during promotion']);
 
     const report = await inspectCompatibilityFreshness({ root: fixture.root, gitBinary });
 

--- a/tests/unit/repository/release-readiness-hermetic.test.ts
+++ b/tests/unit/repository/release-readiness-hermetic.test.ts
@@ -166,6 +166,12 @@ async function commitExtensionSource(root: string, source: string, message: stri
   git(root, ['commit', '-m', message]);
 }
 
+async function expectCurrentCompatibilityFreshness(root: string) {
+  const report = await inspectCompatibilityFreshness({ root, gitBinary });
+  expect(report.status).toBe('current');
+  expect(report.records[0]).toMatchObject({ status: 'current', changedFiles: [] });
+}
+
 async function createPassingCommand(directory: string, name: string) {
   await mkdir(directory, { recursive: true });
   if (process.platform === 'win32') {
@@ -254,10 +260,7 @@ describe('hermetic release readiness', { timeout: GIT_FIXTURE_TEST_TIMEOUT_MS },
     git(fixture.root, ['add', 'easyeda-bridge-extension/src/index.ts']);
     git(fixture.root, ['commit', '-m', 'chore: promote extension version to stable']);
 
-    const report = await inspectCompatibilityFreshness({ root: fixture.root, gitBinary });
-
-    expect(report.status).toBe('current');
-    expect(report.records[0]).toMatchObject({ status: 'current', changedFiles: [] });
+    await expectCurrentCompatibilityFreshness(fixture.root);
   });
 
   it('accepts a stable promotion from a recorded snapshot when the evidence commit is unavailable', async () => {
@@ -269,10 +272,7 @@ describe('hermetic release readiness', { timeout: GIT_FIXTURE_TEST_TIMEOUT_MS },
       'chore: promote snapshot-backed extension version to stable',
     );
 
-    const report = await inspectCompatibilityFreshness({ root: fixture.root, gitBinary });
-
-    expect(report.status).toBe('current');
-    expect(report.records[0]).toMatchObject({ status: 'current', changedFiles: [] });
+    await expectCurrentCompatibilityFreshness(fixture.root);
   });
 
   it('rejects a snapshot-backed stable promotion when extension behavior also changes', async () => {


### PR DESCRIPTION
## Summary

- deduplicate hermetic release-readiness Git/snapshot fixture setup
- deduplicate canvas runtime install/restore setup in extension tests
- preserve existing assertions and runtime behavior; production code is unchanged

## Root cause

Post-merge SonarCloud analysis on exact main SHA `1825568ef1d92f298622911d912d64afe00daf4e` failed because the repository new-code window contained 464 duplicated lines across 7,966 new lines (5.8248%, gate <= 3%). The two refactored test files accounted for 240 of those duplicated lines. The MCP #564 files themselves reported 0 new duplicated lines.

## Verification

- `pnpm verify` (exit 0)
- 2,147 server tests passed
- 408 extension tests passed
- format, server/extension typecheck, lint, complexity, package checks, secret hygiene, metadata, compatibility docs, and VitePress build passed
- `git diff --check`

This PR restores the main-branch quality gate without weakening Sonar or changing test/quality thresholds.