### PR TITLE
fix(mcp): preserve modern HTTP security parity

### DIFF
--- a/src/server/transports/http.ts
+++ b/src/server/transports/http.ts
@@ -390,7 +390,7 @@ export function handleCorsPreflight(req: Request, res: Response, next: NextFunct
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, DELETE, OPTIONS');
     res.setHeader(
       'Access-Control-Allow-Headers',
-      'Content-Type, Authorization, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID',
+      'Content-Type, Authorization, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID, Mcp-Method, Mcp-Name',
     );
     res.setHeader('Access-Control-Max-Age', '86400');
     res.status(204).end();

--- a/tests/unit/remote/http-mcp-integration.test.ts
+++ b/tests/unit/remote/http-mcp-integration.test.ts
@@ -53,14 +53,17 @@ interface RemoteHttpHarness {
   readonly closedSessionServerCount: number;
   instance: McpServerInstance;
   httpTransport: HttpTransportInstance;
-  createClient: (name: string) => {
+  createClient: (
+    name: string,
+    modern?: boolean,
+  ) => {
     client: Client;
     transport: StreamableHTTPClientTransport;
   };
   close: () => Promise<void>;
 }
 
-async function createHarness(): Promise<RemoteHttpHarness> {
+async function createHarness(modernEnabled = false): Promise<RemoteHttpHarness> {
   const port = await reservePort();
   const dataDir = await mkdtemp(join(tmpdir(), 'easyeda-remote-http-'));
   const config = EnvSchema.parse({
@@ -71,6 +74,7 @@ async function createHarness(): Promise<RemoteHttpHarness> {
     HTTP_HOST: '127.0.0.1',
     HTTP_PORT: port,
     HTTP_AUTH_DISABLED: true,
+    MCP_V2_EXPERIMENTAL: modernEnabled,
     MCP_BRIDGE_BACKEND: 'remote_relay',
     BRIDGE_TIMEOUT_MS: 1000,
     JLCSEARCH_ENABLED: false,
@@ -161,8 +165,11 @@ async function createHarness(): Promise<RemoteHttpHarness> {
   await httpTransport.start();
 
   const clients = new Set<Client>();
-  const createClient = (name: string) => {
-    const client = new Client({ name, version: '1.0.0' });
+  const createClient = (name: string, modern = false) => {
+    const client = new Client(
+      { name, version: '1.0.0' },
+      modern ? { versionNegotiation: { mode: { pin: '2026-07-28' } } } : undefined,
+    );
     const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), {
       requestInit: {
         headers: {
@@ -207,6 +214,53 @@ describe('Remote Relay MCP HTTP integration', () => {
       if (task) await task();
     }
   });
+
+  it('preserves Remote Relay identity, isolation, and approval gating for modern HTTP requests', async () => {
+    const harness = await createHarness(true);
+    cleanup.push(harness.close);
+    const { client, transport } = harness.createClient('remote-http-modern', true);
+    await client.connect(transport);
+
+    expect(client.getProtocolEra()).toBe('modern');
+    expect(client.getNegotiatedProtocolVersion()).toBe('2026-07-28');
+    expect(harness.httpTransport.activeSessionCount).toBe(0);
+
+    const readResult = await client.callTool({
+      name: 'easyeda_schematic_components',
+      arguments: {
+        projectId: 'project-modern',
+        remoteSessionId: harness.remoteSessionId,
+      },
+    });
+    expect(readResult.isError).not.toBe(true);
+    expect(harness.dispatched.at(-1)).toMatchObject({
+      sessionId: harness.remoteSessionId,
+      toolName: 'schematic.listComponents',
+      riskLevel: 'read',
+      input: { projectId: 'project-modern' },
+    });
+
+    const writeResult = await client.callTool({
+      name: 'easyeda_schematic_add_text',
+      arguments: {
+        x: 10,
+        y: 20,
+        content: 'Modern approval required',
+        confirmWrite: true,
+        remoteSessionId: harness.remoteSessionId,
+      },
+    });
+    expect(writeResult.isError).toBe(true);
+    expect(writeResult.structuredContent).toMatchObject({
+      errorCode: 'ERR_REMOTE_RELAY',
+      details: {
+        remoteCode: 'APPROVAL_REQUIRED',
+        approvalId: expect.stringMatching(/^appr_/),
+      },
+    });
+    expect(harness.approvalRequests).toHaveLength(1);
+    expect(harness.httpTransport.activeSessionCount).toBe(0);
+  }, 15_000);
 
   it('routes read calls and approval-gated write calls through a paired fake extension without a local bridge listener', async () => {
     const harness = await createHarness();

--- a/tests/unit/server/transports/http.test.ts
+++ b/tests/unit/server/transports/http.test.ts
@@ -244,7 +244,7 @@ describe('createHttpTransport', () => {
       expect(res.status).toBe(204);
       expect(res.headers.get('access-control-allow-methods')).toBe('GET, POST, DELETE, OPTIONS');
       expect(res.headers.get('access-control-allow-headers')).toBe(
-        'Content-Type, Authorization, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID',
+        'Content-Type, Authorization, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID, Mcp-Method, Mcp-Name',
       );
       expect(res.headers.get('access-control-max-age')).toBe('86400');
       expect(res.headers.get('vary')).toBe('Origin');
@@ -588,7 +588,7 @@ describe('handleCorsPreflight', () => {
     );
     expect(res.setHeader).toHaveBeenCalledWith(
       'Access-Control-Allow-Headers',
-      'Content-Type, Authorization, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID',
+      'Content-Type, Authorization, MCP-Protocol-Version, MCP-Session-Id, Last-Event-ID, Mcp-Method, Mcp-Name',
     );
     expect(res.setHeader).toHaveBeenCalledWith('Access-Control-Max-Age', '86400');
     expect(res.end).toHaveBeenCalled();


### PR DESCRIPTION
## Summary
- allow the MCP 2026-07-28 `Mcp-Method` and `Mcp-Name` headers through the existing CORS preflight policy
- add pinned modern HTTP Remote Relay integration coverage for identity propagation, approval gating, and legacy-session isolation
- preserve the legacy/sessionful default and existing OAuth/origin/rate-limit middleware ordering

## Root cause
The modern HTTP route validates `Mcp-Method`/`Mcp-Name`, but the repository-owned CORS preflight response did not advertise those headers. Browser-based modern clients could therefore be blocked before OAuth or MCP dispatch even though direct clients worked.

## Verification
- targeted HTTP + Remote Relay suites: 58 tests passed
- `pnpm verify`
- `pnpm security:audit`
- `pnpm security:semgrep` (0 findings)
- `git diff --check`

Refs #476

#476 remains open for the remaining explicit rollout/acceptance evidence.